### PR TITLE
Reverting temp workaround to get install task using new go version

### DIFF
--- a/integration-tests/pipelines/rhtap-cli-e2e.yaml
+++ b/integration-tests/pipelines/rhtap-cli-e2e.yaml
@@ -115,9 +115,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/dperaza4dustbit/rhtap-cli.git
+            value: https://github.com/redhat-appstudio/rhtap-cli.git
           - name: revision
-            value: upgrade_go_and_deps
+            value: main
           - name: pathInRepo
             value: integration-tests/tasks/rhtap-install.yaml
       params:


### PR DESCRIPTION
After PR 730 merged there is no need for this temp workaround