### PR TITLE
feat: add a PVC for DH plugins

### DIFF
--- a/installer/charts/rhtap-dh/templates/backstage.yaml
+++ b/installer/charts/rhtap-dh/templates/backstage.yaml
@@ -18,3 +18,13 @@ spec:
       enabled: true
   database:
     enableLocalDb: true
+  deployment:
+    patch:
+      spec:
+        template:
+          spec:
+            volumes:
+              - $patch: replace
+                name: dynamic-plugins-root
+                persistentVolumeClaim:
+                  claimName: {{ .Values.developerHub.instanceName }}-dynamic-plugins-root

--- a/installer/charts/rhtap-dh/templates/plugins-cache.yaml
+++ b/installer/charts/rhtap-dh/templates/plugins-cache.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.developerHub.instanceName }}-dynamic-plugins-root
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
This speeds up DH restarts as the plugins are not downloaded on every restart, and instead are cached to persistent storage.

cf https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/configuring/con-dynamic-plugin-cache_running-behind-a-proxy#enabling-the-dynamic-plugins-cache

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED