### PR TITLE
RHTAPINST-56: Red Hat Advanced Cluster Security

### DIFF
--- a/charts/rhtap-backing-services/templates/NOTES.txt
+++ b/charts/rhtap-backing-services/templates/NOTES.txt
@@ -10,7 +10,7 @@ Keycloak:
     Console URL: {{ printf "http://%s" $k.route.host }}
   {{- end }}
     Admin Secret: {{ printf "%s-initial-admin" $keycloakName }}
-{{- end }}
+{{ end }}
 
 {{- if .Values.backingServices.argoCD.enabled }}
   {{- $argoCD := .Values.backingServices.argoCD }}
@@ -20,4 +20,15 @@ ArgoCD:
     Server URL: {{ include "backingServices.argoCD.serverHostname" . }}
     Admin Secret: {{ include "backingServices.argoCD.secretClusterName" . }}
     Integration Secret: {{ $argoCD.secretName }}
+{{ end }}
+
+{{- if .Values.backingServices.acs.enabled }}
+  {{- $acs := .Values.backingServices.acs }}
+Red Hat Advanced Cluster Security (ACS):
+  - Name: {{ $acs.name }}
+    Namspace: {{ $acs.namespace }}
+    Central URL: {{
+      printf "https://central-%s.%s" $acs.namespace $acs.ingressDomain
+    }}
+    Secret: central-htpasswd
 {{- end }}

--- a/charts/rhtap-backing-services/templates/openshift-acs/acs-central.yaml
+++ b/charts/rhtap-backing-services/templates/openshift-acs/acs-central.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.backingServices.acs.enabled -}}
+  {{- $acs := .Values.backingServices.acs -}}
+---
+apiVersion: platform.stackrox.io/v1alpha1
+kind: Central
+metadata:
+  labels:
+    app: acs
+  namespace: {{
+    required ".backingServicews.acs.namespace is required" $acs.namespace
+  }}
+  name: {{
+    required ".backingServices.acs.name is required" $acs.name
+  }} 
+spec:
+  monitoring:
+    openshift:
+      enabled: true
+  central:
+    db:
+      isEnabled: Default
+      persistence:
+        persistentVolumeClaim:
+          claimName: central-db
+      resources: {{-
+        required ".backingServices.acs.central.db.resources is required"
+          $acs.central.db.resources | toYaml | nindent 8
+      }}
+    exposure:
+      loadBalancer:
+        enabled: false
+        port: 443
+      nodePort:
+        enabled: false
+      route:
+        enabled: true
+    notifierSecretsEncryption:
+      enabled: false
+    persistence:
+      persistentVolumeClaim:
+        claimName: stackrox-db
+    resources: {{-
+      required ".backingServices.acs.central.resources is required"
+        $acs.central.resources | toYaml | nindent 6
+    }}
+    telemetry:
+      enabled: true
+  egress:
+    connectivityPolicy: Online
+  scannerV4:
+    db:
+      persistence:
+        persistentVolumeClaim:
+          claimName: scanner-v4-db
+    indexer: {{-
+      required ".backingServices.acs.scanners.indexer is required"
+        $acs.scanners.indexer | toYaml | nindent 6
+    }}
+    matcher: {{-
+      required ".backingServices.acs.scanners.matcher is required"
+        $acs.scanners.matcher | toYaml | nindent 6
+    }}
+    scannerComponent: Default
+  scanner:
+    analyzer: {{-
+      required ".backingServices.acs.scanners.analyzer is required"
+        $acs.scanners.analyzer | toYaml | nindent 6
+    }}
+{{- end }}

--- a/charts/rhtap-backing-services/templates/tests/test.yaml
+++ b/charts/rhtap-backing-services/templates/tests/test.yaml
@@ -73,6 +73,53 @@ spec:
     #
   {{- include "backingServices.argoCD.testArgoCDLogin" . | nindent 4 }}
 {{- end }}
+{{- if .Values.backingServices.acs.enabled -}}
+  {{- $acs := .Values.backingServices.acs }}
+    #
+    # Test the ACS Central rollout status.
+    #
+    - name: {{ printf "acs-central-%s" $acs.name }}
+      image: quay.io/codeready-toolchain/oc-client-base:latest
+      env:
+        - name: NAMESPACE
+          value: {{ $acs.namespace }}
+        - name: RESOURCE_TYPE
+          value: "deployment"
+      command:
+        - /scripts/test-rollout-status.sh
+      args:
+        - {{
+            printf "app=central,app.kubernetes.io/instance=%s"
+              $acs.name | quote
+          }}
+      volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+      securityContext:
+        allowPrivilegeEscalation: false
+    #
+    # Test the ACS Scanners rollout status.
+    #
+    - name: {{ printf "acs-scanners-%s" $acs.name }}
+      image: quay.io/codeready-toolchain/oc-client-base:latest
+      env:
+        - name: NAMESPACE
+          value: {{ $acs.namespace }}
+        - name: RESOURCE_TYPE
+          value: "deployment"
+      command:
+        - /scripts/test-rollout-status.sh
+      args:
+        - {{
+            printf "app=scanner,app.kubernetes.io/instance=%s"
+              $acs.name | quote
+          }}
+      volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+      securityContext:
+        allowPrivilegeEscalation: false
+{{- end }}
   volumes:
     - name: scripts
       emptyDir: {}

--- a/charts/rhtap-backing-services/values.yaml
+++ b/charts/rhtap-backing-services/values.yaml
@@ -114,3 +114,59 @@ backingServices:
             requests:
               cpu: 125m
               memory: 128Mi
+  #
+  # Advanced Cluster Security (ACS)
+  #
+  acs:
+    # Toggle the Advanced Cluster Security (ACS) backing service. The service
+    # consists of a "Central" instance running on the cluster.
+    enabled: false
+    # ACS Central instance namespace.
+    namespace: __OVERWRITE_ME__
+    # ACS Central instance name.
+    name: stackrox-central-services
+    # ACS instances ingress domain.
+    ingressDomain: __OVERWRITE_ME__
+    # ACS Central instance configuration.
+    central:
+      # Central instance resources configuration.
+      resources: &acsCentralResources
+        limits:
+          cpu: 1024m
+          memory: 4Gi
+        requests:
+          cpu: 125m
+          memory: 512Mi
+      # Central instance database configuration.
+      db:
+        # Resources requirements for the Central instance database.
+        resources: *acsCentralResources
+    # Controls the scanning settings for ACS scanners, both stable and v4. Which
+    # includes the resource limits and scaling settings.
+    scanners:
+      # Vulnerability analyzer, responsible for scanning the images for potential
+      # vulnerabilities using vulnerability databases ("db").
+      analyzer:
+        scaling: &acsScannerScaling
+          autoScaling: Enabled
+          maxReplicas: 3
+          minReplicas: 1
+          replicas: 1
+        resources: &acsScannerResources
+          limits:
+            cpu: 250m
+            memory: 1Gi
+          requests:
+            cpu: 125m
+            memory: 256Mi
+      # Indexes the vulnerability data discovered by the scanners.
+      indexer:
+        scaling: *acsScannerScaling
+        resources: *acsScannerResources
+      # Matches the vulnerability scanned data with container images running in
+      # the cluster, based on configured security policies and generating alerts
+      # for security teams.
+      matcher:
+        scaling: *acsScannerScaling
+        resources: *acsScannerResources
+      

--- a/charts/rhtap-infrastructure/templates/openshift-pipelines/job-tekton-config.yaml
+++ b/charts/rhtap-infrastructure/templates/openshift-pipelines/job-tekton-config.yaml
@@ -77,6 +77,6 @@ spec:
     {{- end }}
       volumes:
         - name: scripts
-          emppyDir: {}
+          emptyDir: {}
   {{- end }}
 {{- end }}

--- a/charts/values.yaml.tpl
+++ b/charts/values.yaml.tpl
@@ -36,6 +36,10 @@ openshift:
 {{- if $rhdh.Enabled }}
     - {{ $rhdh.Namespace }}
 {{- end }}
+{{- if $acs.Enabled }}
+    - rhacs-operator
+    - {{ $acs.Namespace }}
+{{- end }}
 
 #
 # rhtap-subscriptions
@@ -149,6 +153,11 @@ backingServices:
     namespace: {{ $argoCDNamespace }}
     # TODO: link this secret name with RHDH configuration.
     secretName: rhtap-argocd-integration
+    ingressDomain: {{ $ingressDomain }}
+  acs:
+    enabled: {{ $acs.Enabled }}
+    namespace: {{ $acs.Namespace }}
+    name: stackrox-central-services
     ingressDomain: {{ $ingressDomain }}
 
 #

--- a/config.yaml
+++ b/config.yaml
@@ -20,7 +20,7 @@ rhtapCLI:
         catalogURL: https://github.com/redhat-appstudio/tssc-sample-templates/blob/release/all.yaml
     redHatAdvancedClusterSecurity:
       enabled: *rhdhEnabled
-      namespace: rhacs-operator
+      namespace: rhtap-stackrox
     redHatQuay:
       enabled: true
       namespace: rhtap-quay


### PR DESCRIPTION
Adding the deployment, and basic configuration, if the Central instance, as well as scanners. Continuing what @Roming22 have started on [his branch](https://github.com/Roming22/rhtap-cli/tree/acs/config).