### PR TITLE
RHTAP-2871: Update rhtap-install task to set DH catalog url from tssc-sample-templates repo

### DIFF
--- a/integration-tests/tasks/rhtap-install.yaml
+++ b/integration-tests/tasks/rhtap-install.yaml
@@ -81,6 +81,15 @@ spec:
         echo "export pipeline_config=\"$(params.pipeline_config)\"" >> ${env_file}
         echo "export auth_config=\"$(params.auth_config)\"" >> ${env_file}
 
+        # Check if GIT_REPO is tssc-sample-templates and update Developer Hub catalog url based on PR changes
+        if [[ "${GIT_REPO}" = "tssc-sample-templates" ]]; then
+            GIT_REVISION="${GIT_REVISION:-$(echo "$JOB_SPEC" | jq -r '.git.commit_sha')}"
+            GIT_URL="${GIT_URL:-$(echo "$JOB_SPEC" | jq -r '.git.source_repo_url')}"
+            TEST_DH_CATALOG_URL="$GIT_URL/blob/$GIT_REVISION/all.yaml"
+            # Update DEVELOPER_HUB__CATALOG__URL value in .ci-env
+            sed -i "s|^export DEVELOPER_HUB__CATALOG__URL.*|export DEVELOPER_HUB__CATALOG__URL=${TEST_DH_CATALOG_URL}|" "${env_file}"
+        fi
+
         echo "INFO: .env file for tssc installation"
         cat ${env_file}
         # Deploy tssc


### PR DESCRIPTION
This change is required for testing tssc-sample-templates PR changes in Konflux.