### PR TITLE
Fix rhtap-openshift

### DIFF
--- a/charts/rhtap-openshift/templates/tests/test.yaml
+++ b/charts/rhtap-openshift/templates/tests/test.yaml
@@ -35,9 +35,11 @@ spec:
       image: quay.io/codeready-toolchain/oc-client-base:latest
       command:
         - /scripts/test-projects.sh
+{{- if .Values.openshift.projects }}
       args:
 {{- range $p := .Values.openshift.projects }}
         - {{ $p }}
+{{- end }}
 {{- end }}
       volumeMounts:
         - name: scripts

--- a/charts/rhtap-openshift/values.yaml
+++ b/charts/rhtap-openshift/values.yaml
@@ -1,2 +1,3 @@
 ---
-openshiftProjects: []
+openshift:
+  projects: []


### PR DESCRIPTION
- The content of values.yaml and the path used in the template were not matching.
- Fixed invalid manifest when there is 0 project.