### PR TITLE
fix: fix bug in the template command

### DIFF
--- a/pkg/subcmd/template.go
+++ b/pkg/subcmd/template.go
@@ -88,6 +88,11 @@ func (t *Template) Complete(args []string) error {
 		return fmt.Errorf("expecting one chart, got %d", len(args))
 	}
 	t.dep.Chart = args[0]
+
+	var err error
+	if t.cfg, err = bootstrapConfig(t.cmd.Context(), t.kube); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
The config was not retrieved from the cluster.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED