### PR TITLE
fix: update pipelines patch jobs

### DIFF
--- a/charts/rhtap-infrastructure/templates/openshift-pipelines/job-tekton-chains.yaml
+++ b/charts/rhtap-infrastructure/templates/openshift-pipelines/job-tekton-chains.yaml
@@ -17,12 +17,11 @@ kind: Job
 metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
     helm.sh/hook-weight: "2"
   labels:
     {{- include "rhtap-infrastructure.labels" . | nindent 4 }}
   namespace: {{ $osp.namespace }}
-  name: {{ printf "cosign-%s-%d" $osp.name .Release.Revision }}
+  name: {{ printf "cosign-%s" $osp.name }}
 spec:
   template:
     spec:

--- a/charts/rhtap-infrastructure/templates/openshift-pipelines/job-tekton-config.yaml
+++ b/charts/rhtap-infrastructure/templates/openshift-pipelines/job-tekton-config.yaml
@@ -10,12 +10,11 @@ kind: Job
 metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: hook-succeeded
     helm.sh/hook-weight: "1"
   labels:
     {{- include "rhtap-infrastructure.labels" . | nindent 4 }}
   namespace: {{ $osp.namespace }}
-  name: {{ printf "patch-tekton-%s-%d" $osp.name .Release.Revision }}
+  name: {{ printf "patch-tekton-%s" $osp.name }}
 spec:
   template:
     spec:


### PR DESCRIPTION
The unique name of the jobs meant that in case of failure it would keep retrying. It means that if RHTAP is then redeployed successfully, the old job might run. This could lead to issues that are difficult to reproduce and troubleshoot.