### PR TITLE
RHTAPINST-120: GitHub Project Release

### DIFF
--- a/.github/actions/go/action.yaml
+++ b/.github/actions/go/action.yaml
@@ -1,0 +1,10 @@
+---
+name: go
+description: Setup latest stable Go SDK
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v5
+      with:
+        go-version: stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+---
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/go
+
+      - name: GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          make github-release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,18 @@
+---
+project_name: rhtap-cli
+dist: bin/dist
+
+builds:
+  - id: rhtap-cli
+    binary: rhtap-cli
+    goos:
+      - darwin
+      - linux
+    env:
+      - GOFLAGS={{ .Env.GOFLAGS }}
+      - CGO_ENABLED={{ .Env.CGO_ENABLED }}
+      - CGO_LDFLAGS={{ .Env.CGO_LDFLAGS }}
+    main: cmd/rhtap-cli/main.go
+    goarch:
+      - arm64
+      - amd64

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,5 +55,36 @@ make &&
     bin/rhtap-cli deploy --help
 ```
 
-[gnuMake]: https://www.gnu.org/software/make/
-[golang]: https://golang.org/dl/
+# GitHub Release
+
+This project uses [GitHub Actions](.github/workflows/release.yaml) to automate the release process, triggered by a new tag in the repository.
+
+To release this application using the the GitHub web interface follow the steps:
+
+1. Go to the [releases page][releases]
+2. Click on "Create a new release" button
+3. Choose the tag you want to release, the tag must start with `v` and follow the semantic versioning pattern.
+4. Fill the release title and description
+5. [Wait for the release workflow][actions] to finish and verify the release assets
+
+## Release Automation
+
+For the release automation the following tools are used:
+- [`gh`][gitHubCLI]: GitHub helper CLI, ensure the release is created, or create it if it doesn't exist yet.
+- [`goreleaser`][goreleaser]: Tool to automate the release process, it creates the release assets and uploads them to the GitHub release.
+
+The [release workflow](.github/workflows/release.yaml) relies on the `make github-release` target, this [`Makefile`](Makefile) target is responsible for ensure the release is created, or create it using `gh` helper, build and upload the release assets using `goreleaser`.
+
+The GitHub workflow provides [`GITHUB_REF_NAME` environment variable][gitHubDocWorkflowEnvVars] to the release job, this variable is used to determine the tag name to release.
+
+```bash
+make github-release GITHUB_REF_NAME="v0.1.0"
+```
+
+[actions]: https://github.com/redhat-appstudio/rhtap-cli/actions
+[gitHubCLI]: https://cli.github.com
+[gitHubDocWorkflowEnvVars]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/variables#default-environment-variables
+[gnuMake]: https://www.gnu.org/software/make
+[golang]: https://golang.org/dl
+[goreleaser]: https://goreleaser.com
+[releases]: https://github.com/redhat-appstudio/rhtap-cli/releases

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,22 @@ APP = rhtap-cli
 BIN_DIR ?= ./bin
 BIN ?= $(BIN_DIR)/$(APP)
 
+# Primary source code directories.
 CMD ?= ./cmd/...
 PKG ?= ./pkg/...
 
+# Golang general flags for build and testing.
 GOFLAGS ?= -v
 GOFLAGS_TEST ?= -failfast -v -cover
+CGO_ENABLED ?= 0
+CGO_LDFLAGS ?= 
 
+# GitHub action current ref name, provided by the action context environment
+# variables, and credentials needed to push the release.
+GITHUB_REF_NAME ?= ${GITHUB_REF_NAME:-}
+GITHUB_TOKEN ?= ${GITHUB_TOKEN:-}
+
+# Coordinates for the container image build.
 IMAGE_REPO ?= ghcr.io/redhat-appstudio/rhtap-cli
 IMAGE_TAG ?= latest
 
@@ -27,6 +37,13 @@ $(BIN):
 
 .PHONY: build
 build: $(BIN)
+
+# Uses goreleaser to create a snapshot build.
+.PHONY: goreleaser-snapshot
+goreleaser-snapshot: tool-goreleaser
+	goreleaser build --clean --snapshot --single-target -o $(BIN) $(ARGS)
+
+snapshot: goreleaser-snapshot
 
 # Runs the application with arbitrary ARGS.
 .PHONY: run
@@ -58,6 +75,18 @@ tool-golangci-lint:
 	@which golangci-lint &>/dev/null || \
 		go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest &>/dev/null
 
+# Installs GitHub CLI ("gh").
+tool-gh: GOFLAGS =
+tool-gh:
+	@which gh >/dev/null 2>&1 || \
+		go install github.com/cli/cli/v2/cmd/gh@latest >/dev/null 2>&1
+
+# Installs GoReleaser.
+tool-goreleaser: GOFLAGS =
+tool-goreleaser:
+	@which goreleaser >/dev/null 2>&1 || \
+		go install github.com/goreleaser/goreleaser@latest >/dev/null 2>&1
+
 #
 # Test and Lint
 #
@@ -73,3 +102,44 @@ test-unit:
 .PHONY: lint
 lint: tool-golangci-lint
 	golangci-lint run ./...
+
+#
+# GitHub Release
+#
+
+# Asserts the required environment variables are set and the target release
+# version starts with "v".
+github-preflight:
+ifeq ($(strip $(GITHUB_REF_NAME)),)
+	$(error variable GITHUB_REF_NAME is not set)
+endif
+ifeq ($(shell echo ${GITHUB_REF_NAME} |grep -v -E '^v'),)
+	@echo GITHUB_REF_NAME=\"${GITHUB_REF_NAME}\"
+else
+	$(error invalid GITHUB_REF_NAME, it must start with "v")
+endif
+ifeq ($(strip $(GITHUB_TOKEN)),)
+	$(error variable GITHUB_TOKEN is not set)
+endif
+
+# Creates a new GitHub release with GITHUB_REF_NAME.
+.PHONY: github-release-create
+github-release-create: tool-gh
+	gh release view $(GITHUB_REF_NAME) >/dev/null 2>&1 || \
+		gh release create --generate-notes $(GITHUB_REF_NAME)
+
+# Runs "goreleaser" to build the artifacts and upload them into the current
+# release payload, it amends the release in progress with the application
+# executables.
+.PHONY: goreleaser-release
+goreleaser-release: tool-goreleaser
+goreleaser-release: CGO_ENABLED = 0
+goreleaser-release: GOFLAGS = -a
+goreleaser-release:
+	goreleaser release --clean --fail-fast $(ARGS)
+
+# Releases the GITHUB_REF_NAME.
+github-release: \
+	github-preflight \
+	github-release-create \
+	goreleaser-release

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+<p align="center">
+    <a alt="Project quality report" href="https://goreportcard.com/report/github.com/redhat-appstudio/rhtap-cli">
+        <img src="https://goreportcard.com/badge/github.com/redhat-appstudio/rhtap-cli">
+    </a>
+    <a alt="Release workflow status" href="https://github.com/redhat-appstudio/rhtap-cli/actions">
+        <img src="https://github.com/redhat-appstudio/rhtap-cli/actions/workflows/release.yaml/badge.svg">
+    </a>
+    <a alt="Latest project release" href="https://github.com/redhat-appstudio/rhtap-cli/releases/latest">
+        <img src="https://img.shields.io/github/v/release/redhat-appstudio/rhtap-cli">
+    </a>
+</p>
+
 Red Hat Trusted Application Pipeline Installer (`rhtap-cli`)
 ------------------------------------------------------------
 


### PR DESCRIPTION
Adding Github Action to release the project artifacts using `goreleaser`.

This PR introduces documentation and automation to release the `rhtap-cli` for multiple platforms upon the creation of a new GitHub release (i.e. Git tag).