### PR TITLE
fix: update patch-tekton-pipeline role

### DIFF
--- a/charts/rhtap-infrastructure/templates/openshift-pipelines/service-account.yaml
+++ b/charts/rhtap-infrastructure/templates/openshift-pipelines/service-account.yaml
@@ -23,7 +23,8 @@ rules:
       - get
       - list
       - create
-
+      - delete
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
- update: needed because the operator might create an empty secret first.
- delete: needed because, in the case the resource exists, it will be deleted to be recreated with the ownerReference.