### PR TITLE
feat: Upgrade to Developer Hub 1.4

### DIFF
--- a/installer/charts/rhtap-dh/templates/app-config.yaml
+++ b/installer/charts/rhtap-dh/templates/app-config.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    rhdh.redhat.com/backstage-name: {{ .Values.developerHub.instanceName | quote }}
+    rhdh.redhat.com/backstage-name: {{ .Values.developerHub.instanceName }}
   labels:
-    rhdh.redhat.com/ext-config-sync: "true"
+    rhdh.redhat.com/ext-config-sync: 'true'
   name: developer-hub-rhtap-app-config
 data:
   app-config.rhtap.yaml: |

--- a/installer/charts/rhtap-dh/templates/backstage.yaml
+++ b/installer/charts/rhtap-dh/templates/backstage.yaml
@@ -1,8 +1,8 @@
 ---
-apiVersion: rhdh.redhat.com/v1alpha1
+apiVersion: rhdh.redhat.com/v1alpha3
 kind: Backstage
 metadata:
-  name: {{ .Values.developerHub.instanceName | quote }}
+  name: {{ .Values.developerHub.instanceName }}
   namespace: {{ .Release.Namespace }}
 spec:
   application:
@@ -14,7 +14,6 @@ spec:
     extraEnvs:
       secrets:
         - name: developer-hub-rhtap-env
-    replicas: 1
     route:
       enabled: true
   database:

--- a/installer/charts/rhtap-dh/templates/extra-env.yaml
+++ b/installer/charts/rhtap-dh/templates/extra-env.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
     annotations:
-        rhdh.redhat.com/backstage-name: {{ .Values.developerHub.instanceName | quote }}
+        rhdh.redhat.com/backstage-name: {{ .Values.developerHub.instanceName }}
     labels:
-        rhdh.redhat.com/ext-config-sync: "true"
+        rhdh.redhat.com/ext-config-sync: 'true'
     name: developer-hub-rhtap-env
     namespace: {{ .Release.Namespace }}
 type: Opaque

--- a/installer/charts/rhtap-dh/templates/plugins-content.yaml
+++ b/installer/charts/rhtap-dh/templates/plugins-content.yaml
@@ -29,11 +29,11 @@ plugins:
   # CI
   #
   - disabled: false
-    package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-tekton
+    package: ./dynamic-plugins/dist/backstage-community-plugin-tekton
     pluginConfig:
       dynamicPlugins:
         frontend:
-          janus-idp.backstage-plugin-tekton:
+          backstage-community.plugin-tekton:
             mountPoints:
               - config:
                   if:
@@ -46,7 +46,7 @@ plugins:
                 mountPoint: entity.page.ci/cards
 {{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-github-integration") }}
   - disabled: false
-    package: ./dynamic-plugins/dist/backstage-plugin-github-actions
+    package: ./dynamic-plugins/dist/backstage-community-plugin-github-actions
 {{- end }}
 {{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-gitlab-integration") }}
   - disabled: false
@@ -88,15 +88,15 @@ plugins:
   #
 {{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-artifactory-integration") }}
   - disabled: false
-    package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-jfrog-artifactory
+    package: ./dynamic-plugins/dist/backstage-community-plugin-jfrog-artifactory
 {{- end }}
 {{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-nexus-integration") }}
   - disabled: false
-    package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-nexus-repository-manager
+    package: ./dynamic-plugins/dist/backstage-community-plugin-nexus-repository-manager
 {{- end }}
 {{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-quay-integration") }}
   - disabled: false
-    package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-quay
+    package: ./dynamic-plugins/dist/backstage-community-plugin-quay
 {{- end }}
   #
   # Kubernetes
@@ -131,7 +131,7 @@ plugins:
         serviceLocatorMethod:
           type: multiTenant
   - disabled: false
-    package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-topology
+    package: ./dynamic-plugins/dist/backstage-community-plugin-topology
   #
   # Tech Docs
   #

--- a/installer/charts/rhtap-dh/templates/plugins.yaml
+++ b/installer/charts/rhtap-dh/templates/plugins.yaml
@@ -2,9 +2,9 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   annotations:
-    rhdh.redhat.com/backstage-name: {{ .Values.developerHub.instanceName | quote }}
+    rhdh.redhat.com/backstage-name: {{ .Values.developerHub.instanceName }}
   labels:
-    rhdh.redhat.com/ext-config-sync: "true"
+    rhdh.redhat.com/ext-config-sync: 'true'
   name: developer-hub-rhtap-dynamic-plugins
 data:
   dynamic-plugins.yaml: |

--- a/installer/charts/rhtap-subscriptions/values.yaml
+++ b/installer/charts/rhtap-subscriptions/values.yaml
@@ -85,6 +85,6 @@ subscriptions:
     apiResource: backstages.rhdh.redhat.com
     namespace: openshift-operators
     name: rhdh
-    channel: fast-1.3
+    channel: fast-1.4
     source: redhat-operators
     sourceNamespace: openshift-marketplace


### PR DESCRIPTION
- Bump subscription channel
- Migrate plugins to community plugins
- Fix formatting in various DH manifests to match operator expectations
- Bump backstage API version and remove deprecated 'replicas' field.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED