### PR TITLE
RHTAP-4048: `rhtap-cli config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,16 @@ Install the `rhtap-cli` binary on your local machine following [these instructio
 
 Follow the below steps to deploy RHTAP on Openshift cluster. 
 
-1. Edit the [`config.yaml`](installer/config.yaml) file for select or deselect the components from installation. See the [configuration](#configuration) section for more details.
+1. Create the installer's cluster configuration. You can use a local configuration file, or default settings. To use the default settings, run the command bellow, and see the [configuration](#configuration) section for more details.
 
-  For instance: change the lines as below to disable installation of components ACS and Quay .
+```bash
+# Shows the options to manage cluster's configuration.
+rhtap-cli config --help
 
-```yaml
-# ...
-redHatAdvancedClusterSecurity: 
-  enabled: false 
-redHatQuay: 
-  enabled: false
+# Creates a new default configuration in the cluster, showing the result.
+rhtap-cli config --create --get
 ```
-      
+
 2. Run the command `rhtap-cli` to display help text that shows all the supported commands and options. 
 
 3. Run the command `rhtap-cli integration` to provide integrations to external components. The command below lists the options supported: 

--- a/integration-tests/scripts/install.sh
+++ b/integration-tests/scripts/install.sh
@@ -187,18 +187,34 @@ install_rhtap() {
   quayio_integration
   artifactory_integration
   nexus_integration
-  # for debugging purpose
-  echo "[INFO] Print out the content of values.yaml.tpl"
+
+  echo "[INFO] Showing the local configuration"
+  set -x
+  cat "$config_file"
+  set +x
+
+  echo "[INFO] Applying the cluster configuration, and showing the 'config.yaml'"
+  set -x
+  ./bin/rhtap-cli config --kube-config "$KUBECONFIG" --log-level=debug --get --create "$config_file"
+  set +x
+
+  echo "[INFO] Print out the content of 'values.yaml.tpl'"
+  set -x
   cat "$tpl_file"
-  ./bin/rhtap-cli deploy --timeout 35m --config "$config_file" --values-template "$tpl_file" --kube-config "$KUBECONFIG" --debug --log-level=debug
+  set +x
+
+  echo "[INFO] Running 'rhtap-cli deploy' command..."
+  set -x
+  ./bin/rhtap-cli deploy --timeout 35m --values-template "$tpl_file" --kube-config "$KUBECONFIG" --debug --log-level=debug
+  set +x
 
   homepage_url=https://$(kubectl -n rhtap-dh get route backstage-developer-hub -o  'jsonpath={.spec.host}')
   callback_url=https://$(kubectl -n rhtap-dh get route backstage-developer-hub -o  'jsonpath={.spec.host}')/api/auth/${auth_config}/handler/frame
   webhook_url=https://$(kubectl -n openshift-pipelines get route pipelines-as-code-controller -o 'jsonpath={.spec.host}')
 
-  echo "[INFO]homepage_url=$homepage_url"
-  echo "[INFO]callback_url=$callback_url"
-  echo "[INFO]webhook_url=$webhook_url"
+  echo "[INFO] homepage_url=$homepage_url"
+  echo "[INFO] callback_url=$callback_url"
+  echo "[INFO] webhook_url=$webhook_url"
 
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/chartfs"
-	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/constants"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/flags"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/k8s"
@@ -15,11 +14,11 @@ import (
 
 // RootCmd is the root command.
 type RootCmd struct {
-	cmd   *cobra.Command   // root command
-	flags *flags.Flags     // global flags
-	cfg   *config.Config   // installer configuration
-	cfs   *chartfs.ChartFS // embedded filesystem
-	kube  *k8s.Kube        // kubernetes client
+	cmd   *cobra.Command // root command
+	flags *flags.Flags   // global flags
+
+	cfs  *chartfs.ChartFS // embedded filesystem
+	kube *k8s.Kube        // kubernetes client
 }
 
 // Cmd exposes the root command, while instantiating the subcommand and their
@@ -27,11 +26,12 @@ type RootCmd struct {
 func (r *RootCmd) Cmd() *cobra.Command {
 	logger := r.flags.GetLogger(os.Stdout)
 
-	r.cmd.AddCommand(subcmd.NewIntegration(logger, r.cfg, r.kube))
+	r.cmd.AddCommand(subcmd.NewIntegration(logger, r.kube))
 
 	for _, sub := range []subcmd.Interface{
-		subcmd.NewDeploy(logger, r.flags, r.cfg, r.cfs, r.kube),
-		subcmd.NewTemplate(logger, r.flags, r.cfg, r.cfs, r.kube),
+		subcmd.NewConfig(logger, r.cfs, r.kube),
+		subcmd.NewDeploy(logger, r.flags, r.cfs, r.kube),
+		subcmd.NewTemplate(logger, r.flags, r.cfs, r.kube),
 		subcmd.NewInstaller(r.flags),
 	} {
 		r.cmd.AddCommand(subcmd.NewRunner(sub).Cmd())
@@ -48,23 +48,17 @@ func NewRootCmd() (*RootCmd, error) {
 		return nil, err
 	}
 
-	cfg := config.NewConfig(cfs)
 	r := &RootCmd{
 		flags: f,
 		cmd: &cobra.Command{
-			Use:   constants.AppName,
-			Short: "RHTAP Installer CLI",
-			PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-				return cfg.UnmarshalYAML()
-			},
+			Use:          constants.AppName,
+			Short:        "RHTAP Installer CLI",
 			SilenceUsage: true,
 		},
-		cfg:  cfg,
 		cfs:  cfs,
 		kube: k8s.NewKube(f),
 	}
 	p := r.cmd.PersistentFlags()
 	r.flags.PersistentFlags(p)
-	r.cfg.PersistentFlags(p)
 	return r, nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,8 +4,9 @@ import (
 	"log/slog"
 	"testing"
 
-	o "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/chartfs"
+
+	o "github.com/onsi/gomega"
 )
 
 func TestNewConfigFromFile(t *testing.T) {
@@ -38,5 +39,19 @@ func TestNewConfigFromFile(t *testing.T) {
 		g.Expect(err).To(o.Succeed())
 		g.Expect(feature).NotTo(o.BeNil())
 		g.Expect(feature.GetNamespace()).NotTo(o.BeEmpty())
+	})
+
+	t.Run("MarshalYAML and UnmarshalYAML", func(t *testing.T) {
+		payload, err := cfg.MarshalYAML()
+		g.Expect(err).To(o.Succeed())
+		g.Expect(string(payload)).To(o.ContainSubstring("rhtapCLI:"))
+
+		err = cfg.UnmarshalYAML()
+		g.Expect(err).To(o.Succeed())
+	})
+
+	t.Run("String", func(t *testing.T) {
+		payload := cfg.String()
+		g.Expect(string(payload)).To(o.ContainSubstring("rhtapCLI:"))
 	})
 }

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -1,0 +1,179 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/redhat-appstudio/rhtap-cli/pkg/k8s"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConfigMapManager the actor responsible for managing installer configuration in
+// the cluster.
+type ConfigMapManager struct {
+	kube *k8s.Kube // kubernetes client
+}
+
+const (
+	// Filename the default
+	Filename = "config.yaml"
+	// Label label selector to find the cluster's installer configuration.
+	Label = "rhtap-cli.redhat-appstudio.github.com/config"
+)
+
+var (
+	// ErrConfigMapNotFound when the configmap isn't created in the cluster.
+	ErrConfigMapNotFound = errors.New("cluster configmap not found")
+	// ErrMultipleConfigMapFound when the label selector find multiple resources.
+	ErrMultipleConfigMapFound = errors.New("multiple cluster configmaps found")
+	// ErrIncompleteConfigMap when the ConfigMap exists, but doesn't contain the
+	// expected payload.
+	ErrIncompleteConfigMap = errors.New("invalid configmap found in the cluster")
+)
+
+// selectorLabel returns the label selector.
+func (m *ConfigMapManager) selectorLabel() string {
+	return fmt.Sprintf("%s=true", Label)
+}
+
+// GetConfigMap retrieves the ConfigMap from the cluster, checking if a single
+// resource is present.
+func (m *ConfigMapManager) GetConfigMap(
+	ctx context.Context,
+) (*corev1.ConfigMap, error) {
+	coreClient, err := m.kube.CoreV1ClientSet("")
+	if err != nil {
+		return nil, nil
+	}
+
+	// Listing all ConfigMaps matching the label selector.
+	configMapList, err := coreClient.ConfigMaps("").List(ctx, metav1.ListOptions{
+		LabelSelector: m.selectorLabel(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// When no ConfigMaps matching criteria is found in the cluster.
+	if len(configMapList.Items) == 0 {
+		return nil, fmt.Errorf(
+			"%w: using label selector %q",
+			ErrConfigMapNotFound,
+			m.selectorLabel(),
+		)
+	}
+	// Also, important to error out when multiple ConfigMaps are present in the
+	// cluster. Collecting and printing out the resources found by the label
+	// selector.
+	if len(configMapList.Items) > 1 {
+		configMaps := []string{}
+		for _, cm := range configMapList.Items {
+			configMaps = append(
+				configMaps,
+				fmt.Sprintf("%s/%s", cm.GetNamespace(), cm.GetName()),
+			)
+		}
+		return nil, fmt.Errorf(
+			"%w: multiple configmaps found on namespace/name pairs: %v",
+			ErrMultipleConfigMapFound,
+			configMaps,
+		)
+	}
+	return &configMapList.Items[0], nil
+}
+
+// GetConfig retrieves configuration from a cluster's ConfigMap.
+func (m *ConfigMapManager) GetConfig(ctx context.Context) (*Config, error) {
+	configMap, err := m.GetConfigMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+	payload, ok := configMap.Data[Filename]
+	if !ok || len(payload) == 0 {
+		return nil, fmt.Errorf(
+			"%w: key %q not found in ConfigMap %s/%s",
+			ErrIncompleteConfigMap,
+			Filename,
+			configMap.GetNamespace(),
+			configMap.GetName(),
+		)
+	}
+
+	return NewConfigFromBytes([]byte(payload))
+}
+
+// configMapForConfig generate a ConfigMap resource based on informed Config.
+func (m *ConfigMapManager) configMapForConfig(
+	cfg *Config,
+) (*corev1.ConfigMap, error) {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhtap-cli-config",
+			Namespace: cfg.Installer.Namespace,
+			Labels: map[string]string{
+				Label: "true",
+			},
+		},
+		Data: map[string]string{
+			Filename: cfg.String(),
+		},
+	}, nil
+}
+
+// Create Bootstrap a ConfigMap with the provided configuration.
+func (m *ConfigMapManager) Create(ctx context.Context, cfg *Config) error {
+	cm, err := m.configMapForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	coreClient, err := m.kube.CoreV1ClientSet(cfg.Installer.Namespace)
+	if err != nil {
+		return nil
+	}
+	_, err = coreClient.
+		ConfigMaps(cfg.Installer.Namespace).
+		Create(ctx, cm, metav1.CreateOptions{})
+	return err
+}
+
+// Update updates a ConfigMap with informed configuration.
+func (m *ConfigMapManager) Update(ctx context.Context, cfg *Config) error {
+	cm, err := m.configMapForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	coreClient, err := m.kube.CoreV1ClientSet(cfg.Installer.Namespace)
+	if err != nil {
+		return nil
+	}
+	_, err = coreClient.
+		ConfigMaps(cfg.Installer.Namespace).
+		Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}
+
+// Delete find and delete the ConfigMap from the cluster.
+func (m *ConfigMapManager) Delete(ctx context.Context) error {
+	cm, err := m.GetConfigMap(ctx)
+	if err != nil {
+		return err
+	}
+
+	coreClient, err := m.kube.CoreV1ClientSet(cm.GetNamespace())
+	if err != nil {
+		return nil
+	}
+
+	return coreClient.ConfigMaps(cm.GetNamespace()).
+		Delete(ctx, cm.GetName(), metav1.DeleteOptions{})
+}
+
+// NewConfigMapManager instantiates the ConfigMapManager.
+func NewConfigMapManager(kube *k8s.Kube) *ConfigMapManager {
+	return &ConfigMapManager{
+		kube: kube,
+	}
+}

--- a/pkg/integrations/bitbucket.go
+++ b/pkg/integrations/bitbucket.go
@@ -19,9 +19,8 @@ const defaultPublicBitBucketHost = "bitbucket.org"
 
 // BitBucketIntegration represents the RHTAP BitBucket integration.
 type BitBucketIntegration struct {
-	logger *slog.Logger   // application logger
-	cfg    *config.Config // installer configuration
-	kube   *k8s.Kube      // kubernetes client
+	logger *slog.Logger // application logger
+	kube   *k8s.Kube    // kubernetes client
 
 	force bool // overwrite the existing secret
 
@@ -67,31 +66,37 @@ func (g *BitBucketIntegration) Validate() error {
 	return nil
 }
 
-// EnsureNamespace ensures the namespace needed for the BitBucket integration secret
-// is created on the cluster.
-func (g *BitBucketIntegration) EnsureNamespace(ctx context.Context) error {
+// EnsureNamespace ensures the namespace needed for the BitBucket integration
+// secret is created on the cluster.
+func (g *BitBucketIntegration) EnsureNamespace(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		g.log(),
 		g.kube,
-		g.cfg.Installer.Namespace,
+		cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
-func (g *BitBucketIntegration) secretName() types.NamespacedName {
+func (g *BitBucketIntegration) secretName(cfg *config.Config) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: g.cfg.Installer.Namespace,
+		Namespace: cfg.Installer.Namespace,
 		Name:      "rhtap-bitbucket-integration",
 	}
 }
 
 // prepareSecret checks if the secret already exists, and if so, it will delete
 // the secret if the force flag is enabled.
-func (g *BitBucketIntegration) prepareSecret(ctx context.Context) error {
+func (g *BitBucketIntegration) prepareSecret(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	g.log().Debug("Checking if integration secret exists")
-	exists, err := k8s.SecretExists(ctx, g.kube, g.secretName())
+	exists, err := k8s.SecretExists(ctx, g.kube, g.secretName(cfg))
 	if err != nil {
 		return err
 	}
@@ -102,20 +107,21 @@ func (g *BitBucketIntegration) prepareSecret(ctx context.Context) error {
 	if !g.force {
 		g.log().Debug("Integration secret already exists")
 		return fmt.Errorf("%w: %s",
-			ErrSecretAlreadyExists, g.secretName().String())
+			ErrSecretAlreadyExists, g.secretName(cfg).String())
 	}
 	g.log().Debug("Integration secret already exists, recreating it")
-	return k8s.DeleteSecret(ctx, g.kube, g.secretName())
+	return k8s.DeleteSecret(ctx, g.kube, g.secretName(cfg))
 }
 
 // store creates the secret with the integration data.
 func (g *BitBucketIntegration) store(
 	ctx context.Context,
+	cfg *config.Config,
 ) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: g.secretName().Namespace,
-			Name:      g.secretName().Name,
+			Namespace: g.secretName(cfg).Namespace,
+			Name:      g.secretName(cfg).Name,
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -130,11 +136,11 @@ func (g *BitBucketIntegration) store(
 	)
 
 	logger.Debug("Creating integration secret")
-	coreClient, err := g.kube.CoreV1ClientSet(g.secretName().Namespace)
+	coreClient, err := g.kube.CoreV1ClientSet(g.secretName(cfg).Namespace)
 	if err != nil {
 		return err
 	}
-	_, err = coreClient.Secrets(g.secretName().Namespace).
+	_, err = coreClient.Secrets(g.secretName(cfg).Namespace).
 		Create(ctx, secret, metav1.CreateOptions{})
 	if err == nil {
 		logger.Info("Integration secret created successfully!")
@@ -143,23 +149,24 @@ func (g *BitBucketIntegration) store(
 }
 
 // Create creates the BitBucket integration Kubernetes secret.
-func (g *BitBucketIntegration) Create(ctx context.Context) error {
+func (g *BitBucketIntegration) Create(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	logger := g.log()
 	logger.Info("Inspecting the cluster for an existing BitBucket integration secret")
-	if err := g.prepareSecret(ctx); err != nil {
+	if err := g.prepareSecret(ctx, cfg); err != nil {
 		return err
 	}
-	return g.store(ctx)
+	return g.store(ctx, cfg)
 }
 
 func NewBitBucketIntegration(
 	logger *slog.Logger,
-	cfg *config.Config,
 	kube *k8s.Kube,
 ) *BitBucketIntegration {
 	return &BitBucketIntegration{
 		logger: logger,
-		cfg:    cfg,
 		kube:   kube,
 
 		force:       false,

--- a/pkg/integrations/gitlab.go
+++ b/pkg/integrations/gitlab.go
@@ -19,9 +19,8 @@ const defaultPublicGitLabHost = "gitlab.com"
 
 // GitLabIntegration represents the RHTAP GitLab integration.
 type GitLabIntegration struct {
-	logger *slog.Logger   // application logger
-	cfg    *config.Config // installer configuration
-	kube   *k8s.Kube      // kubernetes client
+	logger *slog.Logger // application logger
+	kube   *k8s.Kube    // kubernetes client
 
 	force bool // overwrite the existing secret
 
@@ -83,29 +82,35 @@ func (g *GitLabIntegration) Validate() error {
 
 // EnsureNamespace ensures the namespace needed for the GitLab integration secret
 // is created on the cluster.
-func (g *GitLabIntegration) EnsureNamespace(ctx context.Context) error {
+func (g *GitLabIntegration) EnsureNamespace(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		g.log(),
 		g.kube,
-		g.cfg.Installer.Namespace,
+		cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
-func (g *GitLabIntegration) secretName() types.NamespacedName {
+func (g *GitLabIntegration) secretName(cfg *config.Config) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: g.cfg.Installer.Namespace,
+		Namespace: cfg.Installer.Namespace,
 		Name:      "rhtap-gitlab-integration",
 	}
 }
 
 // prepareSecret checks if the secret already exists, and if so, it will delete
 // the secret if the force flag is enabled.
-func (g *GitLabIntegration) prepareSecret(ctx context.Context) error {
+func (g *GitLabIntegration) prepareSecret(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	g.log().Debug("Checking if integration secret exists")
-	exists, err := k8s.SecretExists(ctx, g.kube, g.secretName())
+	exists, err := k8s.SecretExists(ctx, g.kube, g.secretName(cfg))
 	if err != nil {
 		return err
 	}
@@ -116,20 +121,21 @@ func (g *GitLabIntegration) prepareSecret(ctx context.Context) error {
 	if !g.force {
 		g.log().Debug("Integration secret already exists")
 		return fmt.Errorf("%w: %s",
-			ErrSecretAlreadyExists, g.secretName().String())
+			ErrSecretAlreadyExists, g.secretName(cfg).String())
 	}
 	g.log().Debug("Integration secret already exists, recreating it")
-	return k8s.DeleteSecret(ctx, g.kube, g.secretName())
+	return k8s.DeleteSecret(ctx, g.kube, g.secretName(cfg))
 }
 
 // store creates the secret with the integration data.
 func (g *GitLabIntegration) store(
 	ctx context.Context,
+	cfg *config.Config,
 ) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: g.secretName().Namespace,
-			Name:      g.secretName().Name,
+			Namespace: g.secretName(cfg).Namespace,
+			Name:      g.secretName(cfg).Name,
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -146,11 +152,11 @@ func (g *GitLabIntegration) store(
 	)
 
 	logger.Debug("Creating integration secret")
-	coreClient, err := g.kube.CoreV1ClientSet(g.secretName().Namespace)
+	coreClient, err := g.kube.CoreV1ClientSet(g.secretName(cfg).Namespace)
 	if err != nil {
 		return err
 	}
-	_, err = coreClient.Secrets(g.secretName().Namespace).
+	_, err = coreClient.Secrets(g.secretName(cfg).Namespace).
 		Create(ctx, secret, metav1.CreateOptions{})
 	if err == nil {
 		logger.Info("Integration secret created successfully!")
@@ -159,23 +165,24 @@ func (g *GitLabIntegration) store(
 }
 
 // Create creates the GitLab integration Kubernetes secret.
-func (g *GitLabIntegration) Create(ctx context.Context) error {
+func (g *GitLabIntegration) Create(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	logger := g.log()
 	logger.Info("Inspecting the cluster for an existing GitLab integration secret")
-	if err := g.prepareSecret(ctx); err != nil {
+	if err := g.prepareSecret(ctx, cfg); err != nil {
 		return err
 	}
-	return g.store(ctx)
+	return g.store(ctx, cfg)
 }
 
 func NewGitLabIntegration(
 	logger *slog.Logger,
-	cfg *config.Config,
 	kube *k8s.Kube,
 ) *GitLabIntegration {
 	return &GitLabIntegration{
 		logger: logger,
-		cfg:    cfg,
 		kube:   kube,
 
 		force:        false,

--- a/pkg/integrations/jenkins.go
+++ b/pkg/integrations/jenkins.go
@@ -18,9 +18,8 @@ import (
 
 // JenkinsIntegration represents the RHTAP Jenkins integration.
 type JenkinsIntegration struct {
-	logger *slog.Logger   // application logger
-	cfg    *config.Config // installer configuration
-	kube   *k8s.Kube      // kubernetes client
+	logger *slog.Logger // application logger
+	kube   *k8s.Kube    // kubernetes client
 
 	force bool // overwrite the existing secret
 
@@ -76,29 +75,39 @@ func (j *JenkinsIntegration) Validate() error {
 
 // EnsureNamespace ensures the namespace needed for the Jenkins integration secret
 // is created on the cluster.
-func (j *JenkinsIntegration) EnsureNamespace(ctx context.Context) error {
+func (j *JenkinsIntegration) EnsureNamespace(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
+	feature, err := cfg.GetFeature(config.RedHatDeveloperHub)
+	if err != nil {
+		return err
+	}
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		j.log(),
 		j.kube,
-		j.cfg.Installer.Namespace,
+		feature.GetNamespace(),
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
-func (j *JenkinsIntegration) secretName() types.NamespacedName {
+func (j *JenkinsIntegration) secretName(cfg *config.Config) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: j.cfg.Installer.Namespace,
+		Namespace: cfg.Installer.Namespace,
 		Name:      "rhtap-jenkins-integration",
 	}
 }
 
 // prepareSecret checks if the secret already exists, and if so, it will delete
 // the secret if the force flag is enabled.
-func (j *JenkinsIntegration) prepareSecret(ctx context.Context) error {
+func (j *JenkinsIntegration) prepareSecret(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	j.log().Debug("Checking if integration secret exists")
-	exists, err := k8s.SecretExists(ctx, j.kube, j.secretName())
+	exists, err := k8s.SecretExists(ctx, j.kube, j.secretName(cfg))
 	if err != nil {
 		return err
 	}
@@ -109,20 +118,21 @@ func (j *JenkinsIntegration) prepareSecret(ctx context.Context) error {
 	if !j.force {
 		j.log().Debug("Integration secret already exists")
 		return fmt.Errorf("%w: %s",
-			ErrSecretAlreadyExists, j.secretName().String())
+			ErrSecretAlreadyExists, j.secretName(cfg).String())
 	}
 	j.log().Debug("Integration secret already exists, recreating it")
-	return k8s.DeleteSecret(ctx, j.kube, j.secretName())
+	return k8s.DeleteSecret(ctx, j.kube, j.secretName(cfg))
 }
 
 // store creates the secret with the integration data.
 func (j *JenkinsIntegration) store(
 	ctx context.Context,
+	cfg *config.Config,
 ) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: j.secretName().Namespace,
-			Name:      j.secretName().Name,
+			Namespace: j.secretName(cfg).Namespace,
+			Name:      j.secretName(cfg).Name,
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -137,11 +147,11 @@ func (j *JenkinsIntegration) store(
 	)
 
 	logger.Debug("Creating integration secret")
-	coreClient, err := j.kube.CoreV1ClientSet(j.secretName().Namespace)
+	coreClient, err := j.kube.CoreV1ClientSet(j.secretName(cfg).Namespace)
 	if err != nil {
 		return err
 	}
-	_, err = coreClient.Secrets(j.secretName().Namespace).
+	_, err = coreClient.Secrets(j.secretName(cfg).Namespace).
 		Create(ctx, secret, metav1.CreateOptions{})
 	if err == nil {
 		logger.Info("Integration secret created successfully!")
@@ -150,23 +160,24 @@ func (j *JenkinsIntegration) store(
 }
 
 // Create creates the Jenkins integration Kubernetes secret.
-func (j *JenkinsIntegration) Create(ctx context.Context) error {
+func (j *JenkinsIntegration) Create(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	logger := j.log()
 	logger.Info("Inspecting the cluster for an existing Jenkins integration secret")
-	if err := j.prepareSecret(ctx); err != nil {
+	if err := j.prepareSecret(ctx, cfg); err != nil {
 		return err
 	}
-	return j.store(ctx)
+	return j.store(ctx, cfg)
 }
 
 func NewJenkinsIntegration(
 	logger *slog.Logger,
-	cfg *config.Config,
 	kube *k8s.Kube,
 ) *JenkinsIntegration {
 	return &JenkinsIntegration{
 		logger: logger,
-		cfg:    cfg,
 		kube:   kube,
 
 		force:    false,

--- a/pkg/integrations/trustification.go
+++ b/pkg/integrations/trustification.go
@@ -17,9 +17,8 @@ import (
 
 // TrustificationIntegration represents the RHTAP Trustification integration.
 type TrustificationIntegration struct {
-	logger *slog.Logger   // application logger
-	cfg    *config.Config // installer configuration
-	kube   *k8s.Kube      // kubernetes client
+	logger *slog.Logger // application logger
+	kube   *k8s.Kube    // kubernetes client
 
 	force bool // overwrite the existing secret
 
@@ -27,7 +26,7 @@ type TrustificationIntegration struct {
 	oidcIssuerURL             string // URL of the OIDC token issuer
 	oidcClientId              string // OIDC client ID
 	oidcClientSecret          string // OIDC client secret
-	supportedCyclonedxVersion string // If specified the SBOM will be converted to the supported version before uploading.
+	supportedCycloneDXVersion string // CycloneDX supported version.
 }
 
 // PersistentFlags sets the persistent flags for the Trustification integration.
@@ -43,8 +42,8 @@ func (i *TrustificationIntegration) PersistentFlags(p *pflag.FlagSet) {
 		"OIDC client ID")
 	p.StringVar(&i.oidcClientSecret, "oidc-client-secret", i.oidcClientSecret,
 		"OIDC client secret")
-	p.StringVar(&i.supportedCyclonedxVersion, "supported-cyclonedx-version", i.supportedCyclonedxVersion,
-		"If the SBOM uses a higher CycloneDX version, syft convert to the supported version before uploading.")
+	p.StringVar(&i.supportedCycloneDXVersion, "supported-cyclonedx-version", i.supportedCycloneDXVersion,
+		"If the SBOM uses a higher CycloneDX version, Syft convert to the supported version before uploading.")
 }
 
 // log logger with contextual information.
@@ -55,7 +54,7 @@ func (i *TrustificationIntegration) log() *slog.Logger {
 		"oidcIssuerURL", i.oidcIssuerURL,
 		"oidcClientId", i.oidcClientId,
 		"oidcClientSecret-len", len(i.oidcClientSecret),
-		"supportedCyclonedxVersion", i.supportedCyclonedxVersion,
+		"supportedCyclonedxVersion", i.supportedCycloneDXVersion,
 	)
 }
 
@@ -84,29 +83,37 @@ func (i *TrustificationIntegration) Validate() error {
 
 // EnsureNamespace ensures the namespace needed for the Trustification integration secret
 // is created on the cluster.
-func (i *TrustificationIntegration) EnsureNamespace(ctx context.Context) error {
+func (i *TrustificationIntegration) EnsureNamespace(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	return k8s.EnsureOpenShiftProject(
 		ctx,
 		i.log(),
 		i.kube,
-		i.cfg.Installer.Namespace,
+		cfg.Installer.Namespace,
 	)
 }
 
 // secretName returns the secret name for the integration. The name is "lazy"
 // generated to make sure configuration is already loaded.
-func (i *TrustificationIntegration) secretName() types.NamespacedName {
+func (i *TrustificationIntegration) secretName(
+	cfg *config.Config,
+) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: i.cfg.Installer.Namespace,
+		Namespace: cfg.Installer.Namespace,
 		Name:      "rhtap-trustification-integration",
 	}
 }
 
 // prepareSecret checks if the secret already exists, and if so, it will delete
 // the secret if the force flag is enabled.
-func (i *TrustificationIntegration) prepareSecret(ctx context.Context) error {
+func (i *TrustificationIntegration) prepareSecret(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	i.log().Debug("Checking if integration secret exists")
-	exists, err := k8s.SecretExists(ctx, i.kube, i.secretName())
+	exists, err := k8s.SecretExists(ctx, i.kube, i.secretName(cfg))
 	if err != nil {
 		return err
 	}
@@ -117,20 +124,21 @@ func (i *TrustificationIntegration) prepareSecret(ctx context.Context) error {
 	if !i.force {
 		i.log().Debug("Integration secret already exists")
 		return fmt.Errorf("%w: %s",
-			ErrSecretAlreadyExists, i.secretName().String())
+			ErrSecretAlreadyExists, i.secretName(cfg).String())
 	}
 	i.log().Debug("Integration secret already exists, recreating it")
-	return k8s.DeleteSecret(ctx, i.kube, i.secretName())
+	return k8s.DeleteSecret(ctx, i.kube, i.secretName(cfg))
 }
 
 // store creates the secret with the integration data.
 func (i *TrustificationIntegration) store(
 	ctx context.Context,
+	cfg *config.Config,
 ) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: i.secretName().Namespace,
-			Name:      i.secretName().Name,
+			Namespace: i.secretName(cfg).Namespace,
+			Name:      i.secretName(cfg).Name,
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -138,7 +146,7 @@ func (i *TrustificationIntegration) store(
 			"oidc_client_id":              []byte(i.oidcClientId),
 			"oidc_client_secret":          []byte(i.oidcClientSecret),
 			"oidc_issuer_url":             []byte(i.oidcIssuerURL),
-			"supported_cyclonedx_version": []byte(i.supportedCyclonedxVersion),
+			"supported_cyclonedx_version": []byte(i.supportedCycloneDXVersion),
 		},
 	}
 	logger := i.log().With(
@@ -147,11 +155,11 @@ func (i *TrustificationIntegration) store(
 	)
 
 	logger.Debug("Creating integration secret")
-	coreClient, err := i.kube.CoreV1ClientSet(i.secretName().Namespace)
+	coreClient, err := i.kube.CoreV1ClientSet(i.secretName(cfg).Namespace)
 	if err != nil {
 		return err
 	}
-	_, err = coreClient.Secrets(i.secretName().Namespace).
+	_, err = coreClient.Secrets(i.secretName(cfg).Namespace).
 		Create(ctx, secret, metav1.CreateOptions{})
 	if err == nil {
 		logger.Info("Integration secret created successfully!")
@@ -160,23 +168,24 @@ func (i *TrustificationIntegration) store(
 }
 
 // Create creates the Trustification integration Kubernetes secret.
-func (i *TrustificationIntegration) Create(ctx context.Context) error {
+func (i *TrustificationIntegration) Create(
+	ctx context.Context,
+	cfg *config.Config,
+) error {
 	logger := i.log()
 	logger.Info("Inspecting the cluster for an existing Trustification integration secret")
-	if err := i.prepareSecret(ctx); err != nil {
+	if err := i.prepareSecret(ctx, cfg); err != nil {
 		return err
 	}
-	return i.store(ctx)
+	return i.store(ctx, cfg)
 }
 
 func NewTrustificationIntegration(
 	logger *slog.Logger,
-	cfg *config.Config,
 	kube *k8s.Kube,
 ) *TrustificationIntegration {
 	return &TrustificationIntegration{
 		logger: logger,
-		cfg:    cfg,
 		kube:   kube,
 
 		force:                     false,
@@ -184,6 +193,6 @@ func NewTrustificationIntegration(
 		oidcClientId:              "",
 		oidcClientSecret:          "",
 		oidcIssuerURL:             "",
-		supportedCyclonedxVersion: "",
+		supportedCycloneDXVersion: "",
 	}
 }

--- a/pkg/subcmd/config.go
+++ b/pkg/subcmd/config.go
@@ -1,0 +1,221 @@
+package subcmd
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/redhat-appstudio/rhtap-cli/pkg/chartfs"
+	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
+	"github.com/redhat-appstudio/rhtap-cli/pkg/k8s"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+type Config struct {
+	cmd    *cobra.Command   // cobra command
+	logger *slog.Logger     // application logger
+	cfs    *chartfs.ChartFS // embedded filesystem
+	kube   *k8s.Kube        // kubernetes client
+
+	manager    *config.ConfigMapManager // cluster configuration manager
+	configPath string                   // configuration file relative path
+
+	create bool // create a new configuration
+	force  bool // overrides existing configuration
+	get    bool // show the current configuration
+	delete bool // delete the current configuration
+}
+
+var _ Interface = &Config{}
+
+const configDesc = `
+Manages installer's cluster configuration. Before "rhtap-cli deploy", you need to
+create a cluster configuration, responsible to define all installation settings
+for the whole Kubernetes cluster.
+
+You can use the embedded executable configuration, or inform your own local
+configuration file path to "--create". Use "--force" to update existing
+configuration.
+
+The "--create" flag reflects the creation of a new configuration while, "--force"
+is meant to amend the cluster configuration and overwrite changes to installer's
+defaults.
+
+This subcommand ensures a single cluster configuration is applied, identified and
+retrieved using a unique label selector.
+`
+
+// Cmd exposes the cobra instance.
+func (c *Config) Cmd() *cobra.Command {
+	return c.cmd
+}
+
+// log returns a decorated logger.
+func (c *Config) log() *slog.Logger {
+	return c.logger.With("config-path", c.configPath)
+}
+
+// PersistentFlags injects the sub-command flags.
+func (c *Config) PersistentFlags(p *pflag.FlagSet) {
+	p.BoolVarP(
+		&c.create,
+		"create",
+		"c",
+		false,
+		"Create new cluster configuration",
+	)
+	p.BoolVarP(
+		&c.force,
+		"force",
+		"f",
+		false,
+		"Update an existing cluster configuration",
+	)
+	p.BoolVarP(
+		&c.get,
+		"get",
+		"g",
+		false,
+		"Show the current cluster configuration",
+	)
+	p.BoolVarP(
+		&c.delete,
+		"delete",
+		"d",
+		false,
+		"Delete the current cluster configuration",
+	)
+}
+
+// validateFlags validates the flags passed to the subcommand.
+func (c *Config) validateFlags() error {
+	if c.get && c.delete {
+		return fmt.Errorf("cannot get and delete at the same time")
+	}
+	if !c.create && !c.force && !c.get && !c.delete {
+		return fmt.Errorf("either apply, update, get or delete must be set")
+	}
+	return nil
+}
+
+// Complete inspect the context to determine the path of the configuration file,
+// or uses the embedded payload, makes sure the args are adequate.
+func (c *Config) Complete(args []string) error {
+	// It should return an error if more than a single argument is informed.
+	if len(args) > 1 {
+		return fmt.Errorf("unexpected arguments: %v", args)
+	}
+	// It should inform a configuration file only for apply and update flags.
+	if (c.get || c.delete) && !c.create && len(args) > 0 {
+		return fmt.Errorf(
+			"configuration file is only permitted for --create flag")
+	}
+	// Storing the configuration file reference, when empty using the embedded
+	// default configuration path.
+	if len(args) == 1 {
+		c.configPath = args[0]
+		c.log().Debug("Using local configuration file")
+	} else {
+		c.configPath = config.DefaultRelativeConfigPath
+		c.log().Debug("Using embedded configuration file, default settings.")
+	}
+	return nil
+}
+
+// Validate make sure all items are in place.
+func (c *Config) Validate() error {
+	if c.create && c.configPath == "" {
+		return fmt.Errorf("configuration file is not informed")
+	}
+	if err := c.validateFlags(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// runCreate runs create action, makes sure a new configuration is applied in the
+// cluster and update when using the --force flag.
+func (c *Config) runCreate() error {
+	c.log().Debug("Loading configuration from file")
+	cfg, err := config.NewConfigFromFile(c.cfs, c.configPath)
+	if err != nil {
+		return err
+	}
+
+	c.log().Debug("Making sure the OpenShift project is created")
+	if err = k8s.EnsureOpenShiftProject(
+		c.cmd.Context(),
+		c.log(),
+		c.kube,
+		cfg.Installer.Namespace,
+	); err != nil {
+		return err
+	}
+
+	c.log().Debug("Applying the new configuration in the cluster")
+	if err = c.manager.Create(c.cmd.Context(), cfg); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			if c.force {
+				c.log().Debug("Updating the configuration in the cluster")
+				return c.manager.Update(c.cmd.Context(), cfg)
+			} else {
+				return fmt.Errorf(
+					"the configuration already exists, use --force to amend it")
+			}
+		}
+	}
+	return err
+}
+
+// Run runs the subcommand main action, checks which flags are enabled to interact
+// with cluster's configuration.
+func (c *Config) Run() error {
+	var err error
+	switch {
+	case c.create:
+		if err = c.runCreate(); err != nil {
+			return err
+		}
+	case c.delete:
+		if err = c.manager.Delete(c.cmd.Context()); err != nil {
+			return err
+		}
+	}
+
+	if c.get {
+		c.log().Debug("Retrieving the cluster configuration")
+		cfg, err := c.manager.GetConfig(c.cmd.Context())
+		if err != nil {
+			return err
+		}
+		c.log().Debug("Formatting the configuration as string")
+		fmt.Print(cfg.String())
+	}
+	return nil
+}
+
+// NewConfig instantiates the "config" subcommand.
+func NewConfig(
+	logger *slog.Logger,
+	cfs *chartfs.ChartFS,
+	kube *k8s.Kube,
+) Interface {
+	c := &Config{
+		cmd: &cobra.Command{
+			Use:          "config [flags] [path/to/config.yaml]",
+			Short:        "Manages installer's cluster configuration",
+			Long:         configDesc,
+			SilenceUsage: true,
+		},
+		logger:  logger.WithGroup("config"),
+		cfs:     cfs,
+		kube:    kube,
+		manager: config.NewConfigMapManager(kube),
+	}
+
+	c.PersistentFlags(c.cmd.PersistentFlags())
+
+	return c
+}

--- a/pkg/subcmd/config_helper.go
+++ b/pkg/subcmd/config_helper.go
@@ -1,0 +1,28 @@
+package subcmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
+	"github.com/redhat-appstudio/rhtap-cli/pkg/k8s"
+)
+
+func bootstrapConfig(
+	ctx context.Context,
+	kube *k8s.Kube,
+) (*config.Config, error) {
+	mgr := config.NewConfigMapManager(kube)
+	cfg, err := mgr.GetConfig(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, `
+Unable to find the configuration in the cluster, or the configuration is invalid.
+Please refer to the subcommand "rhtap-cli config" to manage installer's
+configuration for the target cluster.
+
+	$ rhtap-cli config --help
+		`)
+	}
+	return cfg, err
+}

--- a/pkg/subcmd/deploy.go
+++ b/pkg/subcmd/deploy.go
@@ -61,6 +61,10 @@ func (d *Deploy) log() *slog.Logger {
 
 // Complete verifies the object is complete.
 func (d *Deploy) Complete(args []string) error {
+	var err error
+	if d.cfg, err = bootstrapConfig(d.cmd.Context(), d.kube); err != nil {
+		return err
+	}
 	if len(args) == 1 {
 		d.chartPath = args[0]
 	}
@@ -145,7 +149,6 @@ func (d *Deploy) Run() error {
 func NewDeploy(
 	logger *slog.Logger,
 	f *flags.Flags,
-	cfg *config.Config,
 	cfs *chartfs.ChartFS,
 	kube *k8s.Kube,
 ) Interface {
@@ -158,7 +161,6 @@ func NewDeploy(
 		},
 		logger:    logger.WithGroup("deploy"),
 		flags:     f,
-		cfg:       cfg,
 		cfs:       cfs,
 		kube:      kube,
 		chartPath: "",

--- a/pkg/subcmd/integration.go
+++ b/pkg/subcmd/integration.go
@@ -3,30 +3,26 @@ package subcmd
 import (
 	"log/slog"
 
-	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
 	"github.com/redhat-appstudio/rhtap-cli/pkg/k8s"
 	"github.com/spf13/cobra"
 )
 
-func NewIntegration(
-	logger *slog.Logger,
-	cfg *config.Config,
-	kube *k8s.Kube,
-) *cobra.Command {
+func NewIntegration(logger *slog.Logger, kube *k8s.Kube) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "integration <type>",
 		Short: "Configures an external service provider for RHTAP",
 	}
 
-	cmd.AddCommand(NewRunner(NewIntegrationACS(logger, cfg, kube)).Cmd())
-	cmd.AddCommand(NewRunner(NewIntegrationArtifactory(logger, cfg, kube)).Cmd())
-	cmd.AddCommand(NewRunner(NewIntegrationAzure(logger, cfg, kube)).Cmd())
-	cmd.AddCommand(NewRunner(NewIntegrationBitBucket(logger, cfg, kube)).Cmd())
-	cmd.AddCommand(NewRunner(NewIntegrationGitHubApp(logger, cfg, kube)).Cmd())
-	cmd.AddCommand(NewRunner(NewIntegrationGitLab(logger, cfg, kube)).Cmd())
-	cmd.AddCommand(NewRunner(NewIntegrationJenkins(logger, cfg, kube)).Cmd())
-	cmd.AddCommand(NewRunner(NewIntegrationNexus(logger, cfg, kube)).Cmd())
-	cmd.AddCommand(NewRunner(NewIntegrationQuay(logger, cfg, kube)).Cmd())
-	cmd.AddCommand(NewRunner(NewIntegrationTrustification(logger, cfg, kube)).Cmd())
+	cmd.AddCommand(NewRunner(NewIntegrationACS(logger, kube)).Cmd())
+	cmd.AddCommand(NewRunner(NewIntegrationArtifactory(logger, kube)).Cmd())
+	cmd.AddCommand(NewRunner(NewIntegrationAzure(logger, kube)).Cmd())
+	cmd.AddCommand(NewRunner(NewIntegrationBitBucket(logger, kube)).Cmd())
+	cmd.AddCommand(NewRunner(NewIntegrationGitHubApp(logger, kube)).Cmd())
+	cmd.AddCommand(NewRunner(NewIntegrationGitLab(logger, kube)).Cmd())
+	cmd.AddCommand(NewRunner(NewIntegrationJenkins(logger, kube)).Cmd())
+	cmd.AddCommand(NewRunner(NewIntegrationNexus(logger, kube)).Cmd())
+	cmd.AddCommand(NewRunner(NewIntegrationQuay(logger, kube)).Cmd())
+	cmd.AddCommand(NewRunner(NewIntegrationTrustification(logger, kube)).Cmd())
+
 	return cmd
 }

--- a/pkg/subcmd/integration_trustification.go
+++ b/pkg/subcmd/integration_trustification.go
@@ -45,7 +45,9 @@ func (d *IntegrationTrustification) Cmd() *cobra.Command {
 
 // Complete is a no-op in this case.
 func (d *IntegrationTrustification) Complete(args []string) error {
-	return nil
+	var err error
+	d.cfg, err = bootstrapConfig(d.cmd.Context(), d.kube)
+	return err
 }
 
 // Validate checks if the required configuration is set.
@@ -62,20 +64,21 @@ func (d *IntegrationTrustification) Validate() error {
 
 // Run creates or updates the Trustification integration secret.
 func (d *IntegrationTrustification) Run() error {
-	if err := d.trustificationIntegration.EnsureNamespace(d.cmd.Context()); err != nil {
+	err := d.trustificationIntegration.EnsureNamespace(d.cmd.Context(), d.cfg)
+	if err != nil {
 		return err
 	}
-	return d.trustificationIntegration.Create(d.cmd.Context())
+	return d.trustificationIntegration.Create(d.cmd.Context(), d.cfg)
 }
 
-// NewIntegrationTrustification creates the sub-command for the "integration trustification"
-// responsible to manage the RHTAP integrations with the Trustification service.
+// NewIntegrationTrustification creates the sub-command for the "integration
+// trustification" responsible to manage the RHTAP integrations with the
+// Trustification service.
 func NewIntegrationTrustification(
 	logger *slog.Logger,
-	cfg *config.Config,
 	kube *k8s.Kube,
 ) *IntegrationTrustification {
-	trustificationIntegration := integrations.NewTrustificationIntegration(logger, cfg, kube)
+	trustificationIntegration := integrations.NewTrustificationIntegration(logger, kube)
 
 	d := &IntegrationTrustification{
 		cmd: &cobra.Command{
@@ -86,7 +89,6 @@ func NewIntegrationTrustification(
 		},
 
 		logger: logger,
-		cfg:    cfg,
 		kube:   kube,
 
 		trustificationIntegration: trustificationIntegration,

--- a/pkg/subcmd/template.go
+++ b/pkg/subcmd/template.go
@@ -154,7 +154,6 @@ func (t *Template) Run() error {
 func NewTemplate(
 	logger *slog.Logger,
 	f *flags.Flags,
-	cfg *config.Config,
 	cfs *chartfs.ChartFS,
 	kube *k8s.Kube,
 ) *Template {
@@ -167,7 +166,6 @@ func NewTemplate(
 		},
 		logger:        logger.WithGroup("template"),
 		flags:         f,
-		cfg:           cfg,
 		cfs:           cfs,
 		kube:          kube,
 		dep:           config.Dependency{Namespace: "default"},


### PR DESCRIPTION
This change allows all cluster administrators to rely on a single configuration.

Introduces the `rhtap-cli config` subcommand, responsible for managing a unique installer's configuration in the cluster.

The configuration is then used from the cluster for all other subcommands, thus it becomes the first step on deploying RHTAP.