### PR TITLE
RHTAPINST-140: Golang v1.22.5 and Container Images Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Build
 #
 
-FROM registry.redhat.io/openshift4/ose-tools-rhel9:latestt@sha256:c2a2eca448a2e1b5d73f88dcd12a6c87e5f4580512303f4e38b67acf810b4778 as ose-tools
+FROM registry.redhat.io/openshift4/ose-tools-rhel9@sha256:683fe19d6624335d60fcfdd9b53aedac6d299205c4c573e4f334008d92591eb5 as ose-tools
 FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 
 USER root
@@ -22,7 +22,7 @@ RUN make GOFLAGS='-buildvcs=false'
 # Run
 #
 
-FROM registry.access.redhat.com/ubi9-minimal:9.4-1227.1726694542
+FROM registry.access.redhat.com/ubi9-minimal:9.5-1731518200
 
 LABEL \
   name="rhtap-cli" \

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11-9
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.5-1730550521
 
 ENV SHELLCHECK_VERSION=0.7.1
 ENV YQ_VERSION=v4.25.2

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/redhat-appstudio/rhtap-cli
 
-go 1.21.0
-
-toolchain go1.21.11
+go 1.22.5
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3

--- a/vendor/github.com/rubenv/sql-migrate/test-migrations/1_initial.sql
+++ b/vendor/github.com/rubenv/sql-migrate/test-migrations/1_initial.sql
@@ -1,8 +1,0 @@
--- +migrate Up
--- SQL in section 'Up' is executed when this migration is applied
-CREATE TABLE people (id int);
-
-
--- +migrate Down
--- SQL section 'Down' is executed when this migration is rolled back
-DROP TABLE people;

--- a/vendor/github.com/rubenv/sql-migrate/test-migrations/2_record.sql
+++ b/vendor/github.com/rubenv/sql-migrate/test-migrations/2_record.sql
@@ -1,5 +1,0 @@
--- +migrate Up
-INSERT INTO people (id) VALUES (1);
-
--- +migrate Down
-DELETE FROM people WHERE id=1;


### PR DESCRIPTION
To mitigate Synk issues, upgrading both Go and container images to support latest UBI9 and OpenShift 4.16 container images.