### PR TITLE
fix: PGO Image

### DIFF
--- a/charts/rhtap-infrastructure/templates/postgresclusters.yaml
+++ b/charts/rhtap-infrastructure/templates/postgresclusters.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   openshift: true
   postgresVersion: {{ $v.postgresVersion }}
+  # Crunchy Data PGO requires the container image in combination with the
+  # PostgreSQL version, thus both needs to be informed.
+  image: {{ required ".image is required" $v.image }}
   # TODO: Move this configuration into "values.yaml", at least the flag for user
   # options like "SUPERUSER".
   users:

--- a/charts/rhtap-infrastructure/values.yaml
+++ b/charts/rhtap-infrastructure/values.yaml
@@ -84,7 +84,7 @@ infrastructure:
         username: __OVERWRITE_ME__
         # Secret with Kafka's password (valueFrom).
         password: {}
-        # The list of buckets and Kakfa topics.
+        # The list of buckets and Kafka topics.
         topics:
           - bucket: *bucketBombastic
             topic: *topicSbomStored
@@ -115,6 +115,7 @@ infrastructure:
       enabled: false
       namespace: __OVERWRITE_ME__
       postgresVersion: 14
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:6f4db1e9707b196aaa9f98ada5c09523ec00ade573ff835bd1ca6367ac0bb9f1
       pgbackrestConfig:
         repo1-retention-full: "3"
       backupRepos:
@@ -138,6 +139,7 @@ infrastructure:
       enabled: false
       namespace: __OVERWRITE_ME__
       postgresVersion: 14
+      image: registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:6f4db1e9707b196aaa9f98ada5c09523ec00ade573ff835bd1ca6367ac0bb9f1
       pgbackrestConfig:
         repo1-retention-full: "3"
       backupRepos:


### PR DESCRIPTION
The operator on OpenShift needs the specific image to spin up the cluster, so both PostgreSQL version and image reference is required.