### PR TITLE
RHTAPINST-149: Wait for Operators Rollout

### DIFF
--- a/installer/charts/rhtap-subscriptions/.helmignore
+++ b/installer/charts/rhtap-subscriptions/.helmignore
@@ -15,4 +15,5 @@
 *.tmp
 *.tmproj
 *~
+*.md
 hack/

--- a/installer/charts/rhtap-subscriptions/Chart.yaml
+++ b/installer/charts/rhtap-subscriptions/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v2
 name: rhtap-subscriptions
 description: RHTAP OpenShift Operator Subscriptions
 type: application
-version: 0.0.1
+version: 0.0.2

--- a/installer/charts/rhtap-subscriptions/README.md
+++ b/installer/charts/rhtap-subscriptions/README.md
@@ -1,0 +1,8 @@
+`rhtap-subscriptions`
+---------------------
+
+This Helm Chart manages OpenShift Operator Hub subscriptions required for RHTAP. It leverages `Subscription` and `OperatorGroup` resources.
+
+During installation, it checks for the existence of the necessary CRDs (Custom Resource Definitions) and waits for the Operator to become available before proceeding.
+
+The list of subscriptions is defined in the [`values.yaml`](values.yaml) file.

--- a/installer/charts/rhtap-subscriptions/scripts/test-rollout-status.sh
+++ b/installer/charts/rhtap-subscriptions/scripts/test-rollout-status.sh
@@ -1,0 +1,1 @@
+../../../scripts/test-rollout-status.sh

--- a/installer/charts/rhtap-subscriptions/templates/tests/test.yaml
+++ b/installer/charts/rhtap-subscriptions/templates/tests/test.yaml
@@ -1,4 +1,3 @@
-{{- $name := printf "%s-test-%d" .Chart.Name .Release.Revision -}}
 ---
 apiVersion: v1
 kind: Pod
@@ -8,7 +7,7 @@ metadata:
     helm.sh/hook-delete-policy: hook-succeeded
   labels:
     {{- include "rhtap-subscriptions.labels" . | nindent 4 }}
-  name: {{ $name }} 
+  name: {{ printf "%s-test-%d" .Chart.Name .Release.Revision }} 
 spec:
   restartPolicy: Never
   serviceAccountName: {{ .Release.Name }}
@@ -32,7 +31,10 @@ spec:
       securityContext:
         allowPrivilegeEscalation: false
   containers:
-    - name: {{ $name }}
+    #
+    # Tests the subcriptions CRDs.
+    #
+    - name: test-subscriptions
       image: quay.io/codeready-toolchain/oc-client-base:latest
       command:
         - /scripts/test-subscriptions.sh
@@ -45,6 +47,29 @@ spec:
           mountPath: /scripts
       securityContext:
         allowPrivilegeEscalation: false
+{{- range $sub := include "subscriptions.enabled" . | fromYaml }}
+    #
+    # Tests the {{ $sub.name }} rollout status.
+    #
+    - name: {{ printf "test-%s" ($sub.name | lower) }} 
+      image: quay.io/codeready-toolchain/oc-client-base:latest
+      env:
+        - name: NAMESPACE
+          value: {{ $sub.namespace }}
+        - name: RESOURCE_TYPE
+          value: "deployment"
+        - name: RETRIES
+          value: "15"
+      command:
+        - /scripts/test-rollout-status.sh
+      args:
+        - olm.managed=true
+      volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+      securityContext:
+        allowPrivilegeEscalation: false
+{{- end }}
   volumes:
     - name: scripts
       emptyDir: {}


### PR DESCRIPTION
All OLM managed operator have a "olm.managed=true" label, so we can use this to wait for the rollout of the operator to complete.