### PR TITLE
RHTAPINST-42: Values as Environment Variables for Hook Scripts

### DIFF
--- a/pkg/hooks/env.go
+++ b/pkg/hooks/env.go
@@ -1,0 +1,32 @@
+package hooks
+
+import (
+	"fmt"
+	"strings"
+)
+
+// valuesToEnv flattens a map of values into a map of environment variables using
+// "__" as a separator to merge the original keys into a single variable.
+func valuesToEnv(vals map[string]interface{}, parentKey string) map[string]string {
+	flatMap := map[string]string{}
+	for k, v := range vals {
+		newKey := strings.ToUpper(k)
+		if parentKey != "" {
+			newKey = fmt.Sprintf(
+				"%s__%s",
+				strings.ToUpper(parentKey),
+				strings.ToUpper(k),
+			)
+		}
+		switch child := v.(type) {
+		case map[string]interface{}:
+			childMap := valuesToEnv(child, newKey)
+			for k, v := range childMap {
+				flatMap[k] = v
+			}
+		default:
+			flatMap[newKey] = fmt.Sprintf("%v", v)
+		}
+	}
+	return flatMap
+}

--- a/pkg/hooks/env_test.go
+++ b/pkg/hooks/env_test.go
@@ -1,0 +1,39 @@
+package hooks
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_valuesToEnv(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]interface{}
+		want   map[string]string
+	}{{
+		name:   "empty map",
+		values: map[string]interface{}{},
+		want:   map[string]string{},
+	}, {
+		name:   "simple map",
+		values: map[string]interface{}{"key": "value"},
+		want:   map[string]string{"KEY": "value"},
+	}, {
+		name: "nested map",
+		values: map[string]interface{}{
+			"key": map[string]interface{}{
+				"nested": "value",
+			},
+		},
+		want: map[string]string{"KEY__NESTED": "value"},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := valuesToEnv(tt.values, "")
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("flattenMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -24,11 +24,14 @@ type Hooks struct {
 	stderr io.Writer          // standard error
 }
 
+const envPrefix = "INSTALLER"
+
 // exec executes the script with the given environment variables.
 func (h *Hooks) exec(scriptPath string, vals map[string]interface{}) error {
 	cmd := exec.Command(scriptPath)
 	cmd.Env = os.Environ()
-	for k, v := range vals {
+	// Transforming the informed values into environment variables.
+	for k, v := range valuesToEnv(vals, envPrefix) {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%v", k, v))
 	}
 	cmd.Stdout = h.stdout

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/redhat-appstudio/rhtap-cli/pkg/chartfs"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
 
-	"helm.sh/helm/v3/pkg/chartutil"
-
 	o "github.com/onsi/gomega"
 )
 
@@ -26,7 +24,12 @@ func TestNewHooks(t *testing.T) {
 		&stdout,
 		&stderr,
 	)
-	vals := chartutil.Values{"key": "value"}
+
+	vals := map[string]interface{}{
+		"key": map[string]interface{}{
+			"nested": "value",
+		},
+	}
 
 	t.Run("PreDeploy", func(t *testing.T) {
 		err := h.PreDeploy(vals)
@@ -34,7 +37,10 @@ func TestNewHooks(t *testing.T) {
 
 		t.Logf("stdout: %s", stdout.String())
 		t.Logf("stderr: %s", stderr.String())
-		g.Expect(stdout.String()).To(o.ContainSubstring("script runs before"))
+		// Asserting the environment variable is printed out by the hook script,
+		// the variable is passed by the informed values.
+		g.Expect(stdout.String()).
+			To(o.ContainSubstring("# INSTALLER__KEY__NESTED='value'"))
 
 		stdout.Reset()
 		stderr.Reset()

--- a/test/charts/testing/hooks/pre-deploy.sh
+++ b/test/charts/testing/hooks/pre-deploy.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 echo "This script runs before the installation of the chart"
+echo "# INSTALLER__KEY__NESTED='${INSTALLER__KEY__NESTED}'"


### PR DESCRIPTION
Hook scripts can now access the Helm values as environment variables, using `INSTALLER__` prefix followed by the flatten keys as environment variable names using `__` as separator.

To be merged after #30 🙏