### PR TITLE
fix(pipeline): add default rhtap-cli image if not found in SNAPSHOT

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -126,6 +126,10 @@ spec:
               #!/usr/bin/env bash
 
               tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="rhtap-cli").containerImage')
+              if [[ -z "$tssc_image" ]]; then
+                echo "rhtap-cli image was not found in SNAPSHOT, using default"
+                tssc_image="quay.io/rhtap/rhtap-cli:latest"
+              fi
 
               # Waits for condition for all started pipelines
               function waitFor() {


### PR DESCRIPTION
This happens when this pipeline is used from different repository (like rhtap-e2e for example)