### PR TITLE
Decrease the chance of CI failure due to TektonConfig cr being there

### DIFF
--- a/installer/charts/rhtap-subscriptions/templates/openshift-pipelines/delete_tekton_config.yaml
+++ b/installer/charts/rhtap-subscriptions/templates/openshift-pipelines/delete_tekton_config.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-tekton-config-if-exists
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  backoffLimit: 8
+  template:
+    spec:
+      serviceAccountName: delete-tekton-config-sa
+      restartPolicy: OnFailure
+      containers:
+        - name: delete-tekton-config
+          image: quay.io/openshift/origin-cli:latest
+          resources:
+            limits:
+              memory: 128Mi
+          command:
+            - /bin/bash
+            - -c
+            - |
+              if [[ "{{ .Values.subscriptions.openshiftPipelines.managed }}" == "true" ]]; then
+                  echo "Deleting TektonConfig resource if it exists to allow helm to own the resource"
+                  oc delete tektonconfig config --ignore-not-found
+              else
+                  echo "Skipping TektonConfig resource delete as pipeline subscription is not managed"
+              fi
+              if [[ $? -ne 0 ]]; then
+                  echo "Sleeping for 5 seconds before letting job restart pod"
+                  sleep 5
+                  exit 1
+              fi

--- a/installer/charts/rhtap-subscriptions/templates/openshift-pipelines/post-install-hook-rbac.yaml
+++ b/installer/charts/rhtap-subscriptions/templates/openshift-pipelines/post-install-hook-rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: delete-tekton-config-sa
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.postDeployDeleteLabels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: delete-tekton-config-role
+  labels: {{- include "common.postDeployDeleteLabels" . | nindent 4 }}
+rules:
+  - apiGroups: ["operator.tekton.dev"]
+    resources: ["tektonconfigs"]
+    verbs: ["get", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: delete-tekton-config-rolebinding
+  labels: {{- include "common.postDeployDeleteLabels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: delete-tekton-config-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: delete-tekton-config-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The logic in the tekton [controller](https://github.com/tektoncd/operator/blob/main/pkg/reconciler/shared/tektonconfig/controller.go#L127) code  which calls the [ensureInstance](https://github.com/tektoncd/operator/blob/main/pkg/reconciler/shared/tektonconfig/instance.go#L64) function suggest that it is best effort to create a config instance if is not there already. So my theory is that even if the AUTOINSTALL_COMPONENTS env var is set to false there could still be a chance of a config being created and that is why we see considerable runs of install failing becase helm cannot take ownership of the resource.

I think this could improve our chances of success with our CI.