### PR TITLE
fix: RHTAP-3416 'template' command uses the wrong namespace

### DIFF
--- a/installer/charts/rhtap-dh/values.yaml
+++ b/installer/charts/rhtap-dh/values.yaml
@@ -1,4 +1,7 @@
 ---
+debug:
+  ci: false
+
 developerHub:
   instanceName: developer-hub
   catalogURL: __OVERWRITE_ME__

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,17 @@ func (c *Config) GetBaseDir() string {
 	return filepath.Dir(c.configPath)
 }
 
+// GetDependency returns a dependency chart configuration.
+func (c *Config) GetDependency(logger *slog.Logger, chart string) (*Dependency, error) {
+	logger.Debug("Getting dependency")
+	for _, dep := range c.Installer.Dependencies {
+		if dep.Chart == chart {
+			return &dep, nil
+		}
+	}
+	return nil, fmt.Errorf("chart %s not found", chart)
+}
+
 // GetEnabledDependencies returns a list of enabled dependencies.
 func (c *Config) GetEnabledDependencies(logger *slog.Logger) []Dependency {
 	enabled := []Dependency{}

--- a/pkg/deployer/helm.go
+++ b/pkg/deployer/helm.go
@@ -68,7 +68,7 @@ func (h *Helm) helmInstall(vals chartutil.Values) (*release.Release, error) {
 	c.DryRun = h.flags.DryRun
 	c.ClientOnly = h.flags.DryRun
 	if h.flags.DryRun {
-		c.DryRunOption = "client"
+		c.DryRunOption = "server"
 	}
 
 	ctx := backgroundContext(func() {

--- a/pkg/subcmd/template.go
+++ b/pkg/subcmd/template.go
@@ -113,7 +113,11 @@ func (t *Template) Run() error {
 	}
 
 	// Installer for the specific dependency
-	i := installer.NewInstaller(t.logger, t.flags, t.kube, t.cfs, &t.dep)
+	dep, err := t.cfg.GetDependency(t.log(), t.dep.Chart)
+	if err != nil {
+		return err
+	}
+	i := installer.NewInstaller(t.logger, t.flags, t.kube, t.cfs, dep)
 
 	// Setting values and loading cluster's information.
 	if err = i.SetValues(


### PR DESCRIPTION
- The chart release namespace is retrieved from the config.yaml.
- Helm connects to the server to provide an accurate rendering of the templates.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED