### PR TITLE
fix: remove unused secrets from some namespaces

### DIFF
--- a/installer/charts/rhtap-app-namespaces/templates/secrets/bitbucket-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/bitbucket-auth.yaml
@@ -2,16 +2,14 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-bitbucket-integration") -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
 {{- if $secretData -}}
-{{- range tuple "development" "prod" "stage" }}
 ---
 kind: Secret
 type: kubernetes.io/basic-auth
 apiVersion: v1
 metadata:
   name: bitbucket-auth-secret
-  namespace: {{ $namespace }}-app-{{ . }}
+  namespace: {{ $namespace }}-app-development
 data:
   password: {{ $secretData.appPassword }}
   username: {{ $secretData.username }}
-{{- end }}
 {{- end }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/cosign-pub.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/cosign-pub.yaml
@@ -2,15 +2,13 @@
 {{- $secretObj := (lookup "v1" "Secret" "openshift-pipelines" "signing-secrets") -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
 {{- if $secretData -}}
-{{- range tuple "development" "prod" "stage" }}
 ---
 kind: Secret
 type: Opaque
 apiVersion: v1
 metadata:
   name: cosign-pub
-  namespace: {{ $namespace }}-app-{{ . }}
+  namespace: {{ $namespace }}-app-development
 data:
   cosign.pub: {{ index $secretData "cosign.pub" }}
-{{- end }}
 {{- end }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/github-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/github-auth.yaml
@@ -2,16 +2,14 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-github-integration") -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
 {{- if $secretData -}}
-{{- range tuple "development" "prod" "stage" }}
 ---
 kind: Secret
 type: kubernetes.io/basic-auth
 apiVersion: v1
 metadata:
   name: gitops-auth-secret
-  namespace: {{ $namespace }}-app-{{ . }}
+  namespace: {{ $namespace }}-app-development
 data:
   password: {{ $secretData.token }}
   username: {{ "oauth2" | b64enc }}
-{{- end }}
 {{- end }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/gitlab-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/gitlab-auth.yaml
@@ -2,16 +2,14 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-gitlab-integration") -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
 {{- if $secretData -}}
-{{- range tuple "development" "prod" "stage" }}
 ---
 kind: Secret
 type: kubernetes.io/basic-auth
 apiVersion: v1
 metadata:
   name: gitlab-auth-secret
-  namespace: {{ $namespace }}-app-{{ . }}
+  namespace: {{ $namespace }}-app-development
 data:
   password: {{ $secretData.token }}
   username: {{ "oauth2" | b64enc }}
-{{- end }}
 {{- end }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/pipelines.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/pipelines.yaml
@@ -4,15 +4,13 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-github-integration") | default dict -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
 {{- if $secretData }}
-{{- range tuple "development" "prod" "stage" }}
 ---
 kind: Secret
 type: Opaque
 apiVersion: v1
 metadata:
   name: pipelines-secret
-  namespace: {{ $namespace }}-app-{{ . }}
+  namespace: {{ $namespace }}-app-development
 data:
   webhook.secret: {{ $secretData.WebhookSecret }}
-{{- end }}
 {{- end }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/rox-api-token.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/rox-api-token.yaml
@@ -2,16 +2,14 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-acs-integration") -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
 {{- if $secretData -}}
-{{- range tuple "development" "prod" "stage" }}
 ---
 kind: Secret
 type: Opaque
 apiVersion: v1
 metadata:
   name: rox-api-token
-  namespace: {{ $namespace }}-app-{{ . }}
+  namespace: {{ $namespace }}-app-development
 data:
   rox-api-endpoint: {{ $secretData.endpoint }}
   rox-api-token: {{ $secretData.token }}
-{{- end }}
 {{- end }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/tpa.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/tpa.yaml
@@ -2,14 +2,13 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-trustification-integration") -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
 {{- if $secretData -}}
-{{- range tuple "development" "prod" "stage" }}
 ---
 kind: Secret
 type: Opaque
 apiVersion: v1
 metadata:
   name: tpa-secret
-  namespace: {{ $namespace }}-app-{{ . }}
+  namespace: {{ $namespace }}-app-development
 data:
   bombastic_api_url: {{ $secretData.bombastic_api_url }}
   oidc_client_id:  {{ $secretData.oidc_client_id }}
@@ -18,5 +17,4 @@ data:
   {{- if $secretData.supported_cyclonedx_version }}
   supported_cyclonedx_version:  {{ $secretData.supported_cyclonedx_version }}
   {{- end }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
The stage and production namespaces do not need as many secrets since they do not run CI workloads.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED