### PR TITLE
Path service-account.yaml.patch.yaml does not exist error

### DIFF
--- a/installer/charts/rhtap-app-namespaces/hooks/post-deploy.sh
+++ b/installer/charts/rhtap-app-namespaces/hooks/post-deploy.sh
@@ -47,7 +47,9 @@ patch_serviceaccount() {
     done
 
     echo "OK"
-    "$KUBECTL" apply -f "$SA_DEFINITION_UPDATED"
+    if [ -e "$SA_DEFINITION_UPDATED" ]; then
+        "$KUBECTL" apply -f "$SA_DEFINITION_UPDATED"
+    fi
 }
 
 app_namespaces() {


### PR DESCRIPTION
If none of the three secrets: `artifactory-auth nexus-auth quay-auth` exists, the script would fail with error: `error: the path service-account.yaml.patch.yaml does not exist`.