### PR TITLE
Bind new ClusterRole to service account rhdh-kubernetes-plugin

### DIFF
--- a/installer/charts/rhtap-infrastructure/templates/developer-hub/serviceaccount.yaml
+++ b/installer/charts/rhtap-infrastructure/templates/developer-hub/serviceaccount.yaml
@@ -33,13 +33,83 @@ secrets:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $saName }}
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - pods
+      - pods/log
+      - configmaps
+      - services
+      - deployments
+      - replicasets
+      - horizontalpodautoscalers
+      - ingresses
+      - statefulsets
+      - limitranges
+      - resourcequotas
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns
+    verbs:
+      - get
+      - list
+      - watch
+
+# The current RBAC permissions required are read-only cluster widie
+# Reference:
+# https://backstage.io/docs/features/kubernetes/configuration#role-based-access-control
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ $saName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view
+  name:  {{ $saName }}
 subjects:
   - kind: ServiceAccount
     name: {{ $saName }}


### PR DESCRIPTION
Add a ClusterRole rhdh-kubernetes-plugin and bind it to service account rhdh-kubernetes-plugin.
The sources of the role is copied from: https://backstage.io/docs/features/kubernetes/configuration#role-based-access-control
And added:
1. apiGroups: `argoproj.io`, `route.openshift.io` and `tekton.dev`, which is from https://github.com/redhat-appstudio/rhtap-cli/blob/1b390bf3d25c628d4b773c4c33b9ffc2e68e072d/installer/charts/rhtap-dh/templates/plugins-content.yaml#L120).
2. resource: `pods/log`, which is needed to view pods log in catalog.

Jira: https://issues.redhat.com/browse/RHTAP-4550