### PR TITLE
fix: DH chart notes

### DIFF
--- a/installer/charts/rhtap-dh/templates/NOTES.txt
+++ b/installer/charts/rhtap-dh/templates/NOTES.txt
@@ -1,8 +1,10 @@
 Developer Hub:
-  - homepage: https://backstage-{{ .Values.developerHub.instanceName }}-rhtap.{{ .Values.developerHub.ingressDomain }}
+  - homepage: https://backstage-{{ .Values.developerHub.instanceName }}-{{ .Release.Namespace }}.{{ .Values.developerHub.ingressDomain }}
 
-{{- $gitlabObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-gitlab-integration") | default dict -}}
-{{- $bitbucketObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-bitbucket-integration") | default dict -}}
+
+{{- $integrationNamespace := .Values.developerHub.integrationSecrets.namespace }}
+{{- $gitlabObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-gitlab-integration") | default dict -}}
+{{- $bitbucketObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-bitbucket-integration") | default dict -}}
 {{- if (or $gitlabObj $bitbucketObj) }}
 
 Tekton Pipelines as Code:
@@ -21,7 +23,7 @@ Tekton Pipelines as Code:
     {{- end }}
 {{- end }}
 
-{{- $jenkinsObj := (lookup "v1" "Secret" .Release.Namespace "rhtap-jenkins-integration") | default dict -}}
+{{- $jenkinsObj := (lookup "v1" "Secret" $integrationNamespace "rhtap-jenkins-integration") | default dict -}}
 {{- if $jenkinsObj }}
     {{- $secretObj := (lookup "v1" "Secret" "openshift-pipelines" "signing-secrets") | default dict -}}
     {{- $secretData := (get $secretObj "data") | default dict -}}
@@ -36,7 +38,7 @@ Tekton Chains:
 Tekton Chains: not installed
     {{- end }}
 
-    {{- $secretObj = (lookup "v1" "Secret" .Release.Namespace "rhtap-tas-integration") | default dict -}}
+    {{- $secretObj = (lookup "v1" "Secret" $integrationNamespace "rhtap-tas-integration") | default dict -}}
     {{- $secretData = (get $secretObj "data") | default dict -}}
     {{- if $secretData }}
 


### PR DESCRIPTION
The notes were broken following #445.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED