### PR TITLE
fix: improve hack scripts

### DIFF
--- a/hack/ci-set-org-vars.sh
+++ b/hack/ci-set-org-vars.sh
@@ -37,7 +37,7 @@ parse_args() {
     while [[ $# -gt 0 ]]; do
         case $1 in
         -e | --env-file)
-            ENVFILE="$2"
+            ENVFILE="$(readlink -e "$2")"
             shift
             ;;
         -n | --namespace)

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -55,7 +55,7 @@ parse_args() {
             shift
             ;;
         -e | --env-file)
-            ENVFILE="$2"
+            ENVFILE="$(readlink -e "$2")"
             shift
             ;;
         -i|--integration)


### PR DESCRIPTION
- reset.sh: add '--all' flag
- reset.sh: remove the '-i dh' option as DH can now be reset with '-n rhtap-dh'
- reset.sh: delete PVCs on namespace deletion
- fix a small issue with the ENVFILE var

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED