### PR TITLE
RHTAPINST-112: Trusted Profile Analyzer Integration Secret

### DIFF
--- a/charts/rhtap-tpa/templates/NOTES.txt
+++ b/charts/rhtap-tpa/templates/NOTES.txt
@@ -12,8 +12,8 @@ Keycloak "chicken" Realm Credentials:
 {{- end }}
 
 {{- $tpa := .Values.trustedProfileAnalyzer }}
-{{ if $tpa.enabled }}
-{{- $trustification := .Values.trustification }}
+{{- if $tpa.enabled }}
+  {{- $trustification := .Values.trustification }}
 Trusted Profile Analyzer (TPA):
   - Keycloak URL:   {{ $trustification.oidc.issuerUrl }}
     Namespace:      {{ .Release.Namespace }}

--- a/charts/rhtap-tpa/templates/realm.yaml
+++ b/charts/rhtap-tpa/templates/realm.yaml
@@ -2,6 +2,11 @@
 {{- if $keycloak.enabled }}
   {{- $appDomain := .Values.trustedProfileAnalyzer.appDomain -}}
   {{- $adminUsername := "admin" -}}
+#
+# Realm Admin
+#
+#   Creates a secret to store admin's credentials.
+#
 ---
   {{- 
     $adminSecretObj := 
@@ -26,6 +31,11 @@ type: Opaque
 data:
   username: {{ $adminUsername | b64enc }}
   password: {{ $adminPassword }}
+#
+# Realm Clients
+#
+#   Creates a secret which contains all enabled clients' credentials.
+#
 ---
   {{- 
     $oidcSecretObj := 
@@ -53,6 +63,51 @@ data:
     {{- $oidcCredentials := mergeOverwrite $oidcCredentials (dict $k $s) }}
   {{ $k }}: {{ $s }}
   {{- end }}
+#
+# Integration Secret
+#
+#   Creates a secret to store integration details.
+#
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: keycloak
+  namespace: {{
+    required "trustedProfileAnalyzer.integrationSecret.namespace is required"
+      .Values.trustedProfileAnalyzer.integrationSecret.namespace
+  }}
+  name: {{
+    required "trustedProfileAnalyzer.integrationSecret.name is required"
+      .Values.trustedProfileAnalyzer.integrationSecret.name
+  }}
+type: Opaque
+stringData:
+  bombastic_api_url: {{
+    required "trustedProfileAnalyzer.integrationSecret.bombasticAPI is required"
+      .Values.trustedProfileAnalyzer.integrationSecret.bombasticAPI
+  }}
+  oidc_issuer_url: {{
+    required "trustification.oidc.issuerUrl is required"
+      .Values.trustification.oidc.issuerUrl
+  }}
+  oidc_client_id: {{
+    required "trustedProfileAnalyzer.integrationSecret.oidcClientID is required"
+      .Values.trustedProfileAnalyzer.integrationSecret.oidcClientID
+  }}
+  oidc_client_secret: {{
+    get $oidcCredentials
+      .Values.trustedProfileAnalyzer.integrationSecret.oidcClientID |
+        b64dec
+  }}
+  supported_cyclonedx_version: "{{
+    required "trustedProfileAnalyzer.integrationSecret.cycloneDXVersion is required"
+      .Values.trustedProfileAnalyzer.integrationSecret.cycloneDXVersion
+  }}"
+#
+# Keycloak Realm Import
+#
 ---
 apiVersion: k8s.keycloak.org/v2alpha1
 kind: KeycloakRealmImport

--- a/charts/rhtap-tpa/values.yaml
+++ b/charts/rhtap-tpa/values.yaml
@@ -9,6 +9,18 @@ trustedProfileAnalyzer:
   enabled: true
   # Trustification's "appDomain" attribute.
   appDomain: __OVERWRITE_ME__
+  # Describe details of Trustification installation for integration with other
+  # components.
+  integrationSecret:
+    # Bombastic API URL.
+    bombasticAPI: __OVERWRITE_ME__
+    # OIDC client ID to interact with the Bombastic API endpoint.
+    oidcClientID: walker
+    # Secret namespace and name.
+    namespace: __OVERWRITE_ME__
+    name: __OVERWRITE_ME__
+    # CycloneDX version supported by TPA (Trustification).
+    cycloneDXVersion: 1.4
   # TPA Keycloak Realm import configuration.
   keycloakRealmImport:
     # Enables the Keycloak Realm import.

--- a/charts/values.yaml.tpl
+++ b/charts/values.yaml.tpl
@@ -243,6 +243,15 @@ developerHub:
 trustedProfileAnalyzer:
   enabled: {{ $tpa.Enabled }}
   appDomain: "{{ $tpaAppDomain }}"
+  integrationSecret:
+    bombasticAPI: {{
+      printf "%s://sbom-%s.%s"
+        $protocol
+        $tpa.Namespace
+        $ingressDomain
+    }}
+    namespace: {{ .Installer.Namespace }}
+    name: rhtap-trustification-integration
   keycloakRealmImport:
     enabled: {{ $keycloak.Enabled }}
     keycloakCR:


### PR DESCRIPTION
After `rhtap-tpa` chart is installed, the following secret is created:

```bash
oc --namespace rhtap extract secrets/rhtap-trustification-integration --to=-
```