### PR TITLE
RHTAP-4382 - Add the cert to ACS central additionalCAs.

### DIFF
--- a/installer/charts/rhtap-acs/templates/acs-central.yaml
+++ b/installer/charts/rhtap-acs/templates/acs-central.yaml
@@ -62,3 +62,8 @@ spec:
       required ".acs.scanners.analyzer is required"
         $acs.scanners.analyzer | toYaml | nindent 6
     }}
+  tls:
+    additionalCAs:
+      - content: |
+{{ .Values.acs.ingressRouterCA | b64dec |nindent 10 }}
+        name: clusterCA

--- a/installer/charts/values.yaml.tpl
+++ b/installer/charts/values.yaml.tpl
@@ -192,6 +192,7 @@ acs: &acs
   enabled: {{ $acs.Enabled }}
   name: &acsName stackrox-central-services
   ingressDomain: {{ $ingressDomain }}
+  ingressRouterCA: {{ $ingressRouterCA }}
   integrationSecret:
     namespace: {{ .Installer.Namespace }}
   test:


### PR DESCRIPTION
Found out the deployment on self-signed cluster was now failing on adding quay (and probably other) integrations to ACS. That's because ACS was not trusting Quay (which was deployed on the same self-signed cluster).