### PR TITLE
RHTAPINST-102: GitHub App Organization Mandatory

### DIFF
--- a/pkg/githubapp/githubapp.go
+++ b/pkg/githubapp/githubapp.go
@@ -42,6 +42,14 @@ func (g *GitHubApp) PersistentFlags(p *pflag.FlagSet) {
 		"Callback webserver port number")
 }
 
+// Validate validates the GitHub App configuration.
+func (g *GitHubApp) Validate() error {
+	if g.gitHubOrgName == "" {
+		return errors.New("GitHub organization name is required")
+	}
+	return nil
+}
+
 // log logger with contextual information.
 func (g *GitHubApp) log() *slog.Logger {
 	return g.logger.With(

--- a/pkg/integrations/github.go
+++ b/pkg/integrations/github.go
@@ -68,7 +68,7 @@ func (g *GithubIntegration) Validate() error {
 	if g.token == "" {
 		return fmt.Errorf("github token is required")
 	}
-	return nil
+	return g.gitHubApp.Validate()
 }
 
 // EnsureNamespace ensures the namespace needed for the GitHub integration secret


### PR DESCRIPTION
The user must inform the organization name (`--org`) upon creating a GitHub App integration.

```bash
rhtap-cli integrations github-app \
    --create \
    --org="redhat-appstudio" \
    --token="deadbeef" \
    rhtap
```