### PR TITLE
RHTAPINST-38: Hooks Support for ChartFS

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -2,50 +2,96 @@ package hooks
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
 
+	"github.com/redhat-appstudio/rhtap-cli/pkg/chartfs"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
-	"helm.sh/helm/v3/pkg/chartutil"
 )
 
+// Hooks represent the hooks that can be executed before and after the Helm Chart
+// installation, it provides the user the ability to customize the process using
+// shell scripts. These scripts can rely on local tools, like "kubectl", "oc" and
+// others, while the Helm Charts are only using Kubernetes resources.
+// Ideally these scripts are temporary measures, and should be replaced by Helm
+// Chart related resources as soon as possible.
 type Hooks struct {
-	dep config.Dependency
+	cfs    *chartfs.ChartFS   // chart file system
+	dep    *config.Dependency // helm chart dependency
+	stdout io.Writer          // standard output
+	stderr io.Writer          // standard error
 }
 
-func (h *Hooks) runHookScript(name string, vals chartutil.Values) error {
+// exec executes the script with the given environment variables.
+func (h *Hooks) exec(scriptPath string, vals map[string]interface{}) error {
+	cmd := exec.Command(scriptPath)
+	cmd.Env = os.Environ()
+	for k, v := range vals {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%v", k, v))
+	}
+	cmd.Stdout = h.stdout
+	cmd.Stderr = h.stderr
+	return cmd.Run()
+}
+
+// runHookScript executes the hook script with the given values.
+func (h *Hooks) runHookScript(name string, vals map[string]interface{}) error {
+	// Extracting the script payload from the Chart directory, using the "hook"
+	// directory as default location.
 	scriptPath := path.Join(h.dep.Chart, "hooks", name)
-	_, err := os.Stat(scriptPath)
+	scriptBytes, err := h.cfs.ReadFile(scriptPath)
 	if err != nil {
+		// Ignoring when the script is not found, it means the given Chart does
+		// not carry hook scripts.
 		if os.IsNotExist(err) {
 			return nil
 		}
 		return err
 	}
 
-	cmd := exec.Command(scriptPath)
-	cmd.Env = os.Environ()
-	for k, v := range vals {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%v", k, v))
+	// Storing the script payload in a temporary file, adding permissions to
+	// execute as a regular shell script.
+	tmpfile, err := os.CreateTemp("/tmp", "rhtap-cli-hook-*.sh")
+	if err != nil {
+		return err
 	}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	defer os.Remove(tmpfile.Name())
+	if _, err := tmpfile.Write(scriptBytes); err != nil {
+		return err
+	}
+	if err := tmpfile.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpfile.Name(), 0o755); err != nil {
 		return err
 	}
 
-	return nil
+	return h.exec(tmpfile.Name(), vals)
 }
 
-func (h *Hooks) PreDeploy(vals chartutil.Values) error {
+// PreDeploy executes the "pre-deploy.sh" hook script with the given values.
+func (h *Hooks) PreDeploy(vals map[string]interface{}) error {
 	return h.runHookScript("pre-deploy.sh", vals)
 }
 
-func (h *Hooks) PostDeploy(vals chartutil.Values) error {
+// PostDeploy executes the "post-deploy.sh" hook script with the given values.
+func (h *Hooks) PostDeploy(vals map[string]interface{}) error {
 	return h.runHookScript("post-deploy.sh", vals)
 }
 
-func NewHooks(dep config.Dependency) *Hooks {
-	return &Hooks{dep: dep}
+// NewHooks instantiates a hooks handler for the given ChartFS and Dependency.
+func NewHooks(
+	cfs *chartfs.ChartFS,
+	dep *config.Dependency,
+	stdout io.Writer,
+	stderr io.Writer,
+) *Hooks {
+	return &Hooks{
+		cfs:    cfs,
+		dep:    dep,
+		stdout: stdout,
+		stderr: stderr,
+	}
 }

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -1,9 +1,12 @@
 package hooks
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/redhat-appstudio/rhtap-cli/pkg/chartfs"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
+
 	"helm.sh/helm/v3/pkg/chartutil"
 
 	o "github.com/onsi/gomega"
@@ -12,15 +15,40 @@ import (
 func TestNewHooks(t *testing.T) {
 	g := o.NewWithT(t)
 
-	h := NewHooks(config.Dependency{
-		Chart:     "../../test/charts/testing",
-		Namespace: "rhtap",
-	})
-
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	h := NewHooks(
+		chartfs.NewChartFS("../.."),
+		&config.Dependency{
+			Chart:     "test/charts/testing",
+			Namespace: "rhtap",
+		},
+		&stdout,
+		&stderr,
+	)
 	vals := chartutil.Values{"key": "value"}
 
-	err := h.PreDeploy(vals)
-	g.Expect(err).To(o.Succeed())
-	err = h.PostDeploy(vals)
-	g.Expect(err).To(o.Succeed())
+	t.Run("PreDeploy", func(t *testing.T) {
+		err := h.PreDeploy(vals)
+		g.Expect(err).To(o.Succeed())
+
+		t.Logf("stdout: %s", stdout.String())
+		t.Logf("stderr: %s", stderr.String())
+		g.Expect(stdout.String()).To(o.ContainSubstring("script runs before"))
+
+		stdout.Reset()
+		stderr.Reset()
+	})
+
+	t.Run("PostDeploy", func(t *testing.T) {
+		err := h.PostDeploy(vals)
+		g.Expect(err).To(o.Succeed())
+
+		t.Logf("stdout: %s", stdout.String())
+		t.Logf("stderr: %s", stderr.String())
+		g.Expect(stdout.String()).To(o.ContainSubstring("script runs after"))
+
+		stdout.Reset()
+		stderr.Reset()
+	})
 }

--- a/pkg/subcmd/deploy.go
+++ b/pkg/subcmd/deploy.go
@@ -3,6 +3,7 @@ package subcmd
 import (
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/chartfs"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
@@ -120,7 +121,7 @@ func (d *Deploy) Run() error {
 			return err
 		}
 
-		hook := hooks.NewHooks(dep)
+		hook := hooks.NewHooks(cfs, &dep, os.Stdout, os.Stderr)
 		logger.Debug("Running pre-deploy hook script...")
 		if err = hook.PreDeploy(values); err != nil {
 			return err


### PR DESCRIPTION
Modifying Hooks to support ChartFS, as in, reading files from the `io.FS` interface.