### PR TITLE
RHTAPBUGS-1294: More Storage by Default

### DIFF
--- a/charts/rhtap-infrastructure/values.yaml
+++ b/charts/rhtap-infrastructure/values.yaml
@@ -116,7 +116,7 @@ infrastructure:
                 - ReadWriteOnce
               resources:
                 requests:
-                  storage: 500Mi
+                  storage: 8Gi
     #
     # Quay.io Tenant, stores the container image artifacts.
     #
@@ -156,7 +156,7 @@ infrastructure:
                 - ReadWriteOnce
               resources:
                 requests:
-                  storage: 500Mi
+                  storage: 2Gi
   #
   # PostgreSQL Clusters
   #


### PR DESCRIPTION
Using 8Gi for TPA and 2Gi for Quay PVCs.