### PR TITLE
feat: use a single secret for image registry authentication

### DIFF
--- a/installer/charts/rhtap-app-namespaces/hooks/post-deploy.sh
+++ b/installer/charts/rhtap-app-namespaces/hooks/post-deploy.sh
@@ -62,9 +62,6 @@ get_namespaces() {
 setup_namespaces() {
     for NAMESPACE in "${NAMESPACES[@]}"; do
         patch_serviceaccount "$NAMESPACE-ci" "pipeline"
-        for env in "ci" "development" "prod" "stage"; do
-            patch_serviceaccount "$NAMESPACE-$env" "default"
-        done
     done
 }
 

--- a/installer/charts/rhtap-app-namespaces/templates/secrets/image-registry-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/image-registry-auth.yaml
@@ -1,21 +1,18 @@
-{{- $dockerconfigjson := dict }}
 {{- $namespace := .Release.Namespace }}
+
+# Merge the image repositories secrets into a single value
+{{- $dockerconfigjson := dict }}
 {{- range (tuple "artifactory" "nexus" "quay") }}
   {{- $secretName := printf "rhtap-%s-integration" . }}
-#
-# secretName: {{ $secretName }}
   {{- $secretObj := (lookup "v1" "Secret" $namespace $secretName) | default dict }}
-# secretObj: {{ $secretObj | toJson }}
   {{- $secretData := (get $secretObj "data") | default dict }}
-# secretData: {{ $secretData | toJson }}
   {{- $secretContent := (get $secretData ".dockerconfigjson" | b64dec ) | default "{}" | fromJson }}
-# secretContent: {{ $secretContent | toJson }}
-  {{- merge $dockerconfigjson $secretContent }}
-# dockerconfigjson: {{ $dockerconfigjson | toJson }}
-#
+  {{- $dockerconfigjson := merge $dockerconfigjson $secretContent }}
 {{- end }}
+
+# Create the unified secret, or fail if the secret is empty
 {{- if not $dockerconfigjson }}
-  {{- required "" (printf "Did not find any image repository integrations in %s" $namespace) }}
+  {{- required (printf "Did not find any image repository integrations in %s" $namespace) "" }}
 {{- end }}
 {{- range .Values.appNamespaces.namespace_prefixes }}
   {{- $namespace := . }}


### PR DESCRIPTION
The templates have been updated to use pullImageSecrets, so linking the secret to the `default` ServiceAccount is not needed any more.

This changeset also fixes a bug in the creation of the secret.

cf [RHTAP-4555](https://issues.redhat.com//browse/RHTAP-4555)