### PR TITLE
RHTAPINST-54: Configurable Features

### DIFF
--- a/charts/values.yaml.tpl
+++ b/charts/values.yaml.tpl
@@ -1,10 +1,10 @@
-{{- $crc := required "CRC settings" .Installer.Features.CRC -}}
-{{- $tas := required "TAS settings" .Installer.Features.TrustedArtifactSigner -}}
-{{- $tpa := required "TPA settings" .Installer.Features.TrustedProfileAnalyzer -}}
-{{- $keycloak := required "Keycloak settings" .Installer.Features.Keycloak -}}
-{{- $acs := required "Red Hat ACS settings" .Installer.Features.RedHatAdvancedClusterSecurity -}}
-{{- $quay := required "Quay settings" .Installer.Features.RedHatQuay -}}
-{{- $rhdh := required "RHDH settings" .Installer.Features.RedHatDeveloperHub -}}
+{{- $crc := required "CRC settings" .Installer.Features.crc -}}
+{{- $tas := required "TAS settings" .Installer.Features.trustedArtifactSigner -}}
+{{- $tpa := required "TPA settings" .Installer.Features.trustedProfileAnalyzer -}}
+{{- $keycloak := required "Keycloak settings" .Installer.Features.keycloak -}}
+{{- $acs := required "Red Hat ACS settings" .Installer.Features.redHatAdvancedClusterSecurity -}}
+{{- $quay := required "Quay settings" .Installer.Features.redHatQuay -}}
+{{- $rhdh := required "RHDH settings" .Installer.Features.redHatDeveloperHub -}}
 {{- $ingressDomain := required "OpenShift ingress domain" .OpenShift.Ingress.Domain -}}
 ---
 debug:
@@ -183,7 +183,7 @@ backingServices:
 #
 
 {{- $catalogURL := required "Red Hat Developer Hub Catalog URL is required"
-    .Installer.Features.RedHatDeveloperHub.Properties.catalogURL -}}
+    .Installer.Features.redHatDeveloperHub.Properties.catalogURL }}
 
 developerHub:
   ingressDomain: {{ $ingressDomain }}

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ rhtapCLI:
   namespace: &installerNamespace rhtap
   features:
     crc:
-      enabled: true
+      enabled: false
     trustedProfileAnalyzer:
       enabled: &tpaEnabled true
       namespace: &trustedProfileAnalyzerNamespace rhtap-tpa

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log/slog"
 	"testing"
 
 	o "github.com/onsi/gomega"
@@ -17,5 +18,21 @@ func TestNewConfigFromFile(t *testing.T) {
 	t.Run("Validate", func(t *testing.T) {
 		err := cfg.Validate()
 		g.Expect(err).To(o.Succeed())
+	})
+
+	t.Run("GetEnabledDependencies", func(t *testing.T) {
+		deps := cfg.GetEnabledDependencies(slog.Default())
+		g.Expect(deps).NotTo(o.BeEmpty())
+		g.Expect(len(deps)).To(o.BeNumerically(">", 1))
+	})
+
+	t.Run("GetFeature", func(t *testing.T) {
+		_, err := cfg.GetFeature("feature1")
+		g.Expect(err).NotTo(o.Succeed())
+
+		feature, err := cfg.GetFeature(RedHatDeveloperHub)
+		g.Expect(err).To(o.Succeed())
+		g.Expect(feature).NotTo(o.BeNil())
+		g.Expect(feature.GetNamespace()).NotTo(o.BeEmpty())
 	})
 }

--- a/pkg/config/dependency.go
+++ b/pkg/config/dependency.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"log/slog"
+)
+
+// Dependency contains a individual Helm chart configuration.
+type Dependency struct {
+	// Chart relative location to the Helm chart directory.
+	Chart string `yaml:"chart"`
+	// Namespace where the Helm chart will be deployed.
+	Namespace string `yaml:"namespace"`
+	// Enabled Helm Chart toggle.
+	Enabled bool `yaml:"enabled"`
+}
+
+// LoggerWith decorates the logger with dependency information.
+func (d *Dependency) LoggerWith(logger *slog.Logger) *slog.Logger {
+	return logger.With(
+		"dep-chart", d.Chart,
+		"dep-namespace", d.Namespace,
+		"dep-enabled", d.Enabled,
+	)
+}

--- a/pkg/config/feature.go
+++ b/pkg/config/feature.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"fmt"
+)
+
+const (
+	// CRC Code Ready Containers (CRC).
+	CRC = "crc"
+	// Keycloak Keycloak IAM/SSO.
+	Keycloak = "keycloak"
+	// TrustedProfileAnalyzer Trusted Profile Analyzer (TPA).
+	TrustedProfileAnalyzer = "trustedProfileAnalyzer"
+	// TrustedArtifactSigner Trusted Artifact Signer (TAS).
+	TrustedArtifactSigner = "trustedArtifactSigner"
+	// RedHatDeveloperHub Red Hat Developer Hub (RHDH).
+	RedHatDeveloperHub = "redHatDeveloperHub"
+	// RedHatAdvancedClusterSecurity Red Hat Advanced Cluster Security (RHACS).
+	RedHatAdvancedClusterSecurity = "redHatAdvancedClusterSecurity"
+	// RedHatQuay Red Hat Quay (RHDH).
+	RedHatQuay = "redHatQuay"
+	// OpenShiftPipelines OpenShift Pipelines.
+	OpenShiftPipelines = "openShiftPipelines"
+)
+
+// FeatureSpec contains the configuration for a specific feature.
+type FeatureSpec struct {
+	// Enabled feature toggle.
+	Enabled bool `yaml:"enabled"`
+	// Namespace target namespace for the feature, which may involve different
+	// Helm charts targeting the specific feature namespace, while the chart
+	// target is deployed in a different namespace.
+	Namespace *string `yaml:"namespace,omitempty"`
+	// Properties contains the feature specific configuration.
+	Properties map[string]interface{} `yaml:"properties"`
+}
+
+// GetNamespace returns the feature namespace, or an empty string if not set.
+func (f *FeatureSpec) GetNamespace() string {
+	if f.Namespace == nil {
+		return ""
+	}
+	return *f.Namespace
+}
+
+// Validate validates the feature configuration, checking for missing fields.
+func (f *FeatureSpec) Validate() error {
+	if f.Enabled && f.GetNamespace() == "" {
+		return fmt.Errorf("%w: missing namespace", ErrInvalidConfig)
+	}
+	return nil
+}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -22,7 +22,7 @@ root:
 {{- end }}
   dependencies:
 	{{- .Installer.Dependencies | toYaml | nindent 4 }}
-  catalogURL: {{ .Installer.Features.RedHatDeveloperHub.Properties.catalogURL }}
+  catalogURL: {{ .Installer.Features.redHatDeveloperHub.Properties.catalogURL }}
 `
 
 func TestEngine_Render(t *testing.T) {
@@ -66,7 +66,8 @@ func TestEngine_Render(t *testing.T) {
 
 	g.Expect(root).To(o.HaveKey("catalogURL"))
 	g.Expect(root["catalogURL"]).NotTo(o.BeNil())
-	g.Expect(root["catalogURL"]).To(o.Equal(
-		cfg.Installer.Features.RedHatDeveloperHub.Properties["catalogURL"],
-	))
+
+	feature, err := cfg.GetFeature(config.RedHatDeveloperHub)
+	g.Expect(err).To(o.Succeed())
+	g.Expect(root["catalogURL"]).To(o.Equal(feature.Properties["catalogURL"]))
 }

--- a/pkg/subcmd/developerhub_githubapp.go
+++ b/pkg/subcmd/developerhub_githubapp.go
@@ -67,10 +67,18 @@ func (d *DeveloperHubGitHubApp) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *DeveloperHubGitHubApp) Validate() error {
-	if !d.cfg.Installer.Features.RedHatDeveloperHub.Enabled {
+	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
+	if err != nil {
+		return err
+	}
+	if !feature.Enabled {
 		return fmt.Errorf("Red Hat Developer Hub feature is not enabled")
 	}
-	if !d.cfg.Installer.Features.OpenShiftPipelines.Enabled {
+	feature, err = d.cfg.GetFeature(config.OpenShiftPipelines)
+	if err != nil {
+		return err
+	}
+	if !feature.Enabled {
 		return fmt.Errorf("OpenShift Pipelines feature is not enabled")
 	}
 	// TODO: make the name optional, the user will inform the GitHub App name on


### PR DESCRIPTION
Using a `map[string]FeatureSpec` for `config.yaml`'s `.rhtapCLI.features` attribute, allowing a free definition of the installer's feature without having to chance Go code.