### PR TITLE
fix: Use RH owned cosign image

### DIFF
--- a/installer/charts/rhtap-infrastructure/templates/openshift-pipelines/job-tekton-chains.yaml
+++ b/installer/charts/rhtap-infrastructure/templates/openshift-pipelines/job-tekton-chains.yaml
@@ -29,7 +29,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: tekton-chains-cosign
-          image: ghcr.io/sigstore/cosign/cosign:latest
+          image: registry.redhat.io/rhtas/cosign-rhel9:1.1.1
           env:
             - name: COSIGN_PASSWORD
               value: {{ randAlphaNum 32 }}


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED