### PR TITLE
RHTAPINST-181: MinIO Operator Namespace

### DIFF
--- a/installer/charts/values.yaml.tpl
+++ b/installer/charts/values.yaml.tpl
@@ -39,9 +39,7 @@ openshift:
 {{- if $rhdh.Enabled }}
     - {{ $rhdh.Namespace }}
 {{- end }}
-{{- if $minIOOperatorEnabled }}
     - minio-operator
-{{- end }}
 
 #
 # rhtap-subscriptions


### PR DESCRIPTION
Even with `.minIOOperator.enabled` set to `false`, the installer requires the specific namespace to be present.