### PR TITLE
RHTAP-2558 - Setup dynamic e2e IntegrationTestingScenario

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,52 @@
+# E2E integration tests
+
+This folder contains resources for running multi-level e2e for RHTAP in Konflux
+
+## Prerequisites
+In order to succesfully run this integration test one must:
+* Create [Role](./custom-resources/plrManager-Role.yaml) that is capable of starting & watching PipelineRuns 
+* Create a [RoleBinding](./custom-resources/plrManager-RoleBinding.yaml) binding that role to `appstudio-pipeline` SA (default SA used by Tekton in Konflux)
+* Create [IntegrationTestScenario](./custom-resources/e2e-IntegrationTestScenario.yaml) in Konflux tenant.
+* Create necessary secrets in the Konflux tenant
+    * `sprayproxy-auth` used to register ephemeray cluster with sprayproxy with keys:
+        * `server-token`
+        * `server-url`
+    * `rhtap-cli-install` used by `rhtap-install` task with keys:
+        * `quay-dockerconfig-json: `
+        * `docker_io: `
+        * `rhdh-github-client-id`
+        * `acs-central-endpoint`
+        * `acs-api-token`
+        * `bitbucket-username`
+        * `jenkins-username`
+        * `jenkins-api-token`
+        * `gitlab_token`
+        * `quay-api-token`
+        * `jenkins-url`
+        * `rhdh-github-client-secret`
+        * `bitbucket-app-password`
+        * `rhdh-github-webhook-secret`
+        * `github_token`
+        * `rhdh-github-app-id`
+        * `rhdh-github-private-key`
+    * `konflux-test-infra` with keys:
+        * `qe-cloud-credentials-us-east-1` - this is current default key holding AWS credentials json. Other key might be used based on what's defined in `cloud-credential-key` parameter of `rhtap-cli-e2e` Pipeline.
+        * `github-bot-commenter-token`
+        * `oci-storage`
+
+## Pipelines used
+
+### e2e-main-pipeline
+
+This is the main pipeline used by our IntegrationTestScenario. It has 3 phases
+1) Downloads & parses [Pict](https://github.com/Microsoft/pict/blob/main/doc/pict.md) file from fork's location `./integration-tests/pict-models/default.pict`. This defines the matrix for this e2e run
+2) Creates new PipelineRun for each row of the matrix defined by used Pict model file using [rhtap-cli-e2e Pipeline](./pipelines/rhtap-cli-e2e.yaml)
+3) Waits for all "nested" pipelines to finish.
+
+### rhtap-cli-e2e
+
+Pipeline that given parameters:
+1) Creates ephemeral cluster
+2) Installs RHTAP
+3) Runs rhtap-e2e tests
+4) Teardown (archive artifacts, destroy cluster, ...)

--- a/integration-tests/custom-resources/e2e-IntegrationTestScenario.yaml
+++ b/integration-tests/custom-resources/e2e-IntegrationTestScenario.yaml
@@ -1,0 +1,25 @@
+apiVersion: appstudio.redhat.com/v1beta2
+kind: IntegrationTestScenario
+metadata:
+  name: pr-e2e-tests
+  labels:
+    test.appstudio.openshift.io/optional: 'false'
+spec:
+  application: rhtap-cli
+  contexts:
+    - description: PR testing
+      name: pull_request
+  params:
+    - name: konflux-test-infra-secret
+      value: konflux-test-infra
+    - name: cloud-credential-key
+      value: qe-cloud-credentials-us-east-1
+  resolverRef:
+    params:
+      - name: url
+        value: 'https://github.com/redhat-appstudio/rhtap-cli'
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: integration-tests/pipelines/e2e-main-pipeline.yaml
+    resolver: git

--- a/integration-tests/custom-resources/plrManager-Role.yaml
+++ b/integration-tests/custom-resources/plrManager-Role.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: plr-manager
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - delete
+  - create
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns
+  verbs:
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - watch
+  - list

--- a/integration-tests/custom-resources/plrManager-RoleBinding.yaml
+++ b/integration-tests/custom-resources/plrManager-RoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manage-plr
+subjects:
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: plr-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/integration-tests/pict-models/default.pict
+++ b/integration-tests/pict-models/default.pict
@@ -1,0 +1,10 @@
+#
+# This is file used for integration tests (PR checks, post-merge checks)
+#
+
+OCP: 4.17, 4.16
+ACS: Enabled(deploy new)
+Registry: Quay(deploy new)
+TPA: Enabled
+SCM: GitHub
+Pipeline/CI: Tekton

--- a/integration-tests/pict-models/smoke.pict
+++ b/integration-tests/pict-models/smoke.pict
@@ -1,0 +1,13 @@
+#
+# This is a sample PICT file for smoke run
+#
+
+OCP: 4.17, 4.16
+ACS: Enabled(hosted), Enabled(deploy new)
+Registry: Quay(hosted), Quay(deploy new), Artifactory
+TPA: Enabled, Disabled
+SCM: Gitlab, GitHub, BitBucket
+Pipeline/CI: Tekton, Jenkins, Gitlab-CI 
+
+if [SCM] = "GitHub" then [Pipeline/CI] in {"Tekton", "Jenkins"};
+if [SCM] = "BitBucket" then [Pipeline/CI] in {"Tekton", "Jenkins"};

--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -87,7 +87,7 @@ spec:
               set -x
               echo "Running tests for OCP versions:"
               echo "$CONFIGS_JSON" | jq -r '.[][] | select(.key == "OCP").value'
-              failed_pipelines=0
+              pids=()
 
               while IFS= read -r version; do
                 (
@@ -108,15 +108,20 @@ spec:
                   pipelinerun_status=$(tkn pipelinerun describe "$pipeline_run_name" -o jsonpath='{.status.conditions[0].status}')
                   if [ "$pipelinerun_status" != "True" ]; then
                     echo "Pipelinerun $pipeline_run_name failed"
-                    failed_pipelines=$((failed_pipelines + 1))
+                    exit 1
                   fi
 
                 ) &
-              done < <(echo "$CONFIGS_JSON" | jq -r '.[][] | select(.key == "OCP").value')
-              wait
-              if [ $failed_pipelines -gt 0 ]; then
-                echo "One or more pipelineruns failed. Exiting with non-zero code."
-                oc get pipelineruns
-                exit 1
-              fi
+                pid="$!"
+                pids+=("$pid")
+              done < <(echo "$CONFIGS_JSON" | jq -r '.[][] | select(.key == "OCP").value');
+              for pid in "${pids[@]}"; do
+                wait "$pid"
+                return_code=$?
+                if [ ! $return_code -eq 0 ]; then
+                  echo "One or more pipelineruns failed. Exiting with non-zero code."
+                  oc get pipelineruns
+                  exit 1
+                fi
+              done
 

--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -99,7 +99,7 @@ spec:
                   --labels "appstudio.openshift.io/component=rhtap-cli" \
                   --labels "appstudio.openshift.io/application=rhtap-cli" \
                   --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
-                  --labels "test.appstudio.openshift.io/scenario=multi-level" \
+                  --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
                   --prefix-name "e2e-$version"\
                   -o name)
                   

--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -1,0 +1,122 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: e2e-main-pipeline
+  namespace: rhtap-shared-team-tenant
+  labels:
+    appstudio.openshift.io/component: rhtap-cli
+    appstudio.openshift.io/application: rhtap-cli
+spec:
+  params:
+    - name: SNAPSHOT
+      description: 'The JSON string representing the snapshot of the application under test.'
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: konflux-test-infra-secret
+      description: The name of secret where testing infrastructures credentials are stored.
+      type: string
+  tasks:
+    - name: test-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: common/tasks/test-metadata/0.2/test-metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: test-name
+          value: $(context.pipelineRun.name)
+    - name: get-pict-file
+      runAfter:
+      - test-metadata
+      taskSpec:
+        results:
+          - name: pict-file
+            description: pict file to be used in next step
+        steps:
+          - name: download
+            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+            env:
+              - name: JOB_SPEC
+                value: $(tasks.test-metadata.results.job-spec)
+            script: |
+              #!/usr/bin/env bash
+              FORK=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
+              BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+              curl -o $(results.pict-file.path) https://raw.githubusercontent.com/$FORK/rhtap-cli/refs/heads/$BRANCH/integration-tests/pict-models/default.pict
+    - name: generate-configs
+      runAfter:
+      - get-pict-file
+      taskSpec:
+        results:
+          - name: configs-json
+            description: Config json generated from pict file.
+        steps:
+          - name: pict-generate
+            image: quay.io/apodhrad/pict:latest
+            script: |
+              #!/usr/bin/env bash
+              echo "$(tasks.get-pict-file.results.pict-file)" > main.pict
+              cat main.pict
+              pict ./main.pict -o:1 -f:json > $(results.configs-json.path)
+    - name: start-nested-pipelines
+      params:
+        - name: job-spec
+          value: "$(tasks.test-metadata.results.job-spec)"
+      runAfter:
+        - test-metadata
+        - generate-configs
+      taskSpec:
+        steps:
+          - name: start-pipeline
+            image: quay.io/openshift-pipeline/ci
+            env: 
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: JOB_SPEC
+                value: $(tasks.test-metadata.results.job-spec)
+              - name: CONFIGS_JSON
+                value: $(tasks.generate-configs.results.configs-json)
+            script: |
+              #!/usr/bin/env bash
+              set -x
+              echo "Running tests for OCP versions:"
+              echo "$CONFIGS_JSON" | jq -r '.[][] | select(.key == "OCP").value'
+              failed_pipelines=0
+
+              while IFS= read -r version; do
+                (
+                pipeline_run_name=$(tkn pipeline start -f https://raw.githubusercontent.com/redhat-appstudio/rhtap-cli/refs/heads/main/integration-tests/pipelines/rhtap-cli-e2e.yaml \
+                  --param ocp-version="$version"\
+                  --param job-spec="$JOB_SPEC"\
+                  --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
+                  --use-param-defaults \
+                  --labels "appstudio.openshift.io/component=rhtap-cli" \
+                  --labels "appstudio.openshift.io/application=rhtap-cli" \
+                  --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
+                  --labels "test.appstudio.openshift.io/scenario=multi-level" \
+                  --prefix-name "e2e-$version"\
+                  -o name)
+                  
+                  tkn pipelinerun logs  "$pipeline_run_name" -f | sed "s/^/$pipeline_run_name: /"
+
+                  pipelinerun_status=$(tkn pipelinerun describe "$pipeline_run_name" -o jsonpath='{.status.conditions[0].status}')
+                  if [ "$pipelinerun_status" != "True" ]; then
+                    echo "Pipelinerun $pipeline_run_name failed"
+                    failed_pipelines=$((failed_pipelines + 1))
+                  fi
+
+                ) &
+              done < <(echo "$CONFIGS_JSON" | jq -r '.[][] | select(.key == "OCP").value')
+              wait
+              if [ $failed_pipelines -gt 0 ]; then
+                echo "One or more pipelineruns failed. Exiting with non-zero code."
+                oc get pipelineruns
+                exit 1
+              fi
+

--- a/integration-tests/pipelines/rhtap-cli-e2e.yaml
+++ b/integration-tests/pipelines/rhtap-cli-e2e.yaml
@@ -10,49 +10,34 @@ spec:
     the ROSA cluster, installs RHTAP using the installer, runs the tests, collects artifacts,
     and finally deprovisions the ROSA cluster.
   params:
-    - name: SNAPSHOT
-      description: 'The JSON string representing the snapshot of the application under test.'
-      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
-      type: string
     - name: test-name
       description: 'The name of the test corresponding to a defined Konflux integration test.'
       default: ''
-    - name: ocp-version
-      description: 'The OpenShift version to use for the ephemeral cluster deployment.'
       type: string
-    - name: test-event-type
-      description: 'Indicates if the test is triggered by a Pull Request or Push event.'
-      default: 'none'
-    - name: konflux-test-infra-secret
-      description: The name of secret where testing infrastructures credentials are stored.
+    - name: ocp-version
+      description: 'The OpenShift version to use for the ephemeral cluster deployment.'   
       type: string
     - name: cloud-credential-key
       type: string
+      default: "qe-cloud-credentials-us-east-1"
       description: The key secret from konflux-test-infra-secret where all AWS ROSA configurations are stored.
     - name: replicas
       description: 'The number of replicas for the cluster nodes.'
+      default: "3"
       type: string
     - name: machine-type
       description: 'The type of machine to use for the cluster nodes.'
+      default: "m6i.4xlarge"
       type: string
     - name: oci-container-repo
       default: 'quay.io/konflux-test-storage/rhtap-team/rhtap-cli'
       description: The ORAS container used to store all test artifacts.
-    - name: acs_install_enabled
-      description: 'Indicates if the ACS installation is enabled.'
-      default: 'true'
-    - name: quay_install_enabled
-      description: 'Indicates if the Quay installation is enabled.'
-      default: 'true'
-    - name: github_enabled
-      description: 'Indicates if the GitHub integration is enabled.'
-      default: 'true'
-    - name: gitlab_enabled
-      description: 'Indicates if the GitLab integration is enabled.'
-      default: 'true'
-    - name: jenkins_enabled
-      description: 'Indicates if the Jenkins integration is enabled.'
-      default: 'true'
+      type: string
+    - name: job-spec
+      type: string
+    - name: konflux-test-infra-secret
+      description: The name of secret where testing infrastructures credentials are stored.
+      type: string
   tasks:
     - name: rosa-hcp-metadata
       taskRef:
@@ -64,21 +49,6 @@ spec:
             value: main
           - name: pathInRepo
             value: common/tasks/rosa/hosted-cp/rosa-hcp-metadata/rosa-hcp-metadata.yaml
-    - name: test-metadata
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/test-metadata/0.1/test-metadata.yaml
-      params:
-        - name: SNAPSHOT
-          value: $(params.SNAPSHOT)
-        - name: test-name
-          value: $(context.pipelineRun.name)
     - name: create-oci-container
       taskRef:
         resolver: git
@@ -95,14 +65,9 @@ spec:
         - name: oci-container-tag
           value: $(context.pipelineRun.name)
     - name: provision-rosa
-      when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
       runAfter:
         - rosa-hcp-metadata
         - create-oci-container
-        - test-metadata
       taskRef:
         resolver: git
         params:
@@ -126,10 +91,6 @@ spec:
         - name: cloud-credential-key
           value: "$(params.cloud-credential-key)"
     - name: rhtap-install
-      when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
       runAfter:
         - provision-rosa
       taskRef:
@@ -142,27 +103,11 @@ spec:
           - name: pathInRepo
             value: integration-tests/tasks/rhtap-install.yaml
       params:
-        - name: job-spec
-          value: $(tasks.test-metadata.results.job-spec)
         - name: ocp-login-command
           value: "$(tasks.provision-rosa.results.ocp-login-command)"
-        - name: image-url
-          value: "$(tasks.test-metadata.results.container-image)"
-        - name: acs_install_enabled
-          value: "$(params.acs_install_enabled)"
-        - name: quay_install_enabled
-          value: "$(params.quay_install_enabled)"
-        - name: github_enabled
-          value: "$(params.github_enabled)"
-        - name: gitlab_enabled
-          value: "$(params.gitlab_enabled)"
-        - name: jenkins_enabled
-          value: "$(params.jenkins_enabled)"
+        - name: job-spec
+          value: "$(params.job-spec)"
     - name: sprayproxy-provision
-      when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
       runAfter:
         - rhtap-install
       taskRef:
@@ -178,10 +123,6 @@ spec:
         - name: ocp-login-command
           value: "$(tasks.provision-rosa.results.ocp-login-command)"
     - name: rhtap-e2e-tests
-      when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
       runAfter:
         - sprayproxy-provision
       taskRef:
@@ -195,22 +136,18 @@ spec:
             value: integration-tests/tasks/rhtap-e2e.yaml
       params:
         - name: job-spec
-          value: $(tasks.test-metadata.results.job-spec)
+          value: $(params.job-spec)
         - name: ocp-login-command
           value: "$(tasks.provision-rosa.results.ocp-login-command)"
         - name: oci-container
           value: $(tasks.create-oci-container.results.oci-container)
   finally:
     - name: deprovision-rosa-collect-artifacts
-      when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
@@ -222,16 +159,6 @@ spec:
           value: "$(tasks.provision-rosa.results.ocp-login-command)"
         - name: oci-container
           value: "$(tasks.create-oci-container.results.oci-container)"
-        - name: pull-request-author
-          value: "$(tasks.test-metadata.results.pull-request-author)"
-        - name: git-revision
-          value: "$(tasks.test-metadata.results.git-revision)"
-        - name: pull-request-number
-          value: "$(tasks.test-metadata.results.pull-request-number)"
-        - name: git-repo
-          value: "$(tasks.test-metadata.results.git-repo)"
-        - name: git-org
-          value: "$(tasks.test-metadata.results.git-org)"
         - name: cluster-name
           value: "$(tasks.rosa-hcp-metadata.results.cluster-name)"
         - name: konflux-test-infra-secret
@@ -241,36 +168,28 @@ spec:
         - name: pipeline-aggregate-status
           value: "$(tasks.status)"
     - name: sprayproxy-deprovision
-      when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
             value: common/tasks/sprayproxy/sprayproxy-deprovision/sprayproxy-unregister-server.yaml
-      params:
+      params: 
         - name: ocp-login-command
           value: "$(tasks.provision-rosa.results.ocp-login-command)"
     - name: pull-request-status-message
-      when:
-        - input: "$(tasks.test-metadata.results.test-event-type)"
-          operator: in
-          values: ["pull_request"]
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+            value: common/tasks/pull-request-comment/0.2/pull-request-comment.yaml
       params:
         - name: test-name
           value: "$(context.pipelineRun.name)"
@@ -278,13 +197,5 @@ spec:
           value: "$(tasks.create-oci-container.results.oci-container)"
         - name: pipeline-aggregate-status
           value: "$(tasks.status)"
-        - name: pull-request-author
-          value: "$(tasks.test-metadata.results.pull-request-author)"
-        - name: pull-request-number
-          value: "$(tasks.test-metadata.results.pull-request-number)"
-        - name: git-repo
-          value: "$(tasks.test-metadata.results.git-repo)"
-        - name: git-org
-          value: "$(tasks.test-metadata.results.git-org)"
-        - name: git-revision
-          value: "$(tasks.test-metadata.results.git-revision)"
+        - name: job-spec
+          value: "$(params.job-spec)"

--- a/integration-tests/tasks/rhtap-install.yaml
+++ b/integration-tests/tasks/rhtap-install.yaml
@@ -57,7 +57,13 @@ spec:
         set -o nounset
         set -o pipefail
 
-        GIT_REPO="${GIT_REPO:-$(echo "$JOB_SPEC" | jq -r '.git.git_repo')}"
+        GIT_REPO="${GIT_REPO:-$(echo "$JOB_SPEC" | jq -r '.git.repo // empty')}"
+
+        if [ -z "$GIT_REPO" ]; then
+          echo "[ERROR] GIT_REPO is not set in JOB_SPEC"
+          exit 1
+        fi
+
         # Clone the rhtap-cli repository
         cd "$(mktemp -d)"
 


### PR DESCRIPTION
This PR adds new Pipeline to be used as IntegrationTestScenario. This pipeline will allow us to specify "test plan" in form of Pict model file. This new pipeline reads this file, generates test configuration matrix based on that model and then runs full E2E scenario (from cluster creation to cluster teardown) for each config.

Current logic only supports specifying different cluster versions (other parameters from the pict model are basically ignored). This functionality will be added in future in different JIRAs/PRs.

For more info see `integration-tests/README.md`