### PR TITLE
filter out the .tekton and vendor from shellcheck

### DIFF
--- a/.tekton/integration-tests/pipelines/static-code-analysis.yaml
+++ b/.tekton/integration-tests/pipelines/static-code-analysis.yaml
@@ -68,3 +68,7 @@ spec:
           value: "$(tasks.test-metadata.results.git-url)"
         - name: git-revision
           value: "$(tasks.test-metadata.results.git-revision)"
+        - name: exclude-dirs
+          value:
+            - "vendor"
+            - ".tekton"


### PR DESCRIPTION
This PR depends on another PR https://github.com/konflux-qe-incubator/konflux-qe-definitions/pull/17