### PR TITLE
RHTAPINST-100: Expose Quay's MinIO Tenant

### DIFF
--- a/charts/rhtap-infrastructure/templates/minio/networkpolicies.yaml
+++ b/charts/rhtap-infrastructure/templates/minio/networkpolicies.yaml
@@ -40,4 +40,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ $v.namespace }}
+  {{- if $v.ingress.enabled }}
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress 
+  {{- end }}
 {{- end }}

--- a/charts/rhtap-infrastructure/templates/minio/route.yaml
+++ b/charts/rhtap-infrastructure/templates/minio/route.yaml
@@ -1,0 +1,24 @@
+{{- range $k, $v := include "infrastructure.minIOTenants.enabled" . | fromYaml }}
+  {{- if $v.ingress.enabled }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: minio
+  namespace: {{ $v.namespace }}
+  name: {{ printf "minio-%s" $k }}
+spec:
+  host: {{ printf "minio-%s.%s" $v.namespace $v.ingress.domain }}
+  port:
+    targetPort: http-minio
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: minio
+    weight: 100
+  wildcardPolicy: None
+  {{- end }}
+{{- end }}

--- a/charts/rhtap-infrastructure/values.yaml
+++ b/charts/rhtap-infrastructure/values.yaml
@@ -60,6 +60,12 @@ infrastructure:
       enabled: false
       # Target namespace for the MinIO Tenant and related resources.
       namespace: __OVERWRITE_ME__
+      # Enable the Ingress resource to expose the MinIO Tenant.
+      ingress:
+        # Toggle the route resource creation.
+        enabled: false
+        # The Ingress domain.
+        domain: __OVERWRITE_ME__
       # Secret name to store MinIO's root password, the password is generated when
       # the secret is empty.
       rootSecretName: tpa-minio-root-env
@@ -118,6 +124,12 @@ infrastructure:
       enabled: false
       # Target namespace for the MinIO Tenant and related resources.
       namespace: __OVERWRITE_ME__
+      # Enable the Ingress resource to expose the MinIO Tenant.
+      ingress:
+        # Toggle the route resource creation.
+        enabled: false
+        # The Ingress domain.
+        domain: __OVERWRITE_ME__
       # Secret name to store MinIO's root password, the password is generated when
       # the secret is empty, otherwise the existing attributes are used.
       rootSecretName: quay-minio-root-env

--- a/charts/values.yaml.tpl
+++ b/charts/values.yaml.tpl
@@ -107,6 +107,9 @@ infrastructure:
     quay:
       enabled: {{ $quay.Enabled }}
       namespace: {{ $quay.Namespace }}
+      ingress:
+        enabled: true
+        domain: {{ $ingressDomain }}
       rootSecretName: {{ $quayMinIOSecretName }}
       kafkaNotify:
         enabled: false
@@ -133,7 +136,8 @@ infrastructure:
 {{- $keycloakRouteTLSSecretName := "keycloak-tls" }}
 {{- $keycloakRouteHost := printf "sso.%s" $ingressDomain }}
 {{- $argoCDName := "argocd" }}
-{{- $quayMinIOHost := printf "minio.%s.svc.cluster.local" $quay.Namespace }}
+{{- $quayMinIOHost := printf "minio-%s.%s" $quay.Namespace $ingressDomain }}
+
 
 backingServices:
   keycloak:
@@ -184,6 +188,8 @@ backingServices:
       radosGWStorage:
         enabled: true
         hostname: {{ $quayMinIOHost }}
+        port: 443
+        isSecure: true
         credentials:
           secretName: {{ $quayMinIOSecretName }}
       superUser:

--- a/scripts/quay-helper.sh
+++ b/scripts/quay-helper.sh
@@ -32,7 +32,7 @@ declare -r SECRET_NAME="${SECRET_NAME:-}"
 
 # After initialization of the super-user, or login, the global variable will be
 # set with the user's access token obtained from Quay.
-declare ACCESS_TOKEN
+declare ACCESS_TOKEN=""
 
 #
 # Functions
@@ -216,7 +216,8 @@ quay_helper() {
     # to get recreated, the acccess token is only obtained during initialization
     if oc get secret "${SECRET_NAME}" --namespace="${NAMESPACE}" &>/dev/null &&
         [[ -z "${ACCESS_TOKEN}" ]]; then
-        fail "Secret already exists, Quay has already been initialized!"
+        warn "Secret already exists, Quay has already been initialized!"
+        return 0
     fi
 
     quay_create_secret || {


### PR DESCRIPTION
In order to pull images from the `QuayRegistry` using MinIO (S3) storage, requires the S3 service reachable from outside the cluster.