### PR TITLE
feat: deploy dh and gitops in their own namespaces

### DIFF
--- a/installer/charts/rhtap-app-namespaces/hooks/post-deploy.sh
+++ b/installer/charts/rhtap-app-namespaces/hooks/post-deploy.sh
@@ -21,6 +21,8 @@ patch_serviceaccount() {
     local NAMESPACE="$1"
     local SA="$2"
 
+    echo -n "- Patching ServiceAccount '$SA' in '$NAMESPACE': "
+
     # Wait until the ServiceAccount is available and get the definition
     until "$KUBECTL" get serviceaccounts --namespace "$NAMESPACE" "$SA" >/dev/null 2>&1; do
         echo -n "_"
@@ -44,14 +46,12 @@ patch_serviceaccount() {
         fi
     done
 
-    if [ -e "$SA_DEFINITION_UPDATED" ]; then
-        echo -n "- Patching ServiceAccount '$SA' in '$NAMESPACE': "
-        "$KUBECTL" apply -f "$SA_DEFINITION_UPDATED"
-    fi
+    echo "OK"
+    "$KUBECTL" apply -f "$SA_DEFINITION_UPDATED"
 }
 
 app_namespaces() {
-    NAMESPACE="$INSTALLER__DEVELOPERHUB__NAMESPACE"
+    NAMESPACE="$INSTALLER__QUAY__SECRET__NAMESPACE"
 
     for env in "development" "prod" "stage"; do
         for SA in "default" "pipeline"; do

--- a/installer/charts/rhtap-app-namespaces/templates/NOTES.txt
+++ b/installer/charts/rhtap-app-namespaces/templates/NOTES.txt
@@ -1,0 +1,5 @@
+{{- $namespace := .Release.Namespace -}}
+OpenShift Projects:
+{{- range tuple "development" "prod" "stage" }}
+  - "{{ $namespace }}-app-{{ . }}"
+{{- end }}

--- a/installer/charts/rhtap-app-namespaces/templates/namespaces.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/namespaces.yaml
@@ -1,11 +1,11 @@
 {{ $namespace := .Release.Namespace }}
-{{ $argoCD := .Values.argoCD }}
+{{ $argoCD := .Values.appNamespaces.argoCD.name }}
 {{- range tuple "development" "prod" "stage" }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    argocd.argoproj.io/managed-by: {{ $argoCD.name }}
+    argocd.argoproj.io/managed-by: {{ $argoCD }}
   name: {{ $namespace }}-app-{{ . }}
 {{- end }}

--- a/installer/charts/rhtap-app-namespaces/values.yaml
+++ b/installer/charts/rhtap-app-namespaces/values.yaml
@@ -1,4 +1,4 @@
 ---
-argoCD:
-  # ArgoCD instance name controlling the namespace
-  name: __OVERWRITE_ME__
+appNamespaces:
+  argoCD:
+    name: __OVERWRITE_ME__

--- a/installer/charts/rhtap-dh/templates/app-config-content.yaml
+++ b/installer/charts/rhtap-dh/templates/app-config-content.yaml
@@ -1,18 +1,19 @@
 {{- define "rhtap-dh.app-conf" }}
+{{- $integrationNamespace := .Values.developerHub.integrationSecrets.namespace }}
 app:
   title: Red Hat Developer Hub
   baseUrl: ${BACKEND_URL}
 # Lookup for all the required secrets
-{{- $argocdSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-argocd-integration") }}
+{{- $argocdSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-argocd-integration") }}
 {{- $argocdSecretData := ($argocdSecretObj.data | default dict) }}
-{{- $bbSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-bitbucket-integration") }}
-{{- $ghSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-github-integration") }}
-{{- $gitlabSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-gitlab-integration") }}
-{{- $jenkinsSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-jenkins-integration") }}
-{{- $quaySecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-quay-integration") }}
+{{- $bbSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-bitbucket-integration") }}
+{{- $githubSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-github-integration") }}
+{{- $gitlabSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-gitlab-integration") }}
+{{- $jenkinsSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-jenkins-integration") }}
+{{- $quaySecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-quay-integration") }}
 {{- $quaySecretData := ($quaySecretObj.data | default dict) }}
-{{- $nexusSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-nexus-integration") }}
-{{- $artifactorySecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-artifactory-integration") }}
+{{- $nexusSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-nexus-integration") }}
+{{- $artifactorySecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-artifactory-integration") }}
 {{- $artifactorySecretData := ($artifactorySecretObj.data | default dict) }}
 
 {{- if $argocdSecretData }}
@@ -35,25 +36,23 @@ auth:
   environment: production
   providers:
   {{- $signInPage := "" }}
-  {{- $ghSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-github-integration") }}
-  {{- if $ghSecretObj }}
+  {{- if $githubSecretObj }}
     {{- $signInPage = "github" }}
     github:
       production:
         clientId: ${GITHUB__APP__CLIENT__ID}
         clientSecret: ${GITHUB__APP__CLIENT__SECRET}
-      {{- if ne ($ghSecretObj.data.host | b64dec) "github.com" }}
+      {{- if ne ($githubSecretObj.data.host | b64dec) "github.com" }}
         enterpriseInstanceUrl: ${GITHUB__URL}
       {{- end }}
   {{- end }}
-  {{- $glSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-gitlab-integration") }}
-  {{- $glSecretData := ($glSecretObj.data | default dict) }}
-  {{- if $glSecretData }}
-    {{- if and $glSecretData.clientId $glSecretData.clientSecret }}
+  {{- $gitlabSecretData := ($gitlabSecretObj.data | default dict) }}
+  {{- if $gitlabSecretData }}
+    {{- if and $gitlabSecretData.clientId $gitlabSecretData.clientSecret }}
     {{- $signInPage = "gitlab" }}
     gitlab:
       production:
-      {{- if ne ($glSecretData.host | b64dec) "gitlab.com" }}
+      {{- if ne ($gitlabSecretData.host | b64dec) "gitlab.com" }}
         audience: ${GITLAB__URL}
       {{- end }}
         clientId: ${GITLAB__APP__CLIENT__ID}
@@ -90,7 +89,7 @@ integrations:
     - appPassword: ${BITBUCKET__APP_PASSWORD}
       username: ${BITBUCKET__USERNAME}
 {{- end }}
-{{- if $ghSecretObj }}
+{{- if $githubSecretObj }}
   github:
     - host: ${GITHUB__HOST}
       token: ${GITHUB__TOKEN}
@@ -108,7 +107,7 @@ integrations:
       apiBaseUrl: https://${GITLAB__HOST}/api/v4
       token: ${GITLAB__TOKEN}
 {{- end }}
-{{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-jenkins-integration") }}
+{{- if $jenkinsSecretObj }}
 jenkins:
   instances:
     - name: default

--- a/installer/charts/rhtap-dh/templates/extra-env.yaml
+++ b/installer/charts/rhtap-dh/templates/extra-env.yaml
@@ -1,3 +1,4 @@
+{{- $integrationNamespace := .Values.developerHub.integrationSecrets.namespace -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -13,7 +14,7 @@ data:
     BACKEND_SECRET: {{ randAlphaNum 16 | b64enc }}
     BACKEND_URL: {{ printf "https://backstage-developer-hub-%s.%s" .Release.Namespace .Values.developerHub.ingressDomain | b64enc }}
     NODE_TLS_REJECT_UNAUTHORIZED:  {{ "0" | b64enc }}
-{{- $argocdSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-argocd-integration") }}
+{{- $argocdSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-argocd-integration") }}
 {{- $argocdSecretData := ($argocdSecretObj.data | default dict) }}
 {{- if $argocdSecretData }}
     ARGOCD__API_TOKEN: {{ $argocdSecretData.ARGOCD_API_TOKEN }}
@@ -21,13 +22,13 @@ data:
     ARGOCD__URL: {{ print "https://" ($argocdSecretData.ARGOCD_HOSTNAME | b64dec) | b64enc }}
     ARGOCD__USER: {{ $argocdSecretData.ARGOCD_USER }}
 {{- end }}
-{{- $artifactorySecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-artifactory-integration") }}
+{{- $artifactorySecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-artifactory-integration") }}
 {{- $artifactorySecretData := ($artifactorySecretObj.data | default dict) }}
 {{- if $artifactorySecretData }}
     ARTIFACTORY__API_TOKEN: {{ $artifactorySecretData.token }}
     ARTIFACTORY__URL: {{ $artifactorySecretData.url }}
 {{- end }}
-{{- $bbSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-bitbucket-integration") }}
+{{- $bbSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-bitbucket-integration") }}
 {{- $bbSecretData := ($bbSecretObj.data | default dict) }}
 {{- if $bbSecretData }}
     BITBUCKET__APP_PASSWORD:  {{ $bbSecretData.appPassword }}
@@ -36,7 +37,7 @@ data:
     DEVELOPER_HUB__CATALOG__URL: {{
         required ".developerHub.catalogURL is required" .Values.developerHub.catalogURL | b64enc
     }}
-{{- $ghSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-github-integration") }}
+{{- $ghSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-github-integration") }}
 {{- $ghSecretData := ($ghSecretObj.data | default dict) }}
 {{- if $ghSecretData }}
     GITHUB__APP__ID: {{ $ghSecretData.id }}
@@ -53,7 +54,7 @@ data:
     GITHUB__URL: {{ print "https://" ($ghSecretData.host | b64dec) | b64enc }}
     {{- end }}
 {{- end }}
-{{- $glSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-gitlab-integration") -}}
+{{- $glSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-gitlab-integration") -}}
 {{- $glSecretData := ($glSecretObj.data | default dict) -}}
 {{- if $glSecretData }}
     GITLAB__HOST: {{ $glSecretData.host }}
@@ -64,24 +65,24 @@ data:
     GITLAB__APP__CLIENT__SECRET: {{ $glSecretData.clientSecret }}
     {{- end }}
 {{- end }}
-{{- $jenkinsSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-jenkins-integration") }}
+{{- $jenkinsSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-jenkins-integration") }}
 {{- $jenkinsSecretData := ($jenkinsSecretObj.data | default dict) }}
 {{- if $jenkinsSecretData }}
     JENKINS__BASEURL: {{ $jenkinsSecretData.baseUrl }}
     JENKINS__USERNAME: {{ $jenkinsSecretData.username }}
     JENKINS__TOKEN: {{ $jenkinsSecretData.token }}
 {{- end }}
-{{- $k8sSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-k8s-integration") }}
+{{- $k8sSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-k8s-integration") }}
 {{- $k8sSecretData := ($k8sSecretObj.data | default dict) }}
 {{- if $k8sSecretData }}
     K8S_SERVICEACCOUNT_TOKEN: {{ $k8sSecretData.token }}
 {{- end }}
-{{- $nexusSecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-nexus-integration") }}
+{{- $nexusSecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-nexus-integration") }}
 {{- $nexusSecretData := ($nexusSecretObj.data | default dict) }}
 {{- if $nexusSecretData }}
     NEXUS__URL: {{ $nexusSecretData.url }}
 {{- end }}
-{{- $quaySecretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-quay-integration") }}
+{{- $quaySecretObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-quay-integration") }}
 {{- $quaySecretData := ($quaySecretObj.data | default dict) }}
 {{- if $quaySecretData }}
     {{- if $quaySecretData.token }}

--- a/installer/charts/rhtap-dh/templates/plugins-content.yaml
+++ b/installer/charts/rhtap-dh/templates/plugins-content.yaml
@@ -1,10 +1,11 @@
 {{- define "rhtap-dh.plugins-conf" }}
+{{- $integrationNamespace := .Values.developerHub.integrationSecrets.namespace }}
 includes:
   - dynamic-plugins.default.yaml
 plugins:
   # Installed plugins can be listed at:
   # https://DH_HOSTNAME/api/dynamic-plugins-info/loaded-plugins
-{{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-argocd-integration") }}
+{{- if (lookup "v1" "Secret" $integrationNamespace "rhtap-argocd-integration") }}
   #
   # ArgoCD
   #
@@ -44,17 +45,17 @@ plugins:
                     gridRowStart: 1
                 importName: TektonCI
                 mountPoint: entity.page.ci/cards
-{{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-github-integration") }}
+{{- if (lookup "v1" "Secret" $integrationNamespace "rhtap-github-integration") }}
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-community-plugin-github-actions
 {{- end }}
-{{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-gitlab-integration") }}
+{{- if (lookup "v1" "Secret" $integrationNamespace "rhtap-gitlab-integration") }}
   - disabled: false
     package: ./dynamic-plugins/dist/immobiliarelabs-backstage-plugin-gitlab
   - disabled: false
     package: ./dynamic-plugins/dist/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic
 {{- end }}
-{{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-jenkins-integration") }}
+{{- if (lookup "v1" "Secret" $integrationNamespace "rhtap-jenkins-integration") }}
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-community-plugin-jenkins
     pluginConfig:
@@ -86,15 +87,15 @@ plugins:
   #
   # Image Registry
   #
-{{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-artifactory-integration") }}
+{{- if (lookup "v1" "Secret" $integrationNamespace "rhtap-artifactory-integration") }}
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-community-plugin-jfrog-artifactory
 {{- end }}
-{{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-nexus-integration") }}
+{{- if (lookup "v1" "Secret" $integrationNamespace "rhtap-nexus-integration") }}
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-community-plugin-nexus-repository-manager
 {{- end }}
-{{- if (lookup "v1" "Secret" .Release.Namespace "rhtap-quay-integration") }}
+{{- if (lookup "v1" "Secret" $integrationNamespace "rhtap-quay-integration") }}
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-community-plugin-quay
 {{- end }}

--- a/installer/charts/rhtap-dh/templates/tests/test.yaml
+++ b/installer/charts/rhtap-dh/templates/tests/test.yaml
@@ -1,4 +1,5 @@
 {{- $name := printf "%s-test-%d" .Chart.Name .Release.Revision -}}
+{{- $integrationNamespace := .Values.developerHub.integrationSecrets.namespace -}}
 ---
 apiVersion: v1
 kind: Pod
@@ -8,7 +9,8 @@ metadata:
     helm.sh/hook-delete-policy: hook-succeeded
   labels:
     {{- include "rhtap-dh.labels" . | nindent 4 }}
-  name: {{ $name }} 
+  name: {{ $name }}
+  namespace: {{ $integrationNamespace }}
 spec:
   restartPolicy: Never
   serviceAccountName: rhdh-kubernetes-plugin

--- a/installer/charts/rhtap-dh/values.yaml
+++ b/installer/charts/rhtap-dh/values.yaml
@@ -6,3 +6,5 @@ developerHub:
   instanceName: developer-hub
   catalogURL: __OVERWRITE_ME__
   ingressDomain: __OVERWRITE_ME__
+  integrationSecrets:
+    namespace: __OVERWRITE_ME__

--- a/installer/charts/rhtap-gitops/templates/job-post-deploy.yaml
+++ b/installer/charts/rhtap-gitops/templates/job-post-deploy.yaml
@@ -71,9 +71,9 @@ spec:
           image: quay.io/codeready-toolchain/oc-client-base:latest
           env:
             - name: SECRET_NAME
-              value: {{ $argoCD.secretName }}
+              value: {{ $argoCD.integrationSecret.name }}
             - name: NAMESPACE
-              value: {{ $argoCD.namespace }}
+              value: {{ $argoCD.integrationSecret.namespace }}
             - name: ARGOCD_ENV_FILE
               value: {{ $argoCDEnvFile }}
           command:

--- a/installer/charts/rhtap-gitops/values.yaml
+++ b/installer/charts/rhtap-gitops/values.yaml
@@ -9,9 +9,10 @@ argoCD:
   namespace: __OVERWRITE_ME__
   # The domain for the ArgoCD instance, used to define the final route.
   ingressDomain: __OVERWRITE_ME__
-  # The secret name to store the ArgoCD API credentials, this secret is later on
+  # The secret namespace to store the ArgoCD API credentials, this secret is later on
   # used for integration with other services.
-  secretName: __OVERWRITE_ME__
+  integrationSecret:
+    namespace: __OVERWRITE_ME__
   # Route configuration for all ArgoCD components.
   route:
     # Toggles the route for the ArgoCD components.

--- a/installer/charts/rhtap-openshift/templates/NOTES.txt
+++ b/installer/charts/rhtap-openshift/templates/NOTES.txt
@@ -1,4 +1,4 @@
 OpenShift Projects:
-{{- range $p := .Values.openshift.projects }}
+{{- range $p := .Values.openshift.projects | sortAlpha }}
   - {{ $p | quote }}
 {{- end }}

--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -21,9 +21,9 @@ rhtapCLI:
         manageSubscription: true
     redHatDeveloperHub:
       enabled: &rhdhEnabled true
-      namespace: *installerNamespace
+      namespace: &rhdhNamespace rhtap-dh
       properties:
-        catalogURL: https://github.com/redhat-appstudio/tssc-sample-templates/blob/v1.4.0/all.yaml
+        catalogURL: https://github.com/redhat-appstudio/tssc-sample-templates/blob/main/all.yaml
         manageSubscription: true
     redHatAdvancedClusterSecurity:
       enabled: &rhacsEnabled true
@@ -37,7 +37,7 @@ rhtapCLI:
         manageSubscription: true
     openShiftGitOps:
       enabled: &gitopsEnabled true
-      namespace: *installerNamespace
+      namespace: &gitopsNamespace rhtap-gitops
       properties:
         manageSubscription: true
     openShiftPipelines:
@@ -66,7 +66,7 @@ rhtapCLI:
       namespace: *rhacsNamespace
       enabled: *rhacsEnabled
     - chart: charts/rhtap-gitops
-      namespace: *installerNamespace
+      namespace: *gitopsNamespace
       enabled: *gitopsEnabled
     - chart: charts/rhtap-pipelines
       namespace: *installerNamespace
@@ -84,7 +84,7 @@ rhtapCLI:
       namespace: *installerNamespace
       enabled: *pipelinesEnabled
     - chart: charts/rhtap-dh
-      namespace: *installerNamespace
+      namespace: *rhdhNamespace
       enabled: *rhdhEnabled
     - chart: charts/rhtap-acs-test
       namespace: *rhacsNamespace

--- a/integration-tests/scripts/install.sh
+++ b/integration-tests/scripts/install.sh
@@ -257,8 +257,8 @@ install_rhtap() {
   cat "$tpl_file"
   ./bin/rhtap-cli deploy --timeout 35m --config "$config_file" --values-template "$tpl_file" --kube-config "$KUBECONFIG" --debug --log-level=debug
 
-  homepage_url=https://$(kubectl -n rhtap get route backstage-developer-hub -o  'jsonpath={.spec.host}')
-  callback_url=https://$(kubectl -n rhtap get route backstage-developer-hub -o  'jsonpath={.spec.host}')/api/auth/${auth_config}/handler/frame
+  homepage_url=https://$(kubectl -n rhtap-dh get route backstage-developer-hub -o  'jsonpath={.spec.host}')
+  callback_url=https://$(kubectl -n rhtap-dh get route backstage-developer-hub -o  'jsonpath={.spec.host}')/api/auth/${auth_config}/handler/frame
   webhook_url=https://$(kubectl -n openshift-pipelines get route pipelines-as-code-controller -o 'jsonpath={.spec.host}')
 
   echo "[INFO]homepage_url=$homepage_url"

--- a/pkg/integrations/acs.go
+++ b/pkg/integrations/acs.go
@@ -67,24 +67,19 @@ func (a *ACSIntegration) Validate() error {
 // EnsureNamespace ensures the namespace needed for the ACS integration secret
 // is created on the cluster.
 func (a *ACSIntegration) EnsureNamespace(ctx context.Context) error {
-	feature, err := a.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		a.log(),
 		a.kube,
-		feature.GetNamespace(),
+		a.cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
 func (a *ACSIntegration) secretName() types.NamespacedName {
-	feature, _ := a.cfg.GetFeature(config.RedHatDeveloperHub)
 	return types.NamespacedName{
-		Namespace: feature.GetNamespace(),
+		Namespace: a.cfg.Installer.Namespace,
 		Name:      "rhtap-acs-integration",
 	}
 }

--- a/pkg/integrations/artifactory.go
+++ b/pkg/integrations/artifactory.go
@@ -77,24 +77,19 @@ func (a *ArtifactoryIntegration) Validate() error {
 // EnsureNamespace ensures the namespace needed for the Artifactory integration secret
 // is created on the cluster.
 func (a *ArtifactoryIntegration) EnsureNamespace(ctx context.Context) error {
-	feature, err := a.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		a.log(),
 		a.kube,
-		feature.GetNamespace(),
+		a.cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
 func (a *ArtifactoryIntegration) secretName() types.NamespacedName {
-	feature, _ := a.cfg.GetFeature(config.RedHatDeveloperHub)
 	return types.NamespacedName{
-		Namespace: feature.GetNamespace(),
+		Namespace: a.cfg.Installer.Namespace,
 		Name:      "rhtap-artifactory-integration",
 	}
 }

--- a/pkg/integrations/bitbucket.go
+++ b/pkg/integrations/bitbucket.go
@@ -70,24 +70,19 @@ func (g *BitBucketIntegration) Validate() error {
 // EnsureNamespace ensures the namespace needed for the BitBucket integration secret
 // is created on the cluster.
 func (g *BitBucketIntegration) EnsureNamespace(ctx context.Context) error {
-	feature, err := g.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		g.log(),
 		g.kube,
-		feature.GetNamespace(),
+		g.cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
 func (g *BitBucketIntegration) secretName() types.NamespacedName {
-	feature, _ := g.cfg.GetFeature(config.RedHatDeveloperHub)
 	return types.NamespacedName{
-		Namespace: feature.GetNamespace(),
+		Namespace: g.cfg.Installer.Namespace,
 		Name:      "rhtap-bitbucket-integration",
 	}
 }

--- a/pkg/integrations/github.go
+++ b/pkg/integrations/github.go
@@ -75,15 +75,11 @@ func (g *GithubIntegration) Validate() error {
 // EnsureNamespace ensures the namespace needed for the GitHub integration secret
 // is created on the cluster.
 func (g *GithubIntegration) EnsureNamespace(ctx context.Context) error {
-	feature, err := g.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		g.log(),
 		g.kube,
-		feature.GetNamespace(),
+		g.cfg.Installer.Namespace,
 	)
 }
 
@@ -136,9 +132,8 @@ func (g *GithubIntegration) setOpenShiftURLs(ctx context.Context) error {
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
 func (g *GithubIntegration) secretName() types.NamespacedName {
-	feature, _ := g.cfg.GetFeature(config.RedHatDeveloperHub)
 	return types.NamespacedName{
-		Namespace: feature.GetNamespace(),
+		Namespace: g.cfg.Installer.Namespace,
 		Name:      "rhtap-github-integration",
 	}
 }

--- a/pkg/integrations/gitlab.go
+++ b/pkg/integrations/gitlab.go
@@ -77,24 +77,19 @@ func (g *GitLabIntegration) Validate() error {
 // EnsureNamespace ensures the namespace needed for the GitLab integration secret
 // is created on the cluster.
 func (g *GitLabIntegration) EnsureNamespace(ctx context.Context) error {
-	feature, err := g.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		g.log(),
 		g.kube,
-		feature.GetNamespace(),
+		g.cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
 func (g *GitLabIntegration) secretName() types.NamespacedName {
-	feature, _ := g.cfg.GetFeature(config.RedHatDeveloperHub)
 	return types.NamespacedName{
-		Namespace: feature.GetNamespace(),
+		Namespace: g.cfg.Installer.Namespace,
 		Name:      "rhtap-gitlab-integration",
 	}
 }

--- a/pkg/integrations/jenkins.go
+++ b/pkg/integrations/jenkins.go
@@ -77,24 +77,19 @@ func (j *JenkinsIntegration) Validate() error {
 // EnsureNamespace ensures the namespace needed for the Jenkins integration secret
 // is created on the cluster.
 func (j *JenkinsIntegration) EnsureNamespace(ctx context.Context) error {
-	feature, err := j.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		j.log(),
 		j.kube,
-		feature.GetNamespace(),
+		j.cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
 func (j *JenkinsIntegration) secretName() types.NamespacedName {
-	feature, _ := j.cfg.GetFeature(config.RedHatDeveloperHub)
 	return types.NamespacedName{
-		Namespace: feature.GetNamespace(),
+		Namespace: j.cfg.Installer.Namespace,
 		Name:      "rhtap-jenkins-integration",
 	}
 }

--- a/pkg/integrations/nexus.go
+++ b/pkg/integrations/nexus.go
@@ -70,24 +70,19 @@ func (n *NexusIntegration) Validate() error {
 // EnsureNamespace ensures the namespace needed for the Nexus integration secret
 // is created on the cluster.
 func (n *NexusIntegration) EnsureNamespace(ctx context.Context) error {
-	feature, err := n.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		n.log(),
 		n.kube,
-		feature.GetNamespace(),
+		n.cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
 func (n *NexusIntegration) secretName() types.NamespacedName {
-	feature, _ := n.cfg.GetFeature(config.RedHatDeveloperHub)
 	return types.NamespacedName{
-		Namespace: feature.GetNamespace(),
+		Namespace: n.cfg.Installer.Namespace,
 		Name:      "rhtap-nexus-integration",
 	}
 }

--- a/pkg/integrations/quay.go
+++ b/pkg/integrations/quay.go
@@ -80,24 +80,19 @@ func (q *QuayIntegration) Validate() error {
 // EnsureNamespace ensures the namespace needed for the Quay integration secret
 // is created on the cluster.
 func (q *QuayIntegration) EnsureNamespace(ctx context.Context) error {
-	feature, err := q.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		q.log(),
 		q.kube,
-		feature.GetNamespace(),
+		q.cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
 func (q *QuayIntegration) secretName() types.NamespacedName {
-	feature, _ := q.cfg.GetFeature(config.RedHatDeveloperHub)
 	return types.NamespacedName{
-		Namespace: feature.GetNamespace(),
+		Namespace: q.cfg.Installer.Namespace,
 		Name:      "rhtap-quay-integration",
 	}
 }

--- a/pkg/integrations/trustification.go
+++ b/pkg/integrations/trustification.go
@@ -85,24 +85,19 @@ func (i *TrustificationIntegration) Validate() error {
 // EnsureNamespace ensures the namespace needed for the Trustification integration secret
 // is created on the cluster.
 func (i *TrustificationIntegration) EnsureNamespace(ctx context.Context) error {
-	feature, err := i.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		i.log(),
 		i.kube,
-		feature.GetNamespace(),
+		i.cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
 func (i *TrustificationIntegration) secretName() types.NamespacedName {
-	feature, _ := i.cfg.GetFeature(config.RedHatDeveloperHub)
 	return types.NamespacedName{
-		Namespace: feature.GetNamespace(),
+		Namespace: i.cfg.Installer.Namespace,
 		Name:      "rhtap-trustification-integration",
 	}
 }


### PR DESCRIPTION
There's no good reason for the 2 services to share the same namespace. This change helps with segregation of services. This in turn helps with development, as it guarantee that there is no unknown link between the 2 services and one can reset a service by deleting the namespace and redeploying the cluster.

With this change, the `rhtap` namespace becomes a location for integration secrets.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED