### PR TITLE
fix: use init containers to copy scripts

### DIFF
--- a/charts/rhtap-backing-services/templates/openshift-acs/job-stackrox-api.yaml
+++ b/charts/rhtap-backing-services/templates/openshift-acs/job-stackrox-api.yaml
@@ -19,12 +19,13 @@ spec:
     spec:
       serviceAccountName: {{ printf "%s-acs" .Release.Name }}
       restartPolicy: Never
-      containers:
+      initContainers:
         #
         # Copying the scripts that will be used on the subsequent containers, the
         # scripts are shared via the "/scripts" volume.
         #
   {{- include "backingServices.copyScripts" . | nindent 8 }}
+      containers:
         #
         # Generates a token for StackRox API, using the ACS Central credentials.
         #

--- a/charts/rhtap-backing-services/templates/openshift-gitops/job-post-deploy.yaml
+++ b/charts/rhtap-backing-services/templates/openshift-gitops/job-post-deploy.yaml
@@ -24,12 +24,13 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}
       restartPolicy: Never
-      containers:
+      initContainers:
         #
         # Copying the scripts that will be used on the subsequent containers, the
         # scripts are shared via the "/scripts" volume.
         #
   {{- include "backingServices.copyScripts" . | nindent 8 }}
+      containers:
         #
         # Generates a token for the ArgoCD API, the credentials are stored on a
         # file which is later stored as a Kubernetes secret.

--- a/charts/rhtap-backing-services/templates/openshift-quay/job-quay-integration.yaml
+++ b/charts/rhtap-backing-services/templates/openshift-quay/job-quay-integration.yaml
@@ -16,12 +16,13 @@ spec:
     spec:
       serviceAccountName: {{ printf "%s-quay" .Release.Name }}
       restartPolicy: Never
-      containers:
+      initContainers:
         #
         # Copying the scripts that will be used on the subsequent containers, the
         # scripts are shared via the "/scripts" volume.
         #
   {{- include "backingServices.copyScripts" . | nindent 8 }}
+      containers:
         #
         # Initializing the Quay integration.
         #

--- a/charts/rhtap-backing-services/templates/tests/test.yaml
+++ b/charts/rhtap-backing-services/templates/tests/test.yaml
@@ -12,12 +12,13 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ .Release.Name }}
-  containers:
+  initContainers:
     #
     # Copying the scripts that will be used on the subsequent containers, the
     # scripts are shared via the "/scripts" volume.
     #
 {{- include "backingServices.copyScripts" . | nindent 4 }}
+  containers:
 {{- if .Values.backingServices.keycloak.enabled }}
     #
     # Tests the Keycloak rollout status.

--- a/charts/rhtap-dh/templates/tests/test.yaml
+++ b/charts/rhtap-dh/templates/tests/test.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: rhdh-kubernetes-plugin
-  containers:
+  initContainers:
     - name: copy-scripts
       image: registry.access.redhat.com/ubi8/ubi-minimal:latest
       workingDir: /scripts
@@ -31,6 +31,7 @@ spec:
           mountPath: /scripts
       securityContext:
         allowPrivilegeEscalation: false
+  containers:
     - name: {{ printf "%s-deployments" $name }}
       image: quay.io/codeready-toolchain/oc-client-base:latest
       env:

--- a/charts/rhtap-infrastructure/templates/openshift-pipelines/job-tekton-config.yaml
+++ b/charts/rhtap-infrastructure/templates/openshift-pipelines/job-tekton-config.yaml
@@ -20,12 +20,13 @@ spec:
     spec:
       serviceAccountName: {{ printf "patch-%s" $osp.name }}
       restartPolicy: Never
-      containers:
+      initContainers:
         #
         # Copying the scripts that will be used on the subsequent containers, the
         # scripts are shared via the "/scripts" volume.
         #
     {{- include "infrastructure.copyScripts" . | nindent 8 }}
+      containers:
     {{- if $osp.patchClusterTektonConfig.annotations }}
         #
         # Patch the Tekton Config with the provided annotations.

--- a/charts/rhtap-infrastructure/templates/tests/test.yaml
+++ b/charts/rhtap-infrastructure/templates/tests/test.yaml
@@ -12,12 +12,13 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ .Release.Name }}
-  containers:
+  initContainers:
     #
     # Copying the scripts that will be used on the subsequent containers, the
     # scripts are shared via the "/scripts" volume.
     #
 {{- include "infrastructure.copyScripts" . | nindent 4 }}
+  containers:
 {{- range $k, $v := include "infrastructure.kafkas.enabled" . | fromYaml }}
     - name: {{ printf "%s-kafka-topics-%s" $name $k }}
       image: quay.io/codeready-toolchain/oc-client-base:latest

--- a/charts/rhtap-openshift/templates/tests/test.yaml
+++ b/charts/rhtap-openshift/templates/tests/test.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ .Release.Name }}
-  containers:
+  initContainers:
     - name: copy-scripts
       image: registry.access.redhat.com/ubi8/ubi-minimal:latest
       workingDir: /scripts
@@ -31,6 +31,7 @@ spec:
           mountPath: /scripts
       securityContext:
         allowPrivilegeEscalation: false
+  containers:
     - name: {{ $name }}
       image: quay.io/codeready-toolchain/oc-client-base:latest
       command:

--- a/charts/rhtap-subscriptions/templates/tests/test.yaml
+++ b/charts/rhtap-subscriptions/templates/tests/test.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ .Release.Name }}
-  containers:
+  initContainers:
     - name: copy-scripts
       image: registry.access.redhat.com/ubi8/ubi-minimal:latest
       workingDir: /scripts
@@ -31,6 +31,7 @@ spec:
           mountPath: /scripts
       securityContext:
         allowPrivilegeEscalation: false
+  containers:
     - name: {{ $name }}
       image: quay.io/codeready-toolchain/oc-client-base:latest
       command:

--- a/charts/rhtap-tas/templates/tests/test.yaml
+++ b/charts/rhtap-tas/templates/tests/test.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ .Release.Name }}
-  containers:
+  initContainers:
     - name: copy-scripts
       image: registry.access.redhat.com/ubi8/ubi-minimal:latest
       workingDir: /scripts
@@ -34,6 +34,7 @@ spec:
           mountPath: /scripts
       securityContext:
         allowPrivilegeEscalation: false
+  containers:
     - name: {{ printf "%s-statefulsets" $name }}
       image: quay.io/codeready-toolchain/oc-client-base:latest
       env:

--- a/charts/rhtap-tpa/templates/tests/test.yaml
+++ b/charts/rhtap-tpa/templates/tests/test.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ .Release.Name }}
-  containers:
+  initContainers:
     - name: copy-scripts
       image: registry.access.redhat.com/ubi8/ubi-minimal:latest
       workingDir: /scripts
@@ -33,6 +33,7 @@ spec:
       securityContext:
         allowPrivilegeEscalation: false
 {{- if $keycloak.enabled }}
+  containers:
     - name: {{ $name }}
       image: quay.io/codeready-toolchain/oc-client-base:latest
       env:


### PR DESCRIPTION
This solves a possible race condition where a script could be executed before it has been written to disk.