### PR TITLE
RHTAPINST-38: Helm Chart Filesystem

### DIFF
--- a/pkg/chartfs/bufferedfile.go
+++ b/pkg/chartfs/bufferedfile.go
@@ -1,0 +1,59 @@
+package chartfs
+
+import (
+	"io/fs"
+	"path/filepath"
+
+	"helm.sh/helm/v3/pkg/chart/loader"
+)
+
+// BufferedFiles represents the group of files needed to load a Helm chart in
+// memory, the files data is stored as `loader.BufferedFile` instances.
+type BufferedFiles struct {
+	fs      fs.FS                  // file system instance
+	baseDir string                 // base directory path
+	files   []*loader.BufferedFile // buffered files
+}
+
+// Files returns the buffered files collected by "Walk" function.
+func (b *BufferedFiles) Files() []*loader.BufferedFile {
+	return b.files
+}
+
+// Walk is the callback function used by "fs.WalkDir" to collect the files data.
+func (b *BufferedFiles) Walk(filePath string, d fs.DirEntry, err error) error {
+	if err != nil {
+		return err
+	}
+	// Skip directories. The "Walk" function is invoked recursively for each file,
+	// or directory, in the filesystem so directories can be safely ignored,
+	// without the need for recursive calls.
+	if d.IsDir() {
+		return nil
+	}
+
+	data, err := fs.ReadFile(b.fs, filePath)
+	if err != nil {
+		return err
+	}
+
+	// The file path is relative to the base directory, therefore paths like
+	// "templates/file.tpl" are kept as is.
+	relPath, err := filepath.Rel(b.baseDir, filePath)
+	if err != nil {
+		return err
+	}
+	// Appending the file data using only the base name as reference. The
+	// collected files represent a single Helm chart payload.
+	b.files = append(b.files, &loader.BufferedFile{Name: relPath, Data: data})
+	return nil
+}
+
+// NewBufferedFiles creates a new BufferedFiles instance.
+func NewBufferedFiles(cfs fs.FS, baseDir string) *BufferedFiles {
+	return &BufferedFiles{
+		fs:      cfs,
+		baseDir: baseDir,
+		files:   []*loader.BufferedFile{},
+	}
+}

--- a/pkg/chartfs/chartfs.go
+++ b/pkg/chartfs/chartfs.go
@@ -1,9 +1,47 @@
 package chartfs
 
+import (
+	"io/fs"
+	"os"
+
+	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+)
+
+// ChartFS represents a file system abstraction which provides the Helm charts
+// payload, and as well the "values.yaml.tpl" file.
 type ChartFS struct {
+	fs      fs.FS  // file system
 	baseDir string // base directory path
 }
 
+// ReadFile reads the file from the file system.
+func (c *ChartFS) ReadFile(name string) ([]byte, error) {
+	return fs.ReadFile(c.fs, name)
+}
+
+// GetChartForDep returns the Helm chart for the given dependency. It uses
+// BufferredFiles to walk through the filesytem and collect the chart files.
+func (c *ChartFS) GetChartForDep(dep *config.Dependency) (*chart.Chart, error) {
+	bf := NewBufferedFiles(c.fs, dep.Chart)
+	if err := fs.WalkDir(c.fs, dep.Chart, bf.Walk); err != nil {
+		return nil, err
+	}
+	return loader.LoadFiles(bf.Files())
+}
+
+// NewChartFS instantiates a new ChartFS instance for the given base directory.
 func NewChartFS(baseDir string) *ChartFS {
-	return nil
+	return &ChartFS{
+		fs:      os.DirFS(baseDir),
+		baseDir: baseDir,
+	}
+}
+
+// NewChartFSForCWD instantiates a new ChartFS instance for the current working
+// directory (".").
+func NewChartFSForCWD() *ChartFS {
+	return NewChartFS(".")
 }

--- a/pkg/chartfs/chartfs_test.go
+++ b/pkg/chartfs/chartfs_test.go
@@ -1,0 +1,43 @@
+package chartfs
+
+import (
+	"testing"
+
+	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
+
+	o "github.com/onsi/gomega"
+)
+
+func TestNewChartFS(t *testing.T) {
+	g := o.NewWithT(t)
+
+	c := NewChartFS("../..")
+	g.Expect(c).ToNot(o.BeNil())
+
+	t.Run("ReadFile", func(t *testing.T) {
+		valuesTmplBytes, err := c.ReadFile("charts/values.yaml.tpl")
+		g.Expect(err).To(o.Succeed())
+		g.Expect(valuesTmplBytes).ToNot(o.BeEmpty())
+	})
+
+	t.Run("GetChartForDep", func(t *testing.T) {
+		chart, err := c.GetChartForDep(&config.Dependency{
+			Chart:     "charts/rhtap-openshift",
+			Namespace: "rhtap",
+		})
+		g.Expect(err).To(o.Succeed())
+		g.Expect(chart).ToNot(o.BeNil())
+		g.Expect(chart.Name()).To(o.Equal("rhtap-openshift"))
+		g.Expect(chart.Files).ToNot(o.BeEmpty())
+		g.Expect(chart.Templates).ToNot(o.BeEmpty())
+
+		// Asserting the chart templates are present, it should contain at least a
+		// few files, plus the presence of the "NOTES.txt" common file.
+		names := []string{}
+		for _, tmpl := range chart.Templates {
+			names = append(names, tmpl.Name)
+		}
+		g.Expect(len(names)).To(o.BeNumerically(">", 1))
+		g.Expect(names).To(o.ContainElement("templates/NOTES.txt"))
+	})
+}

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -3,9 +3,10 @@ package hooks
 import (
 	"testing"
 
-	o "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
 	"helm.sh/helm/v3/pkg/chartutil"
+
+	o "github.com/onsi/gomega"
 )
 
 func TestNewHooks(t *testing.T) {

--- a/pkg/subcmd/template.go
+++ b/pkg/subcmd/template.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/redhat-appstudio/rhtap-cli/pkg/chartfs"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/deployer"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/engine"
@@ -143,8 +144,23 @@ func (t *Template) Run() error {
 		return nil
 	}
 
+	t.log().Debug("Searching Helm charts from the current directory")
+	cfs := chartfs.NewChartFSForCWD()
+
+	t.log().Debug("Loading dependency Helm chart (from CFS)")
+	chart, err := cfs.GetChartForDep(&t.dependency)
+	if err != nil {
+		return err
+	}
+
 	t.log().Debug("Showing rendered chart manifests")
-	hc, err := deployer.NewHelm(t.logger, t.flags, t.kube, t.dependency)
+	hc, err := deployer.NewHelm(
+		t.logger,
+		t.flags,
+		t.kube,
+		t.dependency.Namespace,
+		chart,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adopting the [`io.FS` interface](https://pkg.go.dev/io/fs) to provide a filesystem abstraction for Helm charts. This allows the CLI to read charts from a variety of sources, like the local data for embedded files in the future.