### PR TITLE
Do not enable ODF if TPA is enabled

### DIFF
--- a/installer/charts/values.yaml.tpl
+++ b/installer/charts/values.yaml.tpl
@@ -10,7 +10,7 @@
 {{- $ingressDomain := required "OpenShift ingress domain" .OpenShift.Ingress.Domain -}}
 {{- $ingressRouterCA := required "OpenShift RouterCA" .OpenShift.Ingress.RouterCA -}}
 {{- $openshiftMinorVersion := required "OpenShift Version" .OpenShift.MinorVersion -}}
-{{- $odfEnabled := or $tpa.Enabled $quay.Enabled -}}
+{{- $odfEnabled := $quay.Enabled -}}
 {{- $odfNamespace := "openshift-storage" -}}
 ---
 debug:


### PR DESCRIPTION
TPA is configured to use filesystem storage. It does not have an ODF dependency.