### PR TITLE
RHTAPINST-57: Show Global Values as YAML

### DIFF
--- a/pkg/deployer/helm.go
+++ b/pkg/deployer/helm.go
@@ -43,10 +43,18 @@ var ErrUpgradeFailed = errors.New("upgrade failed")
 
 // printRelease prints the Helm release information.
 func (h *Helm) printRelease(rel *release.Release) {
+	// In debug mode, print the configuration values using key-value pairs.
+	if !h.flags.DryRun && h.flags.Debug {
+		printer.ValuesPrinter("Config", rel.Config)
+	}
 	printer.HelmReleasePrinter(rel)
-	if h.flags.Debug {
+	// Print extended release information only in dry-run or debug mode. This
+	// allows rendering chart templates (dry-run) while inspecting the release
+	// manifests.
+	if h.flags.DryRun || h.flags.Debug {
 		printer.HelmExtendedReleasePrinter(rel)
 	}
+	printer.HelmReleaseNotesPrinter(rel)
 }
 
 // helmInstall equivalent to "helm install" command.

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -17,7 +17,10 @@ func HelmReleasePrinter(rel *release.Release) {
 	fmt.Printf("#    Revision: %d\n", rel.Version)
 	fmt.Printf("#     Updated: %s\n", rel.Info.LastDeployed.String())
 	fmt.Println("#")
+}
 
+// HelmReleaseNotesPrinter prints the release notes.
+func HelmReleaseNotesPrinter(rel *release.Release) {
 	if rel.Info.Notes != "" {
 		fmt.Printf("#\n# Notes\n#\n\n")
 		fmt.Println(rel.Info.Notes)
@@ -27,8 +30,6 @@ func HelmReleasePrinter(rel *release.Release) {
 // HelmExtendedReleasePrinter prints the release information, including the
 // manifest and hooks.
 func HelmExtendedReleasePrinter(rel *release.Release) {
-	ValuesPrinter("Config", rel.Config)
-
 	fmt.Printf("#\n# Manifest\n#\n\n")
 	fmt.Print(rel.Manifest)
 

--- a/pkg/subcmd/template.go
+++ b/pkg/subcmd/template.go
@@ -36,15 +36,26 @@ The Template subcommand is used to render the values template file and,
 optionally, the Helm chart manifests. It is particularly useful for
 troubleshooting and developing Helm charts for the RHTAP installation process.
 
-By using the '--show-manifest=false' flag, only the values template
-('--values-template') will be rendered, making the last argument, with the Helm
-chart directory, optional.
+By using the '--show-manifest=false' flag, only the global values template
+('--values-template') will be rendered as YAML, thus the last argument, with the
+Helm chart directory, optional.
 
-Additionally, the '--debug' flag should be used to display the raw values template
-payload, regardless of whether it is valid YAML or not.
+Additionally, the '--debug' flag should be used to display rendered global values,
+passed into every Helm Chart installed, as key-value pairs.
 
 The installer resources are embedded in the executable, these resources are
 employed by default, to use local files, set the '--embedded' flag to false.
+
+Examples:
+
+  # Only showing the global values as YAML.
+  $ rhtap-cli template --show-manifests=false
+
+  # Rendering only the templates of a single Helm Chart.
+  $ rhtap-cli template --show-values=false charts/rhtap-subscriptions
+
+  # Rendering all resources of a Helm Chart.
+  $ rhtap-cli template charts/rhtap-subscriptions
 `
 
 // Cmd exposes the cobra instance.
@@ -120,16 +131,20 @@ func (t *Template) Run() error {
 	); err != nil {
 		return err
 	}
-	if t.showValues && t.flags.Debug {
-		i.PrintRawValues()
-	}
 
 	// Rendering the global values.
 	if err = i.RenderValues(); err != nil {
 		return err
 	}
+	// Show the rendered global values, what's passed into very chart.
 	if t.showValues {
-		i.PrintValues()
+		// Displaying the rendered values as properties, where it's easier to
+		// verify settings by inspecting key-value pairs.
+		if t.flags.Debug {
+			// i.PrintValues()
+		}
+		// Show values as YAML.
+		i.PrintRawValues()
 	}
 
 	// When the manifests aren't shown, we don't need to dry-run "helm install".


### PR DESCRIPTION
By default, showing global values in the `rhtap-cli template`  as YAML, while the `--debug` flag shows key-value properties.

### Examples

-  Only showing the global values as YAML.
```bash
rhtap-cli template --show-manifests=false
```
- Rendering only the templates of a single Helm Chart.
```bash
rhtap-cli template --show-values=false charts/rhtap-subscriptions
```
- Rendering all resources of a Helm Chart.
```bash
rhtap-cli template charts/rhtap-subscriptions
```
