### PR TITLE
feat: Add option to bypass subscriptions creation

### DIFF
--- a/installer/charts/rhtap-subscriptions/templates/_subscriptions.tpl
+++ b/installer/charts/rhtap-subscriptions/templates/_subscriptions.tpl
@@ -10,3 +10,15 @@
   {{- end -}}
   {{- $enabled | toYaml -}}
 {{- end -}}
+{{- /*
+  Select the managed subscriptions.
+*/ -}}
+{{- define "subscriptions.managed" -}}
+  {{- $managed := dict -}}
+  {{- range $k, $v := .Values.subscriptions -}}
+    {{- if $v.managed -}}
+      {{- $managed = merge $managed (dict $k $v) -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $managed | toYaml -}}
+{{- end -}}

--- a/installer/charts/rhtap-subscriptions/templates/subscriptions.yaml
+++ b/installer/charts/rhtap-subscriptions/templates/subscriptions.yaml
@@ -1,4 +1,4 @@
-{{- range $s := include "subscriptions.enabled" . | fromYaml }}
+{{- range $s := include "subscriptions.managed" . | fromYaml }}
   {{- if $s.operatorGroup }}
 ---
 apiVersion: operators.coreos.com/v1

--- a/installer/charts/values.yaml.tpl
+++ b/installer/charts/values.yaml.tpl
@@ -20,12 +20,16 @@ debug:
 openshift:
   projects:
 {{- if $keycloak.Enabled }}
-    - rhbk-operator
     - {{ $keycloak.Namespace }}
+    {{- if $gitops.Properties.manageSubscription }}
+    - rhbk-operator
+    {{- end }}
 {{- end }}
 {{- if $acs.Enabled }}
-    - rhacs-operator
     - {{ $acs.Namespace }}
+    {{- if $acs.Properties.manageSubscription }}
+    - rhacs-operator
+    {{- end }}
 {{- end }}
 {{- if $quay.Enabled }}
     - {{ $quay.Namespace }}
@@ -50,27 +54,36 @@ openshift:
 subscriptions:
   amqStreams:
     enabled: {{ $tpa.Enabled }}
+    managed: {{ and $tpa.Enabled $tpa.Properties.manageSubscription }}
   crunchyData:
     enabled: {{ or $tpa.Enabled $rhdh.Enabled }}
+    managed: {{ or (and $tpa.Enabled $tpa.Properties.manageSubscription ) (and $rhdh.Enabled $rhdh.Properties.manageSubscription) }}
   openshiftGitOps:
     enabled: {{ $gitops.Enabled }}
+    managed: {{ and $gitops.Enabled $gitops.Properties.manageSubscription }}
     config:
       argoCDClusterNamespace: {{ $argoCDNamespace }}
   openshiftKeycloak:
     enabled: {{ $keycloak.Enabled }}
+    managed: {{ and $keycloak.Enabled $keycloak.Properties.manageSubscription }}
     operatorGroup:
       targetNamespaces:
         - {{ default "empty" $keycloak.Namespace }}
   openshiftPipelines:
     enabled: {{ $pipelines.Enabled }}
+    managed: {{ and $pipelines.Enabled $pipelines.Properties.manageSubscription }}
   openshiftTrustedArtifactSigner:
     enabled: {{ $tas.Enabled }}
+    managed: {{ and $tas.Enabled $tas.Properties.manageSubscription }}
   redHatAdvancedClusterSecurity:
     enabled: {{ $acs.Enabled }}
+    managed: {{ and $acs.Enabled $acs.Properties.manageSubscription }}
   redHatDeveloperHub:
     enabled: {{ $rhdh.Enabled }}
+    managed: {{ and $rhdh.Enabled $rhdh.Properties.manageSubscription }}
   redHatQuay:
     enabled: {{ $quay.Enabled }}
+    managed: {{ and $quay.Enabled $quay.Properties.manageSubscription }}
 
 #
 # rhtap-minio-operator

--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -7,30 +7,45 @@ rhtapCLI:
     trustedProfileAnalyzer:
       enabled: &tpaEnabled true
       namespace: &trustedProfileAnalyzerNamespace rhtap-tpa
+      properties:
+        manageSubscription: true
     keycloak:
       enabled: *tpaEnabled
       namespace: rhtap-keycloak
+      properties:
+        manageSubscription: true
     trustedArtifactSigner:
       enabled: &tasEnabled true
       namespace: &trustedArtifactSignerNamespace rhtap-tas
+      properties:
+        manageSubscription: true
     redHatDeveloperHub:
       enabled: &rhdhEnabled true
       namespace: *installerNamespace
       properties:
         catalogURL: https://github.com/redhat-appstudio/tssc-sample-templates/blob/v1.4.0/all.yaml
+        manageSubscription: true
     redHatAdvancedClusterSecurity:
       enabled: &rhacsEnabled true
       namespace: &rhacsNamespace rhtap-acs
+      properties:
+        manageSubscription: true
     redHatQuay:
       enabled: &quayEnabled true
       namespace: &quayNamespace rhtap-quay
+      properties:
+        manageSubscription: true
     openShiftGitOps:
       enabled: &gitopsEnabled true
       namespace: *installerNamespace
+      properties:
+        manageSubscription: true
     openShiftPipelines:
       enabled: &pipelinesEnabled true
       # No new resources will be created in the namespace
       namespace: openshift-pipelines
+      properties:
+        manageSubscription: true
   dependencies:
     - chart: charts/rhtap-openshift
       namespace: *installerNamespace


### PR DESCRIPTION
Clusters might already have subscriptions installed, which would trigger an error in Helm as it did not control the resources.

A new flag is added to disable the subscription installation per product, with the following limitations:
- AMQ Streams is controlled by TPA
- CrunchyData is controlled by RHDH and TPA

Those limitations means that a user may need to install some subscription manually (eg if they already have AMQ Streams, TPA must be installed manually and the `managedSubscription` flag must be set to `false`).

cf [RHTAP-4063](https://issues.redhat.com//browse/RHTAP-4063)

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED