### PR TITLE
fix: DH db lock on boot (RHIDP-3217).

### DIFF
--- a/charts/rhtap-dh/templates/app-config.yaml
+++ b/charts/rhtap-dh/templates/app-config.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    rhdh.redhat.com/backstage-name: {{ .Values.developerHub.instanceName | quote }}
+  labels:
+    rhdh.redhat.com/ext-config-sync: "true"
   name: developer-hub-rhtap-app-config
 data:
   app-config.rhtap.yaml: |

--- a/charts/rhtap-dh/templates/backstage.yaml
+++ b/charts/rhtap-dh/templates/backstage.yaml
@@ -2,7 +2,7 @@
 apiVersion: rhdh.redhat.com/v1alpha1
 kind: Backstage
 metadata:
-  name: developer-hub
+  name: {{ .Values.developerHub.instanceName | quote }}
   namespace: {{.Release.Namespace}}
 spec:
   application:

--- a/charts/rhtap-dh/templates/extra-env.yaml
+++ b/charts/rhtap-dh/templates/extra-env.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
+    annotations:
+        rhdh.redhat.com/backstage-name: {{ .Values.developerHub.instanceName | quote }}
+    labels:
+        rhdh.redhat.com/ext-config-sync: "true"
     name: developer-hub-rhtap-env
     namespace: {{.Release.Namespace}}
 type: Opaque

--- a/charts/rhtap-dh/templates/plugins.yaml
+++ b/charts/rhtap-dh/templates/plugins.yaml
@@ -1,6 +1,10 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
+  annotations:
+    rhdh.redhat.com/backstage-name: {{ .Values.developerHub.instanceName | quote }}
+  labels:
+    rhdh.redhat.com/ext-config-sync: "true"
   name: developer-hub-rhtap-dynamic-plugins
 data:
   dynamic-plugins.yaml: |

--- a/charts/rhtap-dh/values.yaml
+++ b/charts/rhtap-dh/values.yaml
@@ -1,4 +1,5 @@
 ---
 developerHub:
+  instanceName: developer-hub
   catalogURL: __OVERWRITE_ME__
   ingressDomain: __OVERWRITE_ME__


### PR DESCRIPTION
The operator currently watches all ConfigMaps and Secrets referenced in the CR, and tries to update them by adding the
'rhdh.redhat.com/ext-config-sync' label and
'rhdh.redhat.com/backstage-name' annotation if they are not already present. The problem is that adding this information makes the Operator think that they have changed and updates the Pod Template in the Deployment, triggering the creation of a new Pod.

Explicitly setting those fields at instantiation is the recommended workaround.