### PR TITLE
Hide the Azure pull request tab [1.5]

### DIFF
--- a/installer/charts/rhtap-dh/templates/plugins-content.yaml
+++ b/installer/charts/rhtap-dh/templates/plugins-content.yaml
@@ -50,6 +50,22 @@ plugins:
     package: ./dynamic-plugins/dist/backstage-community-plugin-azure-devops-backend-dynamic
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-community-plugin-azure-devops
+    # The default pluginConfig also includes EntityAzurePullRequestsContent which is not supported
+    # in RHTAP and causes 500 errors when loading the PR/MR tab:
+    # https://issues.redhat.com/browse/RHTAP-4837
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          backstage-community.plugin-azure-devops:
+            mountPoints:
+              - mountPoint: entity.page.ci/cards
+                importName: EntityAzurePipelinesContent
+                config:
+                  layout:
+                    gridColumn: "1 / -1"
+                  if:
+                    allOf:
+                      - isAzureDevOpsAvailable
 {{- end }}
 {{- if (lookup "v1" "Secret" $integrationNamespace "rhtap-github-integration") }}
   - disabled: false


### PR DESCRIPTION
The default config for the azure frontend plugin enables both EntityAzurePullRequestsContent and EntityAzurePipelinesContent. The first is not supported by RHTAP since Azure is not a git provider option. Both are enabled by the `dev.azure.com/project-repo` Component annotation. As such, there is no possible combination of Component annotations that would allow us to enable EntityAzurePipelinesContent but disable EntityAzurePullRequestsContent.

This commit overwrites the default config for the azure plugin to omit EntityAzurePullRequestsContent.