### PR TITLE
chore: ignore symlinks to .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /__debug*
-/.vscode/
+/.vscode
 /*.dll
 /*.dylib
 /*.exe


### PR DESCRIPTION
Developers might use symlinks to the directory, so the change ignore both the dir and the file.