### PR TITLE
RHTAP-4382 - Add router CA to quay config secret.

### DIFF
--- a/installer/charts/rhtap-quay/templates/quay-config-secret.yaml
+++ b/installer/charts/rhtap-quay/templates/quay-config-secret.yaml
@@ -11,3 +11,5 @@ type: Opaque
 stringData:
   config.yaml: |
     {{ include "quay.s3storage.configYAML" . | nindent 4 }}
+  extra_ca_cert_router_ca.crt: |
+{{ .Values.quay.ingressRouterCA | b64dec | indent 4}}

--- a/installer/charts/values.yaml.tpl
+++ b/installer/charts/values.yaml.tpl
@@ -8,6 +8,7 @@
 {{- $quay := required "Quay settings" .Installer.Features.redHatQuay -}}
 {{- $rhdh := required "RHDH settings" .Installer.Features.redHatDeveloperHub -}}
 {{- $ingressDomain := required "OpenShift ingress domain" .OpenShift.Ingress.Domain -}}
+{{- $ingressRouterCA := required "OpenShift RouterCA" .OpenShift.Ingress.RouterCA -}}
 {{- $minIOOperatorEnabled := or $tpa.Enabled $quay.Enabled -}}
 ---
 debug:
@@ -237,6 +238,7 @@ quay:
   enabled: {{ $quay.Enabled }}
   namespace: {{ $quay.Namespace }}
   ingressDomain: {{ $ingressDomain }}
+  ingressRouterCA: {{ $ingressRouterCA }}
   organization:
     email: {{ printf "rhtap@%s" $ingressDomain }}
   secret:

--- a/pkg/engine/variables.go
+++ b/pkg/engine/variables.go
@@ -28,9 +28,14 @@ func (v *Variables) SetOpenShift(ctx context.Context, kube *k8s.Kube) error {
 	if err != nil {
 		return err
 	}
+	ingressRouterCA, err := k8s.GetOpenShiftIngressRouteCA(ctx, kube)
+	if err != nil {
+		return err
+	}
 	v.OpenShift = chartutil.Values{
 		"Ingress": chartutil.Values{
-			"Domain": ingressDomain,
+			"Domain":   ingressDomain,
+			"RouterCA": ingressRouterCA,
 		},
 	}
 	return nil

--- a/pkg/k8s/openshift.go
+++ b/pkg/k8s/openshift.go
@@ -2,23 +2,26 @@ package k8s
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"time"
 
+	v1 "github.com/openshift/api/operator/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	projectv1client "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ErrIngressDomainNotFound returned when the OpenShift ingress domain is empty.
 var ErrIngressDomainNotFound = fmt.Errorf("ingress domain not found")
 
-// GetOpenShiftIngressDomain returns the OpenShift Ingress domain.
-func GetOpenShiftIngressDomain(ctx context.Context, kube *Kube) (string, error) {
+// Returns `default` IngressController CR if exists.
+func getIngressControllerCR(ctx context.Context, kube *Kube) (*v1.IngressController, error) {
 	objectRef := &corev1.ObjectReference{
 		APIVersion: "operator.openshift.io/v1",
 		Namespace:  "openshift-ingress-operator",
@@ -27,11 +30,11 @@ func GetOpenShiftIngressDomain(ctx context.Context, kube *Kube) (string, error) 
 
 	restConfig, err := kube.RESTClientGetter(objectRef.Namespace).ToRESTConfig()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	operatorClient, err := operatorv1client.NewForConfig(restConfig)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	ingressController, err := operatorClient.
@@ -39,8 +42,62 @@ func GetOpenShiftIngressDomain(ctx context.Context, kube *Kube) (string, error) 
 		Get(ctx, objectRef.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return "", ErrIngressDomainNotFound
+			return nil, ErrIngressDomainNotFound
 		}
+		return nil, err
+	}
+	return ingressController, nil
+}
+
+// Returns name of the defaultCertificate as specified in default IngressController
+func getIngressControllerDefaultCertificate(ctx context.Context, kube *Kube) (string, error) {
+	ingressController, err := getIngressControllerCR(ctx, kube)
+	if err != nil {
+		return "", err
+	}
+	if ingressController.Spec.DefaultCertificate == nil {
+		return "", nil
+	}
+	ingressCertSecretName := ingressController.Spec.DefaultCertificate.Name
+
+	return ingressCertSecretName, nil
+}
+
+// GetOpenShiftIngressRouteCA returns base64-encoded root certificate for openshift-ingress route.
+// Uses either what's defines in spec->defaultCertificate of IngressController or if that's not defined
+// uses `router-ca` secret from `openshift-ingress-operator` namespace.
+// Related documentation: https://docs.openshift.com/container-platform/4.18/security/certificates/replacing-default-ingress-certificate.html#replacing-default-ingress
+func GetOpenShiftIngressRouteCA(ctx context.Context, kube *Kube) (string, error) {
+	defaultCertSecretName, err := getIngressControllerDefaultCertificate(ctx, kube)
+	if err != nil {
+		return "", err
+	}
+	secretNamespacedName := types.NamespacedName{
+		Namespace: "openshift-ingress-operator",
+		Name:      "router-ca",
+	}
+	if defaultCertSecretName != "" { // if defaultCertificate is specified, use that instead
+		secretNamespacedName = types.NamespacedName{
+			Namespace: "openshift-ingress",
+			Name:      defaultCertSecretName,
+		}
+	}
+	secret, err := GetSecret(ctx, kube, secretNamespacedName)
+	if err != nil {
+		return "", err
+	}
+
+	certData, ok := secret.Data["tls.crt"]
+	if !ok {
+		return "", fmt.Errorf("tls.crt key not found in router-ca secret")
+	}
+	return base64.StdEncoding.EncodeToString(certData), nil
+}
+
+// GetOpenShiftIngressDomain returns the OpenShift Ingress domain.
+func GetOpenShiftIngressDomain(ctx context.Context, kube *Kube) (string, error) {
+	ingressController, err := getIngressControllerCR(ctx, kube)
+	if err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Router CA is automatically obtained from either
IngressController CR or from `router-ca` secret
from `openshift-ingress-operator` ns.

This PR makes it possible to install RHTAP in "full" configuration on cluster with self signed certificates. 
In order to succesfully execute the golden path scenario, one needs to also make some modification to pipelines. I'll do that in separate PR (pending changes are currently here https://github.com/redhat-appstudio/tssc-sample-pipelines/compare/main...rhopp:tssc-sample-pipelines:fixTls)

This change was originally tested in CI in this PR: https://github.com/redhat-appstudio/rhtap-cli/pull/477/files which contains multiple changes:
* It contains changes made in this PR
* It uses templates that point to tekton pipelines from my fork (https://github.com/redhat-appstudio/tssc-sample-pipelines/compare/main...rhopp:tssc-sample-pipelines:fixTls)
* It chages the e2e-tests pipeline to use hive provided clusters instead of rosa provisioned ones. The hive clusters have self-signed certificates

Link to successfull run of e2e-tests from that branch is here: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-shared-team-tenant/applications/rhtap-cli/pipelineruns/e2e-416-c4j9v

Next steps will be to raise PR to build-definitions, sync them to tssc-sample-pipeline and then we should be able to switch from Rosa to Hive (or maybe even Konflux EaaS)