### PR TITLE
fix: create token for serviceaccount

### DIFF
--- a/installer/charts/rhtap-dh/templates/extra-env.yaml
+++ b/installer/charts/rhtap-dh/templates/extra-env.yaml
@@ -52,10 +52,10 @@ data:
     JENKINS__USERNAME: {{ $jenkinsSecretData.username }}
     JENKINS__TOKEN: {{ $jenkinsSecretData.token }}
 {{- end }}
-{{- range $index, $secret := (lookup "v1" "Secret" .Release.Namespace "").items }}
-    {{- if regexMatch "rhdh-kubernetes-plugin-token-.*" $secret.metadata.name }}
-    K8S_SERVICEACCOUNT_TOKEN: {{ $secret.data.token }}
-    {{- end }}
+{{- $k8sSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-k8s-integration") }}
+{{- $k8sSecretData := ($k8sSecretObj.data | default dict) }}
+{{- if $k8sSecretData }}
+    K8S_SERVICEACCOUNT_TOKEN: {{ $k8sSecretData.token }}
 {{- end }}
 {{- $quaySecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-quay-integration") }}
 {{- $quaySecretData := ($quaySecretObj.data | default dict) }}

--- a/installer/charts/rhtap-integrations/templates/developer-hub/serviceaccount.yaml
+++ b/installer/charts/rhtap-integrations/templates/developer-hub/serviceaccount.yaml
@@ -1,19 +1,46 @@
+{{- $saName := "rhdh-kubernetes-plugin" }}
+{{- $secretName := "rhtap-k8s-integration" }}
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ $saName }}
+type: kubernetes.io/service-account-token
+
+---
+{{- $sa := lookup "v1" "ServiceAccount" .Release.Namespace $saName -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rhdh-kubernetes-plugin
+  name: {{ $saName }}
   namespace: {{ .Release.Namespace }}
+{{- $secrets := (get $sa "secrets" | default list)}}
+secrets:
+  {{/* Patch ServiceAccount secrets */}}
+  {{- $secretExists := false }}
+  {{- range $secrets }}
+  - name: {{ .name }}
+    {{- if eq .name $secretName }}
+      {{- $secretExists = true }}
+    {{- end }}
+  {{- end }}
+  {{- if not $secretExists }}
+  - name: {{ $secretName }}
+  {{- end }}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhdh-kubernetes-plugin
+  name: {{ $saName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: view
 subjects:
   - kind: ServiceAccount
-    name: rhdh-kubernetes-plugin
+    name: {{ $saName }}
     namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The automatic creation of long lived tokens for SA has been disabled starting with OCP 4.16.