### PR TITLE
RHTAP-4553: `tssc config` Subcommand vs. Global Flags (`--dry-run`)

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -29,7 +29,7 @@ func (r *RootCmd) Cmd() *cobra.Command {
 	r.cmd.AddCommand(subcmd.NewIntegration(logger, r.kube))
 
 	for _, sub := range []subcmd.Interface{
-		subcmd.NewConfig(logger, r.cfs, r.kube),
+		subcmd.NewConfig(logger, r.flags, r.cfs, r.kube),
 		subcmd.NewDeploy(logger, r.flags, r.cfs, r.kube),
 		subcmd.NewTemplate(logger, r.flags, r.cfs, r.kube),
 		subcmd.NewInstaller(r.flags),

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -22,6 +22,8 @@ const (
 	Filename = "config.yaml"
 	// Label label selector to find the cluster's installer configuration.
 	Label = "tssc.redhat-appstudio.github.com/config"
+	// Name name of the installer's configuration ConfigMap.
+	Name = "tssc-config"
 )
 
 var (
@@ -111,7 +113,7 @@ func (m *ConfigMapManager) configMapForConfig(
 ) (*corev1.ConfigMap, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "tssc-config",
+			Name:      Name,
 			Namespace: cfg.Installer.Namespace,
 			Labels: map[string]string{
 				Label: "true",


### PR DESCRIPTION
Including the application's global flags reference to identify when `--dry-run` flag is informed on `tssc config` subcommand.