### PR TITLE
fix: Downgrade Keycloak to v24

### DIFF
--- a/installer/charts/rhtap-subscriptions/values.yaml
+++ b/installer/charts/rhtap-subscriptions/values.yaml
@@ -35,7 +35,7 @@ subscriptions:
     apiResource: keycloaks.k8s.keycloak.org
     namespace: rhbk-operator
     name: rhbk-operator
-    channel: stable-v26
+    channel: stable-v24
     source: redhat-operators
     sourceNamespace: openshift-marketplace
     operatorGroup:


### PR DESCRIPTION
v26 requires changes to the manifests. Until this is figured out, we will use v24.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED