### PR TITLE
update templates to v1.3.0

### DIFF
--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -17,7 +17,7 @@ rhtapCLI:
       enabled: &rhdhEnabled true
       namespace: *installerNamespace
       properties:
-        catalogURL: https://github.com/redhat-appstudio/tssc-sample-templates/blob/release/all.yaml
+        catalogURL: https://github.com/redhat-appstudio/tssc-sample-templates/blob/v1.3.0/all.yaml
     redHatAdvancedClusterSecurity:
       enabled: &rhacsEnabled true
       namespace: &rhacsNamespace rhtap-acs


### PR DESCRIPTION
Update the https://github.com/redhat-appstudio/tssc-sample-templates/blob/v1.3.0/all.yaml to the v1.3.0 release tag