### PR TITLE
RHTAPINST-44: Helm Chart Dependency Toggle

### DIFF
--- a/charts/rhtap-tas/values.yaml
+++ b/charts/rhtap-tas/values.yaml
@@ -1,7 +1,5 @@
 ---
 trustedArtifactSigner:
-  # Enable the Trusted Artifact Signer.
-  enabled: true
   # OpenShift cluster's ingress domain, e.g. apps.cluster.example.com. The domain
   # is used to generate the "trusted-artifact-signer" Fulcio's email.
   ingressDomain: __OVERWRITE_ME__

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ rhtapInstallerCLI:
       enabled: *tpaEnabled
       namespace: rhtap-keycloak
     trustedArtifactSigner:
-      enabled: false
+      enabled: &tasEnabled false
       namespace: &trustedArtifactSignerNamespace rhtap-tas
     redHatDeveloperHub:
       enabled: &rhdhEnabled true
@@ -25,17 +25,25 @@ rhtapInstallerCLI:
   dependencies:
     - chart: charts/rhtap-openshift
       namespace: *installerNamespace
+      enabled: true
     - chart: charts/rhtap-subscriptions
       namespace: *installerNamespace
+      enabled: true
     - chart: charts/rhtap-infrastructure
       namespace: *installerNamespace
+      enabled: true
     - chart: charts/rhtap-backing-services
       namespace: *installerNamespace
+      enabled: true
     - chart: charts/rhtap-integrations
       namespace: *installerNamespace
+      enabled: true
     - chart: charts/rhtap-tas
       namespace: *trustedArtifactSignerNamespace
+      enabled: *tasEnabled
     - chart: charts/rhtap-tpa
       namespace: *trustedProfileAnalyzerNamespace
+      enabled: *tpaEnabled
     - chart: charts/rhtap-dh
       namespace: *installerNamespace
+      enabled: *rhdhEnabled

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -29,7 +29,7 @@ func (r *RootCmd) Cmd() *cobra.Command {
 	r.cmd.AddCommand(subcmd.NewDeveloperHub(logger, r.cfg, r.kube))
 
 	for _, sub := range []subcmd.Interface{
-		subcmd.NewDeploy(logger, r.flags, &r.cfg.Installer, r.kube),
+		subcmd.NewDeploy(logger, r.flags, r.cfg, r.kube),
 		subcmd.NewTemplate(logger, r.flags, &r.cfg.Installer, r.kube),
 	} {
 		r.cmd.AddCommand(subcmd.NewRunner(sub).Cmd())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,11 +53,17 @@ type Dependency struct {
 	Chart string `yaml:"chart"`
 	// Namespace where the Helm chart will be deployed.
 	Namespace string `yaml:"namespace"`
+	// Enabled Helm Chart toggle.
+	Enabled bool `yaml:"enabled"`
 }
 
 // LoggerWith returns a logger with Dependency contextual information.
-func (d *Dependency) LoggerWith(l *slog.Logger) *slog.Logger {
-	return l.With("dep-chart", d.Chart, "dep-namespace", d.Namespace)
+func (d *Dependency) LoggerWith(logger *slog.Logger) *slog.Logger {
+	return logger.With(
+		"dep-chart", d.Chart,
+		"dep-namespace", d.Namespace,
+		"dep-enabled", d.Enabled,
+	)
 }
 
 // Spec contains all configuration sections.
@@ -143,6 +149,21 @@ func (c *Config) UnmarshalYAML() error {
 		return fmt.Errorf("%w: %s %w", ErrUnmarshalConfig, c.configPath, err)
 	}
 	return c.Validate()
+}
+
+// GetEnabledDependencies returns a list of enabled dependencies.
+func (c *Config) GetEnabledDependencies(logger *slog.Logger) []Dependency {
+	enabled := []Dependency{}
+	logger.Debug("Getting enabled dependencies")
+	for _, dep := range c.Installer.Dependencies {
+		if dep.Enabled {
+			logger.Debug("Using dependency...", "dep-chart", dep.Chart)
+			enabled = append(enabled, dep)
+		} else {
+			logger.Debug("Skipping dependency...", "dep-chart", dep.Chart)
+		}
+	}
+	return enabled
 }
 
 // NewConfigFromFile returns a new Config instance based on the informed file. The


### PR DESCRIPTION
Adding the ability to enable or disable a given Helm Chart installatino, so the `config.yaml` can use YAML references to link features with Helm Charts directly.