### PR TITLE
chore: reuse templates

### DIFF
--- a/installer/charts/_common/_service-account.tpl
+++ b/installer/charts/_common/_service-account.tpl
@@ -1,0 +1,35 @@
+{{- define "common.serviceAccount" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- define "common.clusterRoleBinding" -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- define "common.clusterRoleBindingClusterAdmin" -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/installer/charts/rhtap-acs-test/templates/_service-account.tpl
+++ b/installer/charts/rhtap-acs-test/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-acs-test/templates/service-account.yaml
+++ b/installer/charts/rhtap-acs-test/templates/service-account.yaml
@@ -1,10 +1,5 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -32,15 +27,4 @@ rules:
       - patch
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ .Release.Name }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBinding" . }}

--- a/installer/charts/rhtap-acs/templates/_service-account.tpl
+++ b/installer/charts/rhtap-acs/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-acs/templates/service-account.yaml
+++ b/installer/charts/rhtap-acs/templates/service-account.yaml
@@ -1,10 +1,5 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -30,17 +25,5 @@ rules:
       - delete
       - update
       - patch
-
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ .Release.Name }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBinding" . }}

--- a/installer/charts/rhtap-backing-services/templates/_service-account.tpl
+++ b/installer/charts/rhtap-backing-services/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-backing-services/templates/service-account.yaml
+++ b/installer/charts/rhtap-backing-services/templates/service-account.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBindingClusterAdmin" . }}

--- a/installer/charts/rhtap-gitops/templates/_service-account.tpl
+++ b/installer/charts/rhtap-gitops/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-gitops/templates/service-account.yaml
+++ b/installer/charts/rhtap-gitops/templates/service-account.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBindingClusterAdmin" . }}

--- a/installer/charts/rhtap-infrastructure/templates/_service-account.tpl
+++ b/installer/charts/rhtap-infrastructure/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-infrastructure/templates/minio/_service-account.tpl
+++ b/installer/charts/rhtap-infrastructure/templates/minio/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-infrastructure/templates/openshift-pipelines/_service-account.tpl
+++ b/installer/charts/rhtap-infrastructure/templates/openshift-pipelines/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-infrastructure/templates/service-account.yaml
+++ b/installer/charts/rhtap-infrastructure/templates/service-account.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBindingClusterAdmin" . }}

--- a/installer/charts/rhtap-integrations/templates/_service-account.tpl
+++ b/installer/charts/rhtap-integrations/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-integrations/templates/service-account.yaml
+++ b/installer/charts/rhtap-integrations/templates/service-account.yaml
@@ -1,10 +1,5 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -20,15 +15,4 @@ rules:
       - get
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ .Release.Name }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBinding" . }}

--- a/installer/charts/rhtap-openshift/templates/_service-account.tpl
+++ b/installer/charts/rhtap-openshift/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-pipelines/templates/_service-account.tpl
+++ b/installer/charts/rhtap-pipelines/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-pipelines/templates/service-account.yaml
+++ b/installer/charts/rhtap-pipelines/templates/service-account.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBindingClusterAdmin" . }}

--- a/installer/charts/rhtap-quay/templates/_service-account.tpl
+++ b/installer/charts/rhtap-quay/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-quay/templates/service-account.yaml
+++ b/installer/charts/rhtap-quay/templates/service-account.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBindingClusterAdmin" . }}

--- a/installer/charts/rhtap-subscriptions/templates/_service-account.tpl
+++ b/installer/charts/rhtap-subscriptions/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-subscriptions/templates/service-account.yaml
+++ b/installer/charts/rhtap-subscriptions/templates/service-account.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBindingClusterAdmin" . }}

--- a/installer/charts/rhtap-tas/templates/_service-account.tpl
+++ b/installer/charts/rhtap-tas/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-tas/templates/service-account.yaml
+++ b/installer/charts/rhtap-tas/templates/service-account.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBindingClusterAdmin" . }}

--- a/installer/charts/rhtap-tpa/templates/_service-account.tpl
+++ b/installer/charts/rhtap-tpa/templates/_service-account.tpl
@@ -1,0 +1,1 @@
+../../_common/_service-account.tpl

--- a/installer/charts/rhtap-tpa/templates/service-account.yaml
+++ b/installer/charts/rhtap-tpa/templates/service-account.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-
+{{- include "common.serviceAccount" . }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Name }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Release.Name }}
-    namespace: {{ .Release.Namespace }}
+{{- include "common.clusterRoleBindingClusterAdmin" . }}


### PR DESCRIPTION
cf [RHTAPINST-50](https://issues.redhat.com//browse/RHTAPINST-50)

Link identical template files to a single instance: service-account.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED