### PR TITLE
fix: Avoid `.__*` Files on macOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,16 @@ In order to contribute to this project you need the following requirements:
 
 - [Golang 1.16 or higher][golang]
 - [GNU Make][gnuMake]
+- [GNU Tar][gnuTar]
 - [Podman][podman] or [Buildah][buildah] (optional)
 
 All the automation needed for the project lives in the [Makefile](Makefile). This file is the entry point for all the automation tasks in the project for CI, development and release
+
+For macOS users make sure `gtar` is available, i.e.:
+
+```bash
+brew install gnu-tar
+```
 
 # Building
 
@@ -122,3 +129,4 @@ make snapshot
 [buildah]: https://buildah.io
 [podman]: https://podman.io
 [releases]: https://github.com/redhat-appstudio/rhtap-cli/releases
+[gnuTar]: https://www.gnu.org/software/tar

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,14 @@ IMAGE_TAG ?= latest
 # Fully qualified container image name.
 IMAGE_FQN ?= $(IMAGE_REPO)/$(IMAGE_NAMESPACE)/$(APP):$(IMAGE_TAG)
 
+# Determine the appropriate tar command based on the operating system.
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	TAR := gtar
+else
+	TAR := tar
+endif
+
 # Directory with the installer resources, scripts, Helm Charts, etc.
 INSTALLER_DIR ?= ./installer
 # Tarball with the installer resources.
@@ -84,7 +92,7 @@ installer-tarball: $(INSTALLER_TARBALL)
 $(INSTALLER_TARBALL): $(INSTALLER_TARBALL_DATA)
 	@echo "# Generating '$(INSTALLER_TARBALL)'"
 	@test -f "$(INSTALLER_TARBALL)" && rm -f "$(INSTALLER_TARBALL)" || true
-	@tar -C "$(INSTALLER_DIR)" -cpf "$(INSTALLER_TARBALL)" \
+	@$(TAR) -C "$(INSTALLER_DIR)" -cpf "$(INSTALLER_TARBALL)" \
 	$(shell echo "$(INSTALLER_TARBALL_DATA)" | sed "s:\./installer/:./:g")
 
 #


### PR DESCRIPTION
By conditionally using GNU Tar (`gtar`) instead of `tar`.