### PR TITLE
adding label to identify its main pipeline

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -142,6 +142,7 @@ spec:
                   --labels "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}" \
                   --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
                   --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
+                  --labels "custom.appstudio.openshift.io/main-pipeline-run=$(context.pipelineRun.name)" \
                   --prefix-name "e2e-$OCP_VERSION"\
                   -o name)
 


### PR DESCRIPTION
This pull request includes a small change to the `integration-tests/pipelines/e2e-main-pipeline.yaml` file. The change adds a new label to the pipeline run command to include the main pipeline run name.