### PR TITLE
fix: template subcommand

### DIFF
--- a/pkg/deployer/helm.go
+++ b/pkg/deployer/helm.go
@@ -90,7 +90,7 @@ func (h *Helm) helmUpgrade(vals chartutil.Values) (*release.Release, error) {
 
 	c.DryRun = h.flags.DryRun
 	if h.flags.DryRun {
-		c.DryRunOption = "client"
+		c.DryRunOption = "server"
 	}
 
 	ctx := backgroundContext(func() {


### PR DESCRIPTION
The template subcommand was behaving differently if the chart was already deployed.

This is now corrected to behave the same as if the chart was to be installed, which gives an accurate representation of the manifests that Helm will apply.