### PR TITLE
Wait for starting pipelines in separate loop

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -182,55 +182,9 @@ spec:
               #Serialize plrs array to be able to export it as var
               export PIPELINERUNS_ARRAY_SERIALIZED="${PIPELINERUNS_ARRAY[*]}"
 
-              waitFor "! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null" "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
-              waitFor "[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]" "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
+              waitFor '! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null' "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
+              waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]'' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
 
-              # Wait for all PLRs to start
-              # timeout --foreground 120m /bin/bash -c '
-              #     #deserialize plrs array
-              #     read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
-              #     while true; do
-              #       PIPELINES_STARTING=false
-              #       for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-              #         if ! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null; then
-              #           #Not started yet
-              #           PIPELINES_STARTING=true
-              #           break
-              #         fi
-              #       done
-              #       it $PIPELINES_STARTING ; then
-              #         echo "Pipelines are still starting. Waiting 1 minute"
-              #         sleep 60
-              #       else
-              #         echo "All pipelines have started"
-              #         break
-              #       fi
-              #     done
-              # '
-
-              # Wait for all PLRs to finish
-              # timeout --foreground 120m /bin/bash -c '
-              #     #deserialize plrs array
-              #     read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
-              #     echo "${PIPELINERUNS_ARRAY[*]}"
-              #     while true; do
-              #       ARE_PIPELINES_RUNNING=false
-              #       for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-              #         if ! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null || [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]; then
-              #           #something is still running. Break this cycle and wait one minute.
-              #           ARE_PIPELINES_RUNNING=true
-              #           break
-              #         fi
-              #       done
-              #       if $ARE_PIPELINES_RUNNING ; then
-              #         echo "Nested pipelines are still running. Waiting 1 minute"
-              #         sleep 60
-              #       else
-              #         echo "All nested pipelines finished"
-              #         break
-              #       fi
-              #     done
-              # '
               ## Explore and report status of all failed pipelineruns. Fail if anything failed
               SOME_PIPELINE_FAILED=false
               SOME_PIPELINE_SUCCEEDED=false

--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -105,6 +105,7 @@ spec:
               function waitFor() {
                   CONDITION=$1 MESSAGE_RUNNING=$2 MESSAGE_DONE=$3 timeout --foreground 120m /bin/bash -c '
                     #deserialize plrs array
+                    set -x
                     read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
                     echo "${PIPELINERUNS_ARRAY[*]}"
                     while true; do
@@ -183,7 +184,7 @@ spec:
               export PIPELINERUNS_ARRAY_SERIALIZED="${PIPELINERUNS_ARRAY[*]}"
 
               waitFor '! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null' "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
-              waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]'' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
+              waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
 
               ## Explore and report status of all failed pipelineruns. Fail if anything failed
               SOME_PIPELINE_FAILED=false

--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -182,8 +182,8 @@ spec:
               #Serialize plrs array to be able to export it as var
               export PIPELINERUNS_ARRAY_SERIALIZED="${PIPELINERUNS_ARRAY[*]}"
 
-              waitFor() "! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null" "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
-              waitFor() "[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]" "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
+              waitFor "! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null" "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
+              waitFor "[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]" "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
 
               # Wait for all PLRs to start
               # timeout --foreground 120m /bin/bash -c '

--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -100,6 +100,33 @@ spec:
                     fieldPath: metadata.namespace
             script: |
               #!/usr/bin/env bash
+
+              # Waits for condition for all started pipelines
+              function waitFor() {
+                  CONDITION=$1 MESSAGE_RUNNING=$2 MESSAGE_DONE=$3 timeout --foreground 120m /bin/bash -c '
+                    #deserialize plrs array
+                    read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
+                    echo "${PIPELINERUNS_ARRAY[*]}"
+                    while true; do
+                      CONDITION_MET=false
+                      for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
+                        if eval "$CONDITION"; then
+                          #something is still running. Break this cycle and wait one minute.
+                          CONDITION_MET=true
+                          break
+                        fi
+                      done
+                      if $CONDITION_MET ; then
+                        echo "$MESSAGE_RUNNING"
+                        sleep 60
+                      else
+                        echo "$MESSAGE_DONE"
+                        break
+                      fi
+                    done
+                  '
+              }
+
               set -euo pipefail
 
               GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
@@ -155,30 +182,55 @@ spec:
               #Serialize plrs array to be able to export it as var
               export PIPELINERUNS_ARRAY_SERIALIZED="${PIPELINERUNS_ARRAY[*]}"
 
+              waitFor() "! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null" "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
+              waitFor() "[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]" "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
+
+              # Wait for all PLRs to start
+              # timeout --foreground 120m /bin/bash -c '
+              #     #deserialize plrs array
+              #     read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
+              #     while true; do
+              #       PIPELINES_STARTING=false
+              #       for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
+              #         if ! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null; then
+              #           #Not started yet
+              #           PIPELINES_STARTING=true
+              #           break
+              #         fi
+              #       done
+              #       it $PIPELINES_STARTING ; then
+              #         echo "Pipelines are still starting. Waiting 1 minute"
+              #         sleep 60
+              #       else
+              #         echo "All pipelines have started"
+              #         break
+              #       fi
+              #     done
+              # '
 
               # Wait for all PLRs to finish
-              timeout --foreground 120m /bin/bash -c '
-                  #deserialize plrs array
-                  read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
-                  echo "${PIPELINERUNS_ARRAY[*]}"
-                  while true; do
-                    ARE_PIPELINES_RUNNING=false
-                    for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-                      if ! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null || [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]; then
-                        #something is still running. Break this cycle and wait one minute.
-                        ARE_PIPELINES_RUNNING=true
-                        break
-                      fi
-                    done
-                    if $ARE_PIPELINES_RUNNING ; then
-                      echo "Nested pipelines are still running. Waiting 1 minute"
-                      sleep 60
-                    else
-                      echo "All nested pipelines finished"
-                      break
-                    fi
-                  done
-              '
+              # timeout --foreground 120m /bin/bash -c '
+              #     #deserialize plrs array
+              #     read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
+              #     echo "${PIPELINERUNS_ARRAY[*]}"
+              #     while true; do
+              #       ARE_PIPELINES_RUNNING=false
+              #       for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
+              #         if ! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null || [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]; then
+              #           #something is still running. Break this cycle and wait one minute.
+              #           ARE_PIPELINES_RUNNING=true
+              #           break
+              #         fi
+              #       done
+              #       if $ARE_PIPELINES_RUNNING ; then
+              #         echo "Nested pipelines are still running. Waiting 1 minute"
+              #         sleep 60
+              #       else
+              #         echo "All nested pipelines finished"
+              #         break
+              #       fi
+              #     done
+              # '
               ## Explore and report status of all failed pipelineruns. Fail if anything failed
               SOME_PIPELINE_FAILED=false
               SOME_PIPELINE_SUCCEEDED=false


### PR DESCRIPTION
Before this fix we sometimes get the situation, where pipelines were started and one of them failed/ended quickly and it was pruned from the cluster befor the second one finished. This got us to a state, where the loop waiting for the PLRs to finish was stuck even though the pipelines were finished.
This PR splits the condition to two wait loops - one for the pipelines to start, the second one for pipelines to finish.