### PR TITLE
Revert "Revert adding quay robot account for registry"

### DIFF
--- a/installer/charts/rhtap-quay/templates/job-quay-integration.yaml
+++ b/installer/charts/rhtap-quay/templates/job-quay-integration.yaml
@@ -65,6 +65,16 @@ spec:
                 required ".quay.secret.name is required"
                   $quay.secret.name
               }}
+            - name: QUAY_ROBOT_SHORT_NAME
+              value: {{
+                required ".quay.robot.name is required"
+                  $quay.robot.name
+              }}
+            - name: QUAY_REPOSITORY
+              value: {{
+                required ".quay.repository.name is required"
+                  $quay.repository.name
+              }}
           command:
             - /scripts/quay-helper.sh
           volumeMounts:

--- a/installer/charts/rhtap-quay/values.yaml
+++ b/installer/charts/rhtap-quay/values.yaml
@@ -14,10 +14,16 @@ quay:
     name: rhtap
     # Organization's email.
     email: __OVERWRITE_ME__
+  repository:
+    # Repository's name
+    name: default
   # Quay admin "docker-registry" secret namespace and name.
   secret:
     namespace: __OVERWRITE_ME__
     name: __OVERWRITE_ME__
+  # Quay robot name for organization
+  robot:
+    name: rhtap_rw
   # Quay configuration bundle.
   config:
     # To support MinIO S3 instance, the RADOS Gateway (RGW) storage is used


### PR DESCRIPTION
Reverts redhat-appstudio/rhtap-cli#588

Tests showed that the issue already existed with the admin account.
Since the PR does not introduce a new regression an improves the security posture, it is being enabled again.
Documentation will be needed to inform the user that the auth token needs to be rotated manually and the integration secret and DH env secret need to be updated.