### PR TITLE
[RHTAP-4541]fix minio issue in namesapce rhtap-tpa

### DIFF
--- a/integration-tests/pict-models/default.pict
+++ b/integration-tests/pict-models/default.pict
@@ -13,7 +13,7 @@
 OCP: 4.17, 4.16
 AUTH: github
 ACS: new
-Registry: quay.io
+Registry: nexus
 TPA: new
 SCM: github
 Pipeline: tekton

--- a/integration-tests/scripts/minio.sh
+++ b/integration-tests/scripts/minio.sh
@@ -19,6 +19,7 @@ oc registry login --registry=docker.io --auth-basic="$DOCKER_IO_AUTH" --to=./glo
 
 namespace_sa_names=$(cat << 'EOF'
 minio-operator|minio-operator-e2e
+rhtap-tpa|minio-operator-tpa
 EOF
 )
 while IFS='|' read -r ns sa_name; do


### PR DESCRIPTION
This PR fixes Docker rate-limit issue  occured in namespace `rhtap-tpa`
```
Failed to pull image "minio/operator:v5.0.16": reading manifest v5.0.16 in docker.io/minio/operator: too many requests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
```
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
