### PR TITLE
RHTAP-3384: Singleton ChartFS

### DIFF
--- a/cmd/rhtap-cli/main.go
+++ b/cmd/rhtap-cli/main.go
@@ -7,7 +7,11 @@ import (
 )
 
 func main() {
-	if err := cmd.NewRootCmd().Cmd().Execute(); err != nil {
+	c, err := cmd.NewRootCmd()
+	if err != nil {
+		os.Exit(1)
+	}
+	if err = c.Cmd().Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/pkg/chartfs/chartfs.go
+++ b/pkg/chartfs/chartfs.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/redhat-appstudio/rhtap-cli/installer"
-	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
 
 	"github.com/quay/claircore/pkg/tarfs"
 	"helm.sh/helm/v3/pkg/chart"
@@ -81,9 +80,9 @@ func (c *ChartFS) ReadFile(name string) ([]byte, error) {
 
 // GetChartForDep returns the Helm chart for the given dependency. It uses
 // BufferredFiles to walk through the filesytem and collect the chart files.
-func (c *ChartFS) GetChartForDep(dep *config.Dependency) (*chart.Chart, error) {
-	bf := NewBufferedFiles(c.embeddedFS, dep.Chart)
-	if err := fs.WalkDir(c.embeddedFS, dep.Chart, bf.Walk); err != nil {
+func (c *ChartFS) GetChartForDep(chartPath string) (*chart.Chart, error) {
+	bf := NewBufferedFiles(c.embeddedFS, chartPath)
+	if err := fs.WalkDir(c.embeddedFS, chartPath, bf.Walk); err != nil {
 		return nil, err
 	}
 	return loader.LoadFiles(bf.Files())
@@ -101,4 +100,14 @@ func NewChartFS(baseDir string) (*ChartFS, error) {
 		baseDir:    installerDir,
 		localFS:    os.DirFS(baseDir),
 	}, nil
+}
+
+// NewChartFSForCWD instantiates a ChartFS instance using the current working
+// directory.
+func NewChartFSForCWD() (*ChartFS, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	return NewChartFS(cwd)
 }

--- a/pkg/chartfs/chartfs_test.go
+++ b/pkg/chartfs/chartfs_test.go
@@ -3,8 +3,6 @@ package chartfs
 import (
 	"testing"
 
-	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
-
 	o "github.com/onsi/gomega"
 )
 
@@ -22,10 +20,7 @@ func TestNewChartFS(t *testing.T) {
 	})
 
 	t.Run("GetChartForDep", func(t *testing.T) {
-		chart, err := c.GetChartForDep(&config.Dependency{
-			Chart:     "charts/rhtap-openshift",
-			Namespace: "rhtap",
-		})
+		chart, err := c.GetChartForDep("charts/rhtap-openshift")
 		g.Expect(err).To(o.Succeed())
 		g.Expect(chart).ToNot(o.BeNil())
 		g.Expect(chart.Name()).To(o.Equal("rhtap-openshift"))

--- a/pkg/chartfs/chartfs_test.go
+++ b/pkg/chartfs/chartfs_test.go
@@ -20,7 +20,7 @@ func TestNewChartFS(t *testing.T) {
 	})
 
 	t.Run("GetChartForDep", func(t *testing.T) {
-		chart, err := c.GetChartForDep("charts/rhtap-openshift")
+		chart, err := c.GetChartFiles("charts/rhtap-openshift")
 		g.Expect(err).To(o.Succeed())
 		g.Expect(chart).ToNot(o.BeNil())
 		g.Expect(chart.Name()).To(o.Equal("rhtap-openshift"))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,12 +5,16 @@ import (
 	"testing"
 
 	o "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/rhtap-cli/pkg/chartfs"
 )
 
 func TestNewConfigFromFile(t *testing.T) {
 	g := o.NewWithT(t)
 
-	cfg, err := NewConfigFromFile("../../installer/config.yaml")
+	cfs, err := chartfs.NewChartFS("../../installer")
+	g.Expect(err).To(o.Succeed())
+
+	cfg, err := NewConfigFromFile(cfs, "config.yaml")
 	g.Expect(err).To(o.Succeed())
 	g.Expect(cfg).NotTo(o.BeNil())
 	g.Expect(cfg.Installer).NotTo(o.BeNil())

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"testing"
 
+	"github.com/redhat-appstudio/rhtap-cli/pkg/chartfs"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
 
 	o "github.com/onsi/gomega"
@@ -28,7 +29,10 @@ root:
 func TestEngine_Render(t *testing.T) {
 	g := o.NewWithT(t)
 
-	cfg, err := config.NewConfigFromFile("../../installer/config.yaml")
+	cfs, err := chartfs.NewChartFS("../../installer")
+	g.Expect(err).To(o.Succeed())
+
+	cfg, err := config.NewConfigFromFile(cfs, "config.yaml")
 	g.Expect(err).To(o.Succeed())
 
 	variables := NewVariables()

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -33,14 +33,14 @@ type Installer struct {
 // prepareHelmClient prepares the Helm client for the given dependency, which also
 // specifies the default namespace for the Helm Chart.
 func (i *Installer) prepareHelmClient() (*deployer.Helm, error) {
-	i.logger.Debug("Loading dependency Helm chart (from CFS)")
-	chart, err := i.cfs.GetChartForDep(i.dep.Chart)
+	i.logger.Debug("Loading dependency Helm chart...")
+	cf, err := i.cfs.GetChartFiles(i.dep.Chart)
 	if err != nil {
 		return nil, err
 	}
 
 	i.logger.Debug("Loading Helm client for dependency and namespace")
-	return deployer.NewHelm(i.logger, i.flags, i.kube, i.dep.Namespace, chart)
+	return deployer.NewHelm(i.logger, i.flags, i.kube, i.dep.Namespace, cf)
 }
 
 // SetValues prepares the values template for the Helm chart installation.

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -34,7 +34,7 @@ type Installer struct {
 // specifies the default namespace for the Helm Chart.
 func (i *Installer) prepareHelmClient() (*deployer.Helm, error) {
 	i.logger.Debug("Loading dependency Helm chart (from CFS)")
-	chart, err := i.cfs.GetChartForDep(i.dep)
+	chart, err := i.cfs.GetChartForDep(i.dep.Chart)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/subcmd/deploy.go
+++ b/pkg/subcmd/deploy.go
@@ -16,11 +16,12 @@ import (
 
 // Deploy is the deploy subcommand.
 type Deploy struct {
-	cmd    *cobra.Command // cobra command
-	logger *slog.Logger   // application logger
-	flags  *flags.Flags   // global flags
-	cfg    *config.Config // installer configuration
-	kube   *k8s.Kube      // kubernetes client
+	cmd    *cobra.Command   // cobra command
+	logger *slog.Logger     // application logger
+	flags  *flags.Flags     // global flags
+	cfg    *config.Config   // installer configuration
+	cfs    *chartfs.ChartFS // embedded filesystem
+	kube   *k8s.Kube        // kubernetes client
 
 	valuesTemplatePath string // path to the values template file
 }
@@ -128,6 +129,7 @@ func NewDeploy(
 	logger *slog.Logger,
 	f *flags.Flags,
 	cfg *config.Config,
+	cfs *chartfs.ChartFS,
 	kube *k8s.Kube,
 ) Interface {
 	d := &Deploy{
@@ -140,6 +142,7 @@ func NewDeploy(
 		logger: logger.WithGroup("deploy"),
 		flags:  f,
 		cfg:    cfg,
+		cfs:    cfs,
 		kube:   kube,
 	}
 	flags.SetValuesTmplFlag(d.cmd.PersistentFlags(), &d.valuesTemplatePath)


### PR DESCRIPTION
Using the same instance for all interactions with the file-system.

Fixing the Helm Chart loading process, making sure it first looks for the local file-system, falling back to embedded.