### PR TITLE
feat: give CI workloads their own namespace

### DIFF
--- a/installer/charts/rhtap-app-namespaces/hooks/post-deploy.sh
+++ b/installer/charts/rhtap-app-namespaces/hooks/post-deploy.sh
@@ -53,10 +53,9 @@ patch_serviceaccount() {
 app_namespaces() {
     NAMESPACE="$INSTALLER__QUAY__SECRET__NAMESPACE"
 
-    for env in "development" "prod" "stage"; do
-        for SA in "default" "pipeline"; do
-            patch_serviceaccount "$NAMESPACE-app-$env" "$SA"
-        done
+    patch_serviceaccount "$NAMESPACE-app-ci" "pipeline"
+    for env in "ci" "development" "prod" "stage"; do
+        patch_serviceaccount "$NAMESPACE-app-$env" "default"
     done
 }
 

--- a/installer/charts/rhtap-app-namespaces/templates/NOTES.txt
+++ b/installer/charts/rhtap-app-namespaces/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{- $namespace := .Release.Namespace -}}
 OpenShift Projects:
-{{- range tuple "development" "prod" "stage" }}
+{{- range tuple "ci" "development" "prod" "stage" }}
   - "{{ $namespace }}-app-{{ . }}"
 {{- end }}

--- a/installer/charts/rhtap-app-namespaces/templates/namespaces.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/namespaces.yaml
@@ -1,6 +1,6 @@
 {{ $namespace := .Release.Namespace }}
 {{ $argoCD := .Values.appNamespaces.argoCD.name }}
-{{- range tuple "development" "prod" "stage" }}
+{{- range tuple "ci" "development" "prod" "stage" }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/artifactory-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/artifactory-auth.yaml
@@ -2,7 +2,7 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-artifactory-integration") | default dict -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
 {{- if $secretData }}
-  {{- range tuple "development" "prod" "stage" }}
+  {{- range tuple "ci" "development" "prod" "stage" }}
 ---
 kind: Secret
 type: kubernetes.io/dockerconfigjson

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/bitbucket-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/bitbucket-auth.yaml
@@ -8,7 +8,7 @@ type: kubernetes.io/basic-auth
 apiVersion: v1
 metadata:
   name: bitbucket-auth-secret
-  namespace: {{ $namespace }}-app-development
+  namespace: {{ $namespace }}-app-ci
 data:
   password: {{ $secretData.appPassword }}
   username: {{ $secretData.username }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/cosign-pub.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/cosign-pub.yaml
@@ -8,7 +8,7 @@ type: Opaque
 apiVersion: v1
 metadata:
   name: cosign-pub
-  namespace: {{ $namespace }}-app-development
+  namespace: {{ $namespace }}-app-ci
 data:
   cosign.pub: {{ index $secretData "cosign.pub" }}
 {{- end }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/github-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/github-auth.yaml
@@ -8,7 +8,7 @@ type: kubernetes.io/basic-auth
 apiVersion: v1
 metadata:
   name: gitops-auth-secret
-  namespace: {{ $namespace }}-app-development
+  namespace: {{ $namespace }}-app-ci
 data:
   password: {{ $secretData.token }}
   username: {{ "oauth2" | b64enc }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/gitlab-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/gitlab-auth.yaml
@@ -8,7 +8,7 @@ type: kubernetes.io/basic-auth
 apiVersion: v1
 metadata:
   name: gitlab-auth-secret
-  namespace: {{ $namespace }}-app-development
+  namespace: {{ $namespace }}-app-ci
 data:
   password: {{ $secretData.token }}
   username: {{ "oauth2" | b64enc }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/nexus-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/nexus-auth.yaml
@@ -2,7 +2,7 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-nexus-integration") | default dict -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
 {{- if $secretData }}
-  {{- range tuple "development" "prod" "stage" }}
+  {{- range tuple "ci" "development" "prod" "stage" }}
 ---
 kind: Secret
 type: kubernetes.io/dockerconfigjson

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/pipelines.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/pipelines.yaml
@@ -10,7 +10,7 @@ type: Opaque
 apiVersion: v1
 metadata:
   name: pipelines-secret
-  namespace: {{ $namespace }}-app-development
+  namespace: {{ $namespace }}-app-ci
 data:
   webhook.secret: {{ $secretData.WebhookSecret }}
 {{- end }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/quay-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/quay-auth.yaml
@@ -2,7 +2,7 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-quay-integration") | default dict -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
 {{- if $secretData }}
-  {{- range tuple "development" "prod" "stage" }}
+  {{- range tuple "ci" "development" "prod" "stage" }}
 ---
 kind: Secret
 type: kubernetes.io/dockerconfigjson

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/rox-api-token.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/rox-api-token.yaml
@@ -8,7 +8,7 @@ type: Opaque
 apiVersion: v1
 metadata:
   name: rox-api-token
-  namespace: {{ $namespace }}-app-development
+  namespace: {{ $namespace }}-app-ci
 data:
   rox-api-endpoint: {{ $secretData.endpoint }}
   rox-api-token: {{ $secretData.token }}

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/tpa.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/tpa.yaml
@@ -8,7 +8,7 @@ type: Opaque
 apiVersion: v1
 metadata:
   name: tpa-secret
-  namespace: {{ $namespace }}-app-development
+  namespace: {{ $namespace }}-app-ci
 data:
   bombastic_api_url: {{ $secretData.bombastic_api_url }}
   oidc_client_id:  {{ $secretData.oidc_client_id }}


### PR DESCRIPTION
There is no reason for the development application to run in a namespace with the extra secrets needed by the ci.

This split provides better segregation of information and makes the development namespace identical to the other deployment namespaces in term of configuration.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED