### PR TITLE
feat: update TektonChain configuration

### DIFF
--- a/installer/charts/tssc-pipelines/scripts/test-signing-secrets.sh
+++ b/installer/charts/tssc-pipelines/scripts/test-signing-secrets.sh
@@ -1,0 +1,1 @@
+../../../scripts/test-signing-secrets.sh

--- a/installer/charts/tssc-pipelines/templates/_copy-scripts.tpl
+++ b/installer/charts/tssc-pipelines/templates/_copy-scripts.tpl
@@ -1,0 +1,1 @@
+../../_common/_copy-scripts.tpl

--- a/installer/charts/tssc-pipelines/templates/tektonconfig/patch._tpl
+++ b/installer/charts/tssc-pipelines/templates/tektonconfig/patch._tpl
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   chain:
+    generateSigningSecret: true
     transparency.enabled: 'true'
     transparency.url: http://rekor-server.tssc-tas.svc
   platforms:

--- a/installer/charts/tssc-pipelines/templates/tests/_test.tpl
+++ b/installer/charts/tssc-pipelines/templates/tests/_test.tpl
@@ -1,0 +1,1 @@
+../../../_common/_test.tpl

--- a/installer/charts/tssc-pipelines/templates/tests/test.yaml
+++ b/installer/charts/tssc-pipelines/templates/tests/test.yaml
@@ -1,0 +1,12 @@
+---
+{{- include "common.test" . }}
+  containers:
+    - name: signing-secrets
+      image: quay.io/codeready-toolchain/oc-client-base:latest
+      command:
+        - /scripts/test-signing-secrets.sh
+      volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+      securityContext:
+        allowPrivilegeEscalation: false

--- a/installer/scripts/test-signing-secrets.sh
+++ b/installer/scripts/test-signing-secrets.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Check that the signing secret is not empty.
+#
+
+shopt -s inherit_errexit
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+usage() {
+    echo "
+Usage:
+    ${0##*/} [options]
+
+Optional arguments:
+    -d, --debug
+        Activate tracing/debug mode.
+    -h, --help
+        Display this message.
+
+Example:
+    ${0##*/}
+" >&2
+}
+
+parse_args() {
+    # Number of retries to attempt before giving up.
+    RETRIES=${RETRIES:-20}
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+        -d | --debug)
+            set -x
+            DEBUG="--debug"
+            export DEBUG
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        esac
+        shift
+    done
+}
+
+#
+# Functions
+#
+
+fail() {
+    echo "# [ERROR] ${*}" >&2
+    exit 1
+}
+
+info() {
+    echo "# [INFO] ${*}"
+}
+
+status() {
+    items=$(
+        oc get secret \
+            --ignore-not-found \
+            --namespace="openshift-pipelines" \
+            --output=jsonpath="{.data}" \
+        "signing-secrets" | sed 's:",":\n:g' | grep -c '":"'
+    )
+    if [ "$items" -lt 3 ]; then
+        return 1
+    fi
+    return 0
+}
+
+test_signing_secrets() {
+    for i in $(seq 0 "${RETRIES}"); do
+        wait=$(( i * 5))
+        [[ $wait -gt 30  ]] && wait=30
+        info "[${i}/${RETRIES}] Waiting for ${wait} seconds before retrying..."
+        sleep ${wait}
+
+        status &&
+            return 0
+    done
+    return 1
+}
+
+#
+# Main
+#
+main() {
+    parse_args "$@"
+    if test_signing_secrets; then
+        info "# signing-secrets ready"
+    else
+        fail "signing-secrets not ready!"
+    fi
+}
+
+if [ "${BASH_SOURCE[0]}" == "$0" ]; then
+    main "$@"
+    echo "Success"
+fi


### PR DESCRIPTION
Use the operator configuration to generate the signing-secret. Tests have shown that the operator does not overwrites an existing secret, so no additional safeguards are needed to enable the feature.

Remove the option to configure the secret name, as the name is static for TektonChain.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED