### PR TITLE
Fix name of app/comp on Konflux pipeline

### DIFF
--- a/.tekton/rhtap-cli-pull-request.yaml
+++ b/.tekton/rhtap-cli-pull-request.yaml
@@ -13,8 +13,8 @@ metadata:
       && files.all.exists(x, !x.matches('^(?:docs|.github|.vscode|.ci)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE.txt|.golangci.yaml|.goreleaser.yaml|.snyk|.dockerignore|yamllint.yaml)$'))
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhtap-cli-release-1-4
-    appstudio.openshift.io/component: rhtap-cli-release-1-4
+    appstudio.openshift.io/application: rhtap-cli-1-4
+    appstudio.openshift.io/component: rhtap-cli-1-4
     pipelines.appstudio.openshift.io/type: build
   name: rhtap-cli-on-pull-request
   namespace: rhtap-shared-team-tenant

--- a/.tekton/rhtap-cli-push.yaml
+++ b/.tekton/rhtap-cli-push.yaml
@@ -12,8 +12,8 @@ metadata:
       && files.all.exists(x, !x.matches('^(?:docs|.github|.vscode|.ci)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE.txt|.golangci.yaml|.goreleaser.yaml|.snyk|.dockerignore|yamllint.yaml)$'))
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: rhtap-cli-release-1-4
-    appstudio.openshift.io/component: rhtap-cli-release-1-4
+    appstudio.openshift.io/application: rhtap-cli-1-4
+    appstudio.openshift.io/component: rhtap-cli-1-4
     pipelines.appstudio.openshift.io/type: build
   name: rhtap-cli-on-push
   namespace: rhtap-shared-team-tenant


### PR DESCRIPTION
The labels `appstudio.openshift.io/application` and `appstudio.openshift.io/component` must match the respective Application and Component name in Konflux.