### PR TITLE
fix: extract REGISTRY_ENDPOINT from .dockerconfigjson

### DIFF
--- a/installer/charts/rhtap-integrations/templates/acs/job.yaml
+++ b/installer/charts/rhtap-integrations/templates/acs/job.yaml
@@ -57,7 +57,7 @@ spec:
             allowPrivilegeEscalation: false
       {{- end }}
       {{- $secretNexus := (lookup "v1" "Secret" .Release.Namespace "rhtap-nexus-integration") }}
-      {{- if and $integrations.acs.enabled $secretArtifactory }}
+      {{- if and $integrations.acs.enabled $secretNexus }}
         #
         # Create the Nexus integration.
         #


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

For both Nexus and Artifactory, they have two urls, one is console url, which is used to login registry UI to manage registry. Another one is registry url, which is used for pushing/pull images to registry server with podman or docker cli.  The value of `.data.url` is image registry console url, not registry url. We need to extract registry url from .dockerconfigjson