### PR TITLE
[RHTAPBUGS-1305] Adds default username to github integration

### DIFF
--- a/charts/rhtap-dh/templates/app-namespaces/github-auth.secret.yaml
+++ b/charts/rhtap-dh/templates/app-namespaces/github-auth.secret.yaml
@@ -12,5 +12,6 @@ metadata:
   namespace: {{ $namespace }}-app-{{ . }}
 data:
   password: {{ $secretData.token }}
+  username: {{ "oauth2" | b64enc }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR adjusts github-auth-secret creation to work with [RHTAPBUGS-1305](https://issues.redhat.com//browse/RHTAPBUGS-1305) fix.