### PR TITLE
revert using task from fork back to main

### DIFF
--- a/integration-tests/pipelines/rhtap-cli-e2e.yaml
+++ b/integration-tests/pipelines/rhtap-cli-e2e.yaml
@@ -119,9 +119,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/rhopp/rhtap-cli.git
+            value: https://github.com/redhat-appstudio/rhtap-cli.git
           - name: revision
-            value: useSnapshot
+            value: main
           - name: pathInRepo
             value: integration-tests/tasks/rhtap-install.yaml
       params:


### PR DESCRIPTION
I needed to use task from my fork/feature branch in order for the CI to pass.
This PR reverts that now that https://github.com/redhat-appstudio/rhtap-cli/pull/829 is merged.