### PR TITLE
Remove temporary serviceaccounts and clusterrolebindings

### DIFF
--- a/installer/charts/_common/_helpers.tpl
+++ b/installer/charts/_common/_helpers.tpl
@@ -43,6 +43,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Need deleted labels
+*/}}
+{{- define "common.postDeployDeleteLabels" -}}
+rhtap-cli.redhat-appstudio.github.com/post-deploy: delete
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "common.selectorLabels" -}}

--- a/installer/charts/_common/_service-account.tpl
+++ b/installer/charts/_common/_service-account.tpl
@@ -4,12 +4,14 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.postDeployDeleteLabels" . | nindent 4 }}
 {{- end }}
 {{- define "common.clusterRoleBinding" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}
+  labels: {{- include "common.postDeployDeleteLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -24,6 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}
+  labels: {{- include "common.postDeployDeleteLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/installer/charts/rhtap-acs-test/templates/service-account.yaml
+++ b/installer/charts/rhtap-acs-test/templates/service-account.yaml
@@ -6,6 +6,7 @@ kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.postDeployDeleteLabels" . | nindent 4 }}
 rules:
   - apiGroups: 
       - "apps"

--- a/installer/charts/rhtap-acs/templates/service-account.yaml
+++ b/installer/charts/rhtap-acs/templates/service-account.yaml
@@ -6,6 +6,7 @@ kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.postDeployDeleteLabels" . | nindent 4 }}
 rules:
   - apiGroups: 
       - "apps"

--- a/installer/charts/rhtap-integrations/templates/service-account.yaml
+++ b/installer/charts/rhtap-integrations/templates/service-account.yaml
@@ -6,6 +6,7 @@ kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.postDeployDeleteLabels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/pkg/k8s/delete_resources.go
+++ b/pkg/k8s/delete_resources.go
@@ -1,0 +1,164 @@
+package k8s
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// labelSelector is the label set for resources to be deleted.
+const labelSelector = "rhtap-cli.redhat-appstudio.github.com/post-deploy=delete"
+
+// DeleteClusterRoleBindings deletes Kubernetes ClusterRoleBindings by label.
+func DeleteClusterRoleBindings(
+	ctx context.Context,
+	kube *Kube,
+	namespace string,
+) error {
+	rbacClient, err := kube.RBACV1ClientSet(namespace)
+	if err != nil {
+		return err
+	}
+	return rbacClient.ClusterRoleBindings().
+		DeleteCollection(ctx, metav1.DeleteOptions{},
+			metav1.ListOptions{LabelSelector: labelSelector})
+}
+
+// DeleteClusterRoles deletes Kubernetes ClusterRoles by label.
+func DeleteClusterRoles(
+	ctx context.Context,
+	kube *Kube,
+	namespace string,
+) error {
+	rbacClient, err := kube.RBACV1ClientSet(namespace)
+	if err != nil {
+		return err
+	}
+	return rbacClient.ClusterRoles().
+		DeleteCollection(ctx, metav1.DeleteOptions{},
+			metav1.ListOptions{LabelSelector: labelSelector})
+}
+
+// DeleteRoleBindings deletes Kuberbetes RoleBindings by label.
+func DeleteRoleBindings(
+	ctx context.Context,
+	kube *Kube,
+	namespace string,
+) error {
+	rbacClient, err := kube.RBACV1ClientSet(namespace)
+	if err != nil {
+		return err
+	}
+	RoleBindingsList, err := rbacClient.RoleBindings("").
+		List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	for _, rb := range RoleBindingsList.Items {
+		err := rbacClient.RoleBindings(rb.Namespace).
+			Delete(ctx, rb.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteRoles deletes Kubernetes Roles by label.
+func DeleteRoles(
+	ctx context.Context,
+	kube *Kube,
+	namespace string,
+) error {
+	rbacClient, err := kube.RBACV1ClientSet(namespace)
+	if err != nil {
+		return err
+	}
+	RolesList, err := rbacClient.Roles("").
+		List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	for _, role := range RolesList.Items {
+		err := rbacClient.Roles(role.Namespace).
+			Delete(ctx, role.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteServiceAccounts deletes Kubernetes ServiceAccounts by label.
+func DeleteServiceAccounts(
+	ctx context.Context,
+	kube *Kube,
+	namespace string,
+) error {
+	coreClient, err := kube.CoreV1ClientSet(namespace)
+	if err != nil {
+		return err
+	}
+	ServiceAccountList, err := coreClient.ServiceAccounts("").
+		List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	for _, sa := range ServiceAccountList.Items {
+		err := coreClient.ServiceAccounts(sa.Namespace).
+			Delete(ctx, sa.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteResources deletes temporary Kubernetes resources created during deployment.
+func DeleteResources(
+	ctx context.Context,
+	kube *Kube,
+	namespace string,
+) error {
+	// Delete ClusterRoleBindings
+	if err := DeleteClusterRoleBindings(ctx, kube, namespace); err != nil {
+		return err
+	}
+	// Delete ClusterRoles
+	if err := DeleteClusterRoles(ctx, kube, namespace); err != nil {
+		return err
+	}
+	// Delete RoleBindings
+	if err := DeleteRoleBindings(ctx, kube, namespace); err != nil {
+		return err
+	}
+	// Delete Roles
+	if err := DeleteRoles(ctx, kube, namespace); err != nil {
+		return err
+	}
+	// Delete ServiceAccounts
+	if err := DeleteServiceAccounts(ctx, kube, namespace); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Retry defines retry.
+func Retry(attempts int, sleep time.Duration, fn func() error) error {
+	for i := 0; ; i++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if i >= (attempts - 1) {
+			return err
+		}
+		time.Sleep(sleep)
+	}
+}
+
+// RetryDeleteResources deletes temporary resources with retry 5 times.
+func RetryDeleteResources(
+	ctx context.Context,
+	kube *Kube,
+	namespace string,
+) error {
+	// Delete temporary resources
+	err := Retry(5, 10*time.Second, func() error {
+		err := DeleteResources(ctx, kube, namespace)
+		return err
+	})
+	return err
+}

--- a/pkg/k8s/interface.go
+++ b/pkg/k8s/interface.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 )
 
 type Interface interface {
@@ -16,5 +17,6 @@ type Interface interface {
 	DiscoveryClient(string) (discovery.DiscoveryInterface, error)
 	DynamicClient(string) (dynamic.Interface, error)
 	GetDynamicClientForObjectRef(*corev1.ObjectReference) (dynamic.ResourceInterface, error)
+	RBACV1ClientSet(string) (rbacv1client.RbacV1Interface, error)
 	RESTClientGetter(string) genericclioptions.RESTClientGetter
 }

--- a/pkg/k8s/kube.go
+++ b/pkg/k8s/kube.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 )
 
 // Kube represents the Kubernetes client helper.
@@ -69,6 +70,15 @@ func (k *Kube) DynamicClient(namespace string) (dynamic.Interface, error) {
 		return nil, err
 	}
 	return dynamic.NewForConfig(restConfig)
+}
+
+// RBACV1ClientSet returns a "rbacv1" Kubernetes Clientset.
+func (k *Kube) RBACV1ClientSet(namespace string) (rbacv1client.RbacV1Interface, error) {
+	restConfig, err := k.RESTClientGetter(namespace).ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	return rbacv1client.NewForConfig(restConfig)
 }
 
 // GetDynamicClientForObjectRef returns a dynamic client for the object reference.

--- a/pkg/k8s/kube_fake.go
+++ b/pkg/k8s/kube_fake.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
 
@@ -86,6 +87,16 @@ func (f *FakeKube) GetDynamicClientForObjectRef(
 		return dynamicClient.Resource(gvr).Namespace(objectRef.Namespace), nil
 	}
 	return dynamicClient.Resource(gvr), nil
+}
+
+func (f *FakeKube) RBACV1ClientSet(
+	namespace string,
+) (rbacv1client.RbacV1Interface, error) {
+	cs, err := f.ClientSet(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return cs.RbacV1(), nil
 }
 
 func (f *FakeKube) RESTClientGetter(_ string) genericclioptions.RESTClientGetter {

--- a/pkg/subcmd/deploy.go
+++ b/pkg/subcmd/deploy.go
@@ -135,7 +135,12 @@ func (d *Deploy) Run() error {
 			i.PrintValues()
 		}
 
-		if err = i.Install(d.cmd.Context()); err != nil {
+		err = i.Install(d.cmd.Context())
+		// Delete temporary resources
+		if err := k8s.RetryDeleteResources(d.cmd.Context(), d.kube, d.cfg.Installer.Namespace); err != nil {
+			d.log().Debug(err.Error())
+		}
+		if err != nil {
 			return err
 		}
 		fmt.Printf("############################################################\n\n")


### PR DESCRIPTION
1. Add `need-delete` labels to service accounts and clusterrolebindings
2. When deploy failed or finished, delete serviceaccounts and clusterrolebindings with label `need-delete`
3. Retry on delete operations, retry 5 times with 10 seconds waiting.
Jira: [RHTAP-4552](https://issues.redhat.com/browse/RHTAP-4552)