### PR TITLE
feat: allow gitops/pipelines bypass

### DIFF
--- a/charts/values.yaml.tpl
+++ b/charts/values.yaml.tpl
@@ -3,6 +3,8 @@
 {{- $tpa := required "TPA settings" .Installer.Features.trustedProfileAnalyzer -}}
 {{- $keycloak := required "Keycloak settings" .Installer.Features.keycloak -}}
 {{- $acs := required "Red Hat ACS settings" .Installer.Features.redHatAdvancedClusterSecurity -}}
+{{- $gitops := required "GitOps settings" .Installer.Features.openShiftGitOps -}}
+{{- $pipelines := required "Pipelines settings" .Installer.Features.openShiftPipelines -}}
 {{- $quay := required "Quay settings" .Installer.Features.redHatQuay -}}
 {{- $rhdh := required "RHDH settings" .Installer.Features.redHatDeveloperHub -}}
 {{- $ingressDomain := required "OpenShift ingress domain" .OpenShift.Ingress.Domain -}}
@@ -55,7 +57,7 @@ subscriptions:
   minIO:
     enabled: {{ $tpa.Enabled }}
   openshiftGitOps:
-    enabled: {{ $rhdh.Enabled }}
+    enabled: {{ $gitops.Enabled }}
     config:
       argoCDClusterNamespace: {{ $argoCDNamespace }}
   openshiftKeycloak:
@@ -64,7 +66,7 @@ subscriptions:
       targetNamespaces:
         - {{ default "empty" $keycloak.Namespace }}
   openshiftPipelines:
-    enabled: {{ $rhdh.Enabled }}
+    enabled: {{ $pipelines.Enabled }}
   openshiftTrustedArtifactSigner:
     enabled: {{ $tas.Enabled }}
   redHatAdvancedClusterSecurity:

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,9 @@ rhtapCLI:
     redHatQuay:
       enabled: true
       namespace: rhtap-quay
+    openShiftGitOps:
+      enabled: *rhdhEnabled
+      namespace: openshift-gitops-operator
     openShiftPipelines:
       enabled: *rhdhEnabled
       namespace: openshift-pipelines


### PR DESCRIPTION
In the case of GitOps, the subscription must be edited manually to add the namespace to the ARGOCD_CLUSTER_CONFIG_NAMESPACES env var.