### PR TITLE
fix: lock rhtap-e2e revision

### DIFF
--- a/integration-tests/pipelines/rhtap-cli-e2e.yaml
+++ b/integration-tests/pipelines/rhtap-cli-e2e.yaml
@@ -170,7 +170,7 @@ spec:
           - name: url
             value: https://github.com/redhat-appstudio/rhtap-e2e.git
           - name: revision
-            value: main
+            value: rhtap
           - name: pathInRepo
             value: integration-tests/tasks/rhtap-e2e.yaml
       params:


### PR DESCRIPTION
Lock to revision before name change.