### PR TITLE
fix: Prevent NPE in Config's `.tssc.settings`

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,11 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("%w: missing namespace", ErrInvalidConfig)
 	}
 
+	// The installer must have a settings section.
+	if root.Settings == nil {
+		return fmt.Errorf("%w: missing settings", ErrInvalidConfig)
+	}
+
 	// Validating the products, making sure every product entry is valid.
 	for _, product := range root.Products {
 		if err := product.Validate(); err != nil {


### PR DESCRIPTION
When the `.tssc.settings` is null, this template evaluation fails:

    {{- $crc := required "CRC settings" .Installer.Settings.crc -}}

This commit fixes this issue, making sure the attribute is validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation to ensure the Settings section is present, providing clearer error messages when required settings are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->