### PR TITLE
fix the issue of sprayproxy-deprovision

### DIFF
--- a/integration-tests/pipelines/rhtap-cli-e2e.yaml
+++ b/integration-tests/pipelines/rhtap-cli-e2e.yaml
@@ -257,6 +257,9 @@ spec:
             value: main
           - name: pathInRepo
             value: common/tasks/sprayproxy/sprayproxy-deprovision/sprayproxy-unregister-server.yaml
+      params:
+        - name: ocp-login-command
+          value: "$(tasks.provision-rosa.results.ocp-login-command)"
     - name: pull-request-status-message
       when:
         - input: "$(tasks.test-metadata.results.test-event-type)"


### PR DESCRIPTION
The PR https://github.com/konflux-ci/konflux-qe-definitions/pull/62 fixed issue of unregister pac server from Sprayprox. It shouldn't delete all of pac servers. This pr is to adapt that PR by passing  ocp-login-command as task parameter