### PR TITLE
fix: increase RETRIES for test-acs-image-scan.sh

### DIFF
--- a/installer/scripts/test-acs-image-scan.sh
+++ b/installer/scripts/test-acs-image-scan.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 
 # Number of retries to attempt before giving up.
-declare -r RETRIES=${RETRIES:-30}
+declare -r RETRIES=${RETRIES:-90}
 
 get_roxctl() {
   echo "# Download roxctl cli from ${ROX_CENTRAL_ENDPOINT}"


### PR DESCRIPTION
Previous value was too low and was responsible for CI flakiness.

cf. [RHTAP-4556](https://issues.redhat.com//browse/RHTAP-4556)