### PR TITLE
fix: lock amq-streams to 2.7

### DIFF
--- a/installer/charts/rhtap-subscriptions/values.yaml
+++ b/installer/charts/rhtap-subscriptions/values.yaml
@@ -6,7 +6,7 @@ subscriptions:
     apiResource: kafkas.kafka.strimzi.io
     namespace: openshift-operators
     name: amq-streams
-    channel: stable
+    channel: amq-streams-2.7.x
     source: redhat-operators
     sourceNamespace: openshift-marketplace
   crunchyData:


### PR DESCRIPTION
The latest 2.8 breaks TPA as the `tpa-kafka` secret isn't created in the `rhtap-tpa` namespace.