### PR TITLE
fix case where the PLR was not yet created

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -163,7 +163,7 @@ spec:
                   while true; do
                     ARE_PIPELINES_RUNNING=false
                     for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-                      if [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]; then
+                      if ! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null || [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]; then
                         #something is still running. Break this cycle and wait one minute.
                         ARE_PIPELINES_RUNNING=true
                         break


### PR DESCRIPTION
Sometimes the main pipeline ends & succeeds even though the plrs it created are still running. I suppose it's because when this IF condition is evaluated, the PLR is not yet existing. This PR should take care of that.