### PR TITLE
Switch default namespace from rhtap to tssc

### DIFF
--- a/hack/ci-set-org-vars.sh
+++ b/hack/ci-set-org-vars.sh
@@ -20,7 +20,7 @@ Optional arguments:
     -e, --env-file ENVFILE
         Environment variables definitions (default: $SCRIPT_DIR/private.env)
     -n, --namespace NAMESPACE
-        RHTAP installation namespace (default: rhtap)
+        RHTAP installation namespace (default: tssc)
     -d, --debug
         Activate tracing/debug mode.
     -h, --help
@@ -32,7 +32,7 @@ Example:
 }
 
 parse_args() {
-    NAMESPACE="rhtap"
+    NAMESPACE="tssc"
     ENVFILE="$SCRIPT_DIR/private.env"
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -97,8 +97,8 @@ getValues() {
     ROX_CENTRAL_ENDPOINT="$(oc get secrets -n "$NAMESPACE" "$SECRET" -o json | yq '.data.endpoint | @base64d')"
     ROX_API_TOKEN="$(oc get secrets -n "$NAMESPACE" "$SECRET" -o json | yq '.data.token | @base64d')"
 
-    REKOR_HOST="https://$(oc get routes -n rhtap-tas -l "app.kubernetes.io/name=rekor-server" -o jsonpath="{.items[0].spec.host}")"
-    TUF_MIRROR="https://$(oc get routes -n rhtap-tas -l "app.kubernetes.io/name=tuf" -o jsonpath="{.items[0].spec.host}")"
+    REKOR_HOST="https://$(oc get routes -n tssc-tas -l "app.kubernetes.io/name=rekor-server" -o jsonpath="{.items[0].spec.host}")"
+    TUF_MIRROR="https://$(oc get routes -n tssc-tas -l "app.kubernetes.io/name=tuf" -o jsonpath="{.items[0].spec.host}")"
 }
 
 getSCMs() {

--- a/installer/charts/rhtap-infrastructure/templates/openshift-pipelines/tektonconfig/patch._tpl
+++ b/installer/charts/rhtap-infrastructure/templates/openshift-pipelines/tektonconfig/patch._tpl
@@ -2,7 +2,7 @@
 spec:
   chain:
     transparency.enabled: 'true'
-    transparency.url: http://rekor-server.rhtap-tas.svc
+    transparency.url: http://rekor-server.tssc-tas.svc
   platforms:
     openshift:
       pipelinesAsCode:

--- a/installer/charts/rhtap-infrastructure/templates/postgres/postgresclusters.yaml
+++ b/installer/charts/rhtap-infrastructure/templates/postgres/postgresclusters.yaml
@@ -24,7 +24,8 @@ spec:
       options: SUPERUSER
   backups:
     pgbackrest:
-  {{- with $v.pgbackrestGlobal }}
+      image: {{ required ".image is required" $v.pgbackrest.image }}
+  {{- with $v.pgbackrest.global }}
       global:
         {{- toYaml . | nindent 8 }}
   {{- end }}

--- a/installer/charts/rhtap-infrastructure/values.yaml
+++ b/installer/charts/rhtap-infrastructure/values.yaml
@@ -140,8 +140,10 @@ infrastructure:
       namespace: __OVERWRITE_ME__
       postgresVersion: 14
       image: registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:6f4db1e9707b196aaa9f98ada5c09523ec00ade573ff835bd1ca6367ac0bb9f1
-      pgbackrestGlobal:
-        repo1-retention-full: "3"
+      pgbackrest:
+        global:
+          repo1-retention-full: "3"
+        image: registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:7092a1036b0ff04004a45bae296262a97b96cb81eab266ce68197060f6711c6b
       backupRepos:
         - name: repo1
           volume:
@@ -164,8 +166,10 @@ infrastructure:
       namespace: __OVERWRITE_ME__
       postgresVersion: 14
       image: registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:6f4db1e9707b196aaa9f98ada5c09523ec00ade573ff835bd1ca6367ac0bb9f1
-      pgbackrestGlobal:
-        repo1-retention-full: "3"
+      pgbackrest:
+        global:
+          repo1-retention-full: "3"
+        image: registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:7092a1036b0ff04004a45bae296262a97b96cb81eab266ce68197060f6711c6b
       backupRepos:
         - name: repo1
           volume:

--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -1,32 +1,32 @@
 ---
 rhtapCLI:
-  namespace: &installerNamespace rhtap
+  namespace: &installerNamespace tssc
   features:
     crc:
       enabled: false
     trustedProfileAnalyzer:
       enabled: &tpaEnabled true
-      namespace: &trustedProfileAnalyzerNamespace rhtap-tpa
+      namespace: &trustedProfileAnalyzerNamespace tssc-tpa
       properties:
         manageSubscription: true
     keycloak:
       enabled: *tpaEnabled
-      namespace: rhtap-keycloak
+      namespace: tssc-keycloak
       properties:
         manageSubscription: true
     trustedArtifactSigner:
       enabled: &tasEnabled true
-      namespace: &trustedArtifactSignerNamespace rhtap-tas
+      namespace: &trustedArtifactSignerNamespace tssc-tas
       properties:
         manageSubscription: true
     redHatDeveloperHub:
       enabled: &rhdhEnabled true
-      namespace: &rhdhNamespace rhtap-dh
+      namespace: &rhdhNamespace tssc-dh
       properties:
         catalogURL: https://github.com/redhat-appstudio/tssc-sample-templates/blob/release-v1.5.x/all.yaml
         manageSubscription: true
         # namespacePrefixes:
-        #   - rhtap-app
+        #   - tssc-app
         # RBAC:
         #   adminUsers:
         #     - myUsername
@@ -35,17 +35,17 @@ rhtapCLI:
         #     - myOrg
     redHatAdvancedClusterSecurity:
       enabled: &rhacsEnabled true
-      namespace: &rhacsNamespace rhtap-acs
+      namespace: &rhacsNamespace tssc-acs
       properties:
         manageSubscription: true
     redHatQuay:
       enabled: &quayEnabled true
-      namespace: &quayNamespace rhtap-quay
+      namespace: &quayNamespace tssc-quay
       properties:
         manageSubscription: true
     openShiftGitOps:
       enabled: &gitopsEnabled true
-      namespace: &gitopsNamespace rhtap-gitops
+      namespace: &gitopsNamespace tssc-gitops
       properties:
         manageSubscription: true
     openShiftPipelines:

--- a/installer/scripts/acs-integration-helper.sh
+++ b/installer/scripts/acs-integration-helper.sh
@@ -18,7 +18,7 @@ Optional arguments:
     --insecure
         Disable TLS certificate validation in the integration
     -n, --namespace NAMESPACE
-        RHTAP installation namespace (default: rhtap)
+        RHTAP installation namespace (default: tssc)
     -d, --debug
         Activate tracing/debug mode.
     -h, --help
@@ -30,7 +30,7 @@ Example:
 }
 
 parse_args() {
-    NAMESPACE="${NAMESPACE:-rhtap}"
+    NAMESPACE="${NAMESPACE:-tssc}"
     INSECURE="false"
     while [[ $# -gt 0 ]]; do
         case $1 in

--- a/integration-tests/pipelines/rhtap-cli-e2e.yaml
+++ b/integration-tests/pipelines/rhtap-cli-e2e.yaml
@@ -168,9 +168,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/rhtap-e2e.git
+            value: https://github.com/rhopp/rhtap-e2e.git
           - name: revision
-            value: main
+            value: fixCI
           - name: pathInRepo
             value: integration-tests/tasks/rhtap-e2e.yaml
       params:

--- a/integration-tests/scripts/install.sh
+++ b/integration-tests/scripts/install.sh
@@ -228,8 +228,8 @@ install_rhtap() {
   ./bin/tssc deploy --timeout 35m --values-template "$tpl_file" --kube-config "$KUBECONFIG"
   set +x
 
-  homepage_url=https://$(kubectl -n rhtap-dh get route backstage-developer-hub -o  'jsonpath={.spec.host}')
-  callback_url=https://$(kubectl -n rhtap-dh get route backstage-developer-hub -o  'jsonpath={.spec.host}')/api/auth/${auth_config}/handler/frame
+  homepage_url=https://$(kubectl -n tssc-dh get route backstage-developer-hub -o  'jsonpath={.spec.host}')
+  callback_url=https://$(kubectl -n tssc-dh get route backstage-developer-hub -o  'jsonpath={.spec.host}')/api/auth/${auth_config}/handler/frame
   webhook_url=https://$(kubectl -n openshift-pipelines get route pipelines-as-code-controller -o 'jsonpath={.spec.host}')
 
   echo "[INFO] homepage_url=$homepage_url"


### PR DESCRIPTION
As this switch already happened in tssc-sample-templates, we need to do this switch here as well. Otherwise argocd deployments will be failing with 
```
time="2025-05-14T04:24:37Z" level=info msg="Adding resource result, status: 'SyncFailed', phase: 'Failed', message: 'applications.argoproj.io is forbidden: User \"system:serviceaccount:rhtap-gitops:rhtap-gitops-argocd-application-controller\" cannot create resource \"applications\" in API group \"argoproj.io\" in the namespace \"tssc-gitops\"'" application=rhtap-gitops/vz543j17x-nodejs-app-of-apps kind=Application name=vz543j17x-nodejs-prod namespace=tssc-gitops phase=Sync syncId=00003-bMBop
```

This PR is rebased on https://github.com/redhat-appstudio/rhtap-cli/pull/771 in order for installation to succeed.