### PR TITLE
fix: remove deprecated validations in integrations

### DIFF
--- a/pkg/subcmd/integration_acs.go
+++ b/pkg/subcmd/integration_acs.go
@@ -1,7 +1,6 @@
 package subcmd
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
@@ -49,13 +48,6 @@ func (d *IntegrationACS) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *IntegrationACS) Validate() error {
-	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("Red Hat Developer Hub feature is not enabled")
-	}
 	return d.acsIntegration.Validate()
 }
 

--- a/pkg/subcmd/integration_artifactory.go
+++ b/pkg/subcmd/integration_artifactory.go
@@ -1,7 +1,6 @@
 package subcmd
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
@@ -49,13 +48,6 @@ func (d *IntegrationArtifactory) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *IntegrationArtifactory) Validate() error {
-	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("Red Hat Developer Hub feature is not enabled")
-	}
 	return d.artifactoryIntegration.Validate()
 }
 

--- a/pkg/subcmd/integration_azure.go
+++ b/pkg/subcmd/integration_azure.go
@@ -1,7 +1,6 @@
 package subcmd
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
@@ -52,13 +51,6 @@ func (d *IntegrationAzure) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *IntegrationAzure) Validate() error {
-	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("Red Hat Developer Hub feature is not enabled")
-	}
 	return d.azureIntegration.Validate()
 }
 

--- a/pkg/subcmd/integration_bitbucket.go
+++ b/pkg/subcmd/integration_bitbucket.go
@@ -1,7 +1,6 @@
 package subcmd
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
@@ -51,13 +50,6 @@ func (d *IntegrationBitBucket) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *IntegrationBitBucket) Validate() error {
-	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("Red Hat Developer Hub feature is not enabled")
-	}
 	return d.bitbucketIntegration.Validate()
 }
 

--- a/pkg/subcmd/integration_githubapp.go
+++ b/pkg/subcmd/integration_githubapp.go
@@ -72,20 +72,6 @@ func (d *IntegrationGitHubApp) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *IntegrationGitHubApp) Validate() error {
-	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("The 'redHatDeveloperHub' feature is not enabled")
-	}
-	feature, err = d.cfg.GetFeature(config.OpenShiftPipelines)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("The 'openShiftPipelines' feature is not enabled")
-	}
 	// TODO: make the name optional, the user will inform the GitHub App name on
 	// the web-form, which can be later extracted.
 	if d.name == "" {

--- a/pkg/subcmd/integration_gitlab.go
+++ b/pkg/subcmd/integration_gitlab.go
@@ -1,7 +1,6 @@
 package subcmd
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
@@ -46,13 +45,6 @@ func (d *IntegrationGitLab) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *IntegrationGitLab) Validate() error {
-	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("Red Hat Developer Hub feature is not enabled")
-	}
 	return d.gitlabIntegration.Validate()
 }
 

--- a/pkg/subcmd/integration_jenkins.go
+++ b/pkg/subcmd/integration_jenkins.go
@@ -1,7 +1,6 @@
 package subcmd
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
@@ -50,13 +49,6 @@ func (d *IntegrationJenkins) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *IntegrationJenkins) Validate() error {
-	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("Red Hat Developer Hub feature is not enabled")
-	}
 	return d.jenkinsIntegration.Validate()
 }
 

--- a/pkg/subcmd/integration_nexus.go
+++ b/pkg/subcmd/integration_nexus.go
@@ -1,7 +1,6 @@
 package subcmd
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
@@ -48,13 +47,6 @@ func (d *IntegrationNexus) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *IntegrationNexus) Validate() error {
-	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("Red Hat Developer Hub feature is not enabled")
-	}
 	return d.nexusIntegration.Validate()
 }
 

--- a/pkg/subcmd/integration_quay.go
+++ b/pkg/subcmd/integration_quay.go
@@ -1,7 +1,6 @@
 package subcmd
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
@@ -56,13 +55,6 @@ func (d *IntegrationQuay) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *IntegrationQuay) Validate() error {
-	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("Red Hat Developer Hub feature is not enabled")
-	}
 	return d.quayIntegration.Validate()
 }
 

--- a/pkg/subcmd/integration_trustification.go
+++ b/pkg/subcmd/integration_trustification.go
@@ -1,7 +1,6 @@
 package subcmd
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/redhat-appstudio/rhtap-cli/pkg/config"
@@ -52,13 +51,6 @@ func (d *IntegrationTrustification) Complete(args []string) error {
 
 // Validate checks if the required configuration is set.
 func (d *IntegrationTrustification) Validate() error {
-	feature, err := d.cfg.GetFeature(config.RedHatDeveloperHub)
-	if err != nil {
-		return err
-	}
-	if !feature.Enabled {
-		return fmt.Errorf("Red Hat Developer Hub feature is not enabled")
-	}
 	return d.trustificationIntegration.Validate()
 }
 


### PR DESCRIPTION
- `config.RedHatDeveloperHub`: since DH has been moved to its own namespace, this validation is deprecated.
- `config.OpenShiftPipelines`: since we support other CI than Tekton and the GH App would still be needed for authentication, this validation is deprecated.