### PR TITLE
Read-only credentials for the development namespaces

### DIFF
--- a/installer/charts/rhtap-app-namespaces/templates/secrets/image-registry-auth.yaml
+++ b/installer/charts/rhtap-app-namespaces/templates/secrets/image-registry-auth.yaml
@@ -2,12 +2,15 @@
 
 # Merge the image repositories secrets into a single value
 {{- $dockerconfigjson := dict }}
+{{- $dockerconfigjsonreadonly := dict }}
 {{- range (tuple "artifactory" "nexus" "quay") }}
   {{- $secretName := printf "rhtap-%s-integration" . }}
   {{- $secretObj := (lookup "v1" "Secret" $namespace $secretName) | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
   {{- $secretContent := (get $secretData ".dockerconfigjson" | b64dec ) | default "{}" | fromJson }}
+  {{- $readonlysecretContent := (get $secretData ".dockerconfigjsonreadonly" | b64dec ) | default "{}" | fromJson }}
   {{- $dockerconfigjson := merge $dockerconfigjson $secretContent }}
+  {{- $dockerconfigjsonreadonly := merge $dockerconfigjsonreadonly $readonlysecretContent }}
 {{- end }}
 
 # Create the unified secret, or fail if the secret is empty
@@ -25,6 +28,10 @@ metadata:
   name: rhtap-image-registry-auth
   namespace: {{ $namespace }}-{{ . }}
 stringData:
+    {{- if and $dockerconfigjsonreadonly (ne . "ci") }}
+  .dockerconfigjson: '{{ $dockerconfigjsonreadonly | toJson }}'
+    {{- else }}
   .dockerconfigjson: '{{ $dockerconfigjson | toJson }}'
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/installer/charts/rhtap-quay/templates/job-quay-integration.yaml
+++ b/installer/charts/rhtap-quay/templates/job-quay-integration.yaml
@@ -70,6 +70,11 @@ spec:
                 required ".quay.robot.name is required"
                   $quay.robot.name
               }}
+            - name: QUAY_ROBOT_SHORT_NAME_READONLY
+              value: {{
+                required ".quay.robotReadonly.name is required"
+                  $quay.robotReadonly.name
+              }}
             - name: QUAY_REPOSITORY
               value: {{
                 required ".quay.repository.name is required"

--- a/installer/charts/rhtap-quay/values.yaml
+++ b/installer/charts/rhtap-quay/values.yaml
@@ -24,6 +24,9 @@ quay:
   # Quay robot name for organization
   robot:
     name: rhtap_rw
+  robotReadonly:
+  # Quay robot name with read-only pemission
+    name: rhtap_ro
   # Quay configuration bundle.
   config:
     # Quay's instance adminstration user.

--- a/installer/scripts/quay-helper.sh
+++ b/installer/scripts/quay-helper.sh
@@ -39,6 +39,11 @@ declare QUAY_ROBOT_SHORT_NAME="${QUAY_ROBOT_SHORT_NAME:-rhtap_rw}"
 declare QUAY_ROBOT_USERNAME=""
 declare QUAY_ROBOT_TOKEN=""
 
+# Quay read only reobot account
+declare QUAY_ROBOT_SHORT_NAME_READONLY="${QUAY_ROBOT_SHORT_NAME_READONLY:-rhtap_ro}"
+declare QUAY_ROBOT_USERNAME_READONLY=""
+declare QUAY_ROBOT_TOKEN_READONLY=""
+
 #
 # Functions
 #
@@ -176,16 +181,28 @@ quay_create_secret() {
     fi
     info "Secret created/updated successfully!"
 
-    # Patching the secret to include the "token" and "url" attributes, needed for
-    # the later RHDH integration.
-    info "Patch secret with 'token' and 'url'..."
-    local token url
+    # Patching the secret to include the ".dockerconfigjsonreadonly" "token" and
+    # "url" attributes, needed for the later RHDH integration.
+    info "Patch secret with '.dockerconfigjsonreadonly' 'token' and 'url'..."
+    local readonlyjson token url
     local -a patch
 
+    readonlyjson=$(
+        oc create secret docker-registry "${SECRET_NAME}" \
+            --namespace="${NAMESPACE}" \
+            --docker-server="${QUAY_HOSTNAME}" \
+            --docker-username="${QUAY_ROBOT_USERNAME_READONLY}" \
+            --docker-password="${QUAY_ROBOT_TOKEN_READONLY}" \
+            --docker-email="${QUAY_EMAIL}" \
+            --dry-run=client \
+            --output=json |
+            jq -r '.data.".dockerconfigjson"'
+        )
     token=$(base64 -w0 <<<"${ACCESS_TOKEN}")
     url=$(base64 -w0 <<<"https://${QUAY_HOSTNAME}")
     patch=(
         "["
+        "{\"op\": \"add\", \"path\": \"/data/.dockerconfigjsonreadonly\", \"value\": \"${readonlyjson}\"},"
         "{\"op\": \"add\", \"path\": \"/data/token\", \"value\": \"${token}\"},"
         "{\"op\": \"add\", \"path\": \"/data/url\", \"value\": \"${url}\"}"
         "]"
@@ -204,7 +221,7 @@ quay_create_secret() {
 # Create a robot account in organization with the name informed via environment,
 # using the super-user's ACCESS_TOKEN to authorize the request.
 quay_create_robot_account() {
-    local quay_url="https://${QUAY_HOSTNAME}/api/v1/organization/${QUAY_ORGANIZATION}/robots/${QUAY_ROBOT_SHORT_NAME}"
+    local quay_url="https://${QUAY_HOSTNAME}/api/v1/organization/${QUAY_ORGANIZATION}/robots/$1"
     local data=(
         "{"
         "\"description\": \"Quay robot account for ${QUAY_ORGANIZATION}\","
@@ -213,7 +230,7 @@ quay_create_robot_account() {
     )
     local create_response token
 
-    info "Creating Quay robot account ${QUAY_ROBOT_SHORT_NAME}..."
+    info "Creating Quay robot account $1..."
     create_response=$(
         curl \
             --silent \
@@ -245,23 +262,34 @@ quay_create_robot_account() {
         fail "Failed to get robot account token!"
     fi
 
-    info "Robot account created successfully!"
-    export QUAY_ROBOT_TOKEN="${token}"
-    export QUAY_ROBOT_USERNAME="${QUAY_ORGANIZATION}+${QUAY_ROBOT_SHORT_NAME}"
+    info "Robot account $1 created successfully!"
+    if [[ "$1" == "rhtap_rw" ]]; then
+        export QUAY_ROBOT_TOKEN="${token}"
+        export QUAY_ROBOT_USERNAME="${QUAY_ORGANIZATION}+${QUAY_ROBOT_SHORT_NAME}"
+    else
+        export QUAY_ROBOT_TOKEN_READONLY="${token}"
+        export QUAY_ROBOT_USERNAME_READONLY="${QUAY_ORGANIZATION}+${QUAY_ROBOT_SHORT_NAME_READONLY}"
+    fi
 }
 
 # Create a new permission prototype in organization, that will automatically
-# grant admin permission of repositories to robot account
+# grant related permission of repositories to robot account
 quay_create_permission_prototype() {
     local quay_url="https://${QUAY_HOSTNAME}/api/v1/organization/${QUAY_ORGANIZATION}/prototypes"
+    local role
+    if [[ "$1" == *"rhtap_rw" ]]; then
+        role="admin"
+    else
+        role="read"
+    fi
     local data=(
         "{"
-        "\"role\": \"admin\","
+        "\"role\": \"${role}\","
         "\"activating_user\": {"
             "\"name\": \"\""
             "},"
         "\"delegate\": {"
-            "\"name\": \"${QUAY_ROBOT_USERNAME}\","
+            "\"name\": \"$1\","
             "\"kind\": \"user\""
             "}"
         "}"
@@ -281,7 +309,7 @@ quay_create_permission_prototype() {
             "${quay_url}"
     )
 
-    if [[ -z "${create_response}" || "${create_response}" != *"${QUAY_ROBOT_USERNAME}"* ]]; then
+    if [[ -z "${create_response}" || "${create_response}" != *"$1"* ]]; then
         fail "Failed to create new permission prototype!"
     fi
 
@@ -368,8 +396,15 @@ quay_helper() {
     fi
 
     quay_create_organization
-    quay_create_robot_account
-    quay_create_permission_prototype
+
+    for robot in "${QUAY_ROBOT_SHORT_NAME}" "${QUAY_ROBOT_SHORT_NAME_READONLY}"; do
+        quay_create_robot_account "${robot}"
+    done
+
+    for robot in "$QUAY_ROBOT_USERNAME" "$QUAY_ROBOT_USERNAME_READONLY"; do
+        quay_create_permission_prototype "${robot}"
+    done
+
     quay_create_team
     quay_assign_robot_to_team
 

--- a/pkg/integrations/quay.go
+++ b/pkg/integrations/quay.go
@@ -26,9 +26,10 @@ type QuayIntegration struct {
 
 	force bool // overwrite the existing secret
 
-	dockerconfigjson string // dockerconfig credentials
-	token            string // API token credentials
-	url              string // quay URL
+	dockerconfigjson         string // dockerconfig credentials
+	dockerconfigjsonreadonly string // dockerconfigjsonreadonly credentials
+	token                    string // API token credentials
+	url                      string // quay URL
 }
 
 // PersistentFlags sets the persistent flags for the Quay integration.
@@ -38,6 +39,8 @@ func (q *QuayIntegration) PersistentFlags(p *pflag.FlagSet) {
 
 	p.StringVar(&q.dockerconfigjson, "dockerconfigjson", q.dockerconfigjson,
 		"Quay dockerconfigjson, e.g. '{ \"auths\": { \"quay.io\": { \"auth\": \"****\", \"email\": \"\" }}}'")
+	p.StringVar(&q.dockerconfigjsonreadonly, "dockerconfigjsonreadonly", q.dockerconfigjsonreadonly,
+		"Quay dockerconfigjson for read only account, e.g. '{ \"auths\": { \"quay.io\": { \"auth\": \"****\", \"email\": \"\" }}}")
 	p.StringVar(&q.token, "token", q.token,
 		"Quay API token")
 	p.StringVar(&q.url, "url", q.url,
@@ -50,6 +53,7 @@ func (q *QuayIntegration) log() *slog.Logger {
 		"url", q.url,
 		"force", q.force,
 		"dockerconfigjson-len", len(q.dockerconfigjson),
+		"dockerconfigjsonreadonly-len", len(q.dockerconfigjsonreadonly),
 		"token-len", len(q.token),
 	)
 }
@@ -135,9 +139,10 @@ func (q *QuayIntegration) store(
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{
-			".dockerconfigjson": []byte(q.dockerconfigjson),
-			"token":             []byte(q.token),
-			"url":               []byte(q.url),
+			".dockerconfigjson":         []byte(q.dockerconfigjson),
+			".dockerconfigjsonreadonly": []byte(q.dockerconfigjsonreadonly),
+			"token":                     []byte(q.token),
+			"url":                       []byte(q.url),
 		},
 	}
 	logger := q.log().With(
@@ -179,9 +184,10 @@ func NewQuayIntegration(
 		logger: logger,
 		kube:   kube,
 
-		force:            false,
-		dockerconfigjson: "",
-		token:            "",
-		url:              "",
+		force:                    false,
+		dockerconfigjson:         "",
+		dockerconfigjsonreadonly: "",
+		token:                    "",
+		url:                      "",
 	}
 }

--- a/pkg/subcmd/integration_quay.go
+++ b/pkg/subcmd/integration_quay.go
@@ -20,8 +20,9 @@ type IntegrationQuay struct {
 
 	quayIntegration *integrations.QuayIntegration // quay integration
 
-	apiToken         string // web API token
-	dockerconfigjson string // credentials to push/pull from the registry
+	apiToken                 string // web API token
+	dockerconfigjson         string // credentials to push/pull from the registry
+	dockerconfigjsonreadonly string // credentials to read from the registry
 }
 
 var _ Interface = &IntegrationQuay{}


### PR DESCRIPTION
1. Add read only robot account to quay
2. Add `.dockerconfigjsonreadonly` item in `rhtap-quay-integration` secret
3. Set image registry auth to read only for development prod and stage namespaces
4. Add `--dockerconfigjsonreadonly` to `rhtap-cli integration quay`

Jira: https://issues.redhat.com/browse/RHTAP-4464