### PR TITLE
fix: RHTAP-3388 Warning when deploying rhtap-infrastructure

### DIFF
--- a/installer/charts/rhtap-infrastructure/templates/postgres/postgresclusters.yaml
+++ b/installer/charts/rhtap-infrastructure/templates/postgres/postgresclusters.yaml
@@ -24,8 +24,8 @@ spec:
       options: SUPERUSER
   backups:
     pgbackrest:
-  {{- with $v.pgbackrestConfig }}
-      config:
+  {{- with $v.pgbackrestGlobal }}
+      global:
         {{- toYaml . | nindent 8 }}
   {{- end }}
       repos:

--- a/installer/charts/rhtap-infrastructure/values.yaml
+++ b/installer/charts/rhtap-infrastructure/values.yaml
@@ -180,7 +180,7 @@ infrastructure:
       namespace: __OVERWRITE_ME__
       postgresVersion: 14
       image: registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:6f4db1e9707b196aaa9f98ada5c09523ec00ade573ff835bd1ca6367ac0bb9f1
-      pgbackrestConfig:
+      pgbackrestGlobal:
         repo1-retention-full: "3"
       backupRepos:
         - name: repo1
@@ -204,7 +204,7 @@ infrastructure:
       namespace: __OVERWRITE_ME__
       postgresVersion: 14
       image: registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:6f4db1e9707b196aaa9f98ada5c09523ec00ade573ff835bd1ca6367ac0bb9f1
-      pgbackrestConfig:
+      pgbackrestGlobal:
         repo1-retention-full: "3"
       backupRepos:
         - name: repo1


### PR DESCRIPTION
Renamed 'config' to 'global'
cf https://access.crunchydata.com/documentation/postgres-operator/5.7/tutorials/backups-disaster-recovery/backup-management#managing-backup-retention

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED