### PR TITLE
add cloud-credential-key parameter

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -16,6 +16,9 @@ spec:
         - name: konflux-test-infra-secret
           description: The name of secret where testing infrastructures credentials are stored.
           type: string
+        - name: cloud-credential-key
+          description: The key secret from konflux-test-infra-secret where all AWS ROSA configurations are stored.
+          type: string
     tasks:
         - name: test-metadata
           taskRef:
@@ -158,6 +161,7 @@ spec:
                             --param job-spec="$JOB_SPEC"\
                             --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
                             --param rhads-config="$RHADS_CONFIG_CONTENT" \
+                            --param cloud-credential-key="$(params.cloud-credential-key)" \
                             $(if [[ "${tssc_image}" != "" ]]; then echo "--param tssc-image=${tssc_image}"; fi) \
                             $(if [[ "${tssc_test_image}" != "" ]]; then echo "--param tssc-test-image=${tssc_test_image}"; fi) \
                             --use-param-defaults \

--- a/integration-tests/pipelines/rhtap-cli-e2e.yaml
+++ b/integration-tests/pipelines/rhtap-cli-e2e.yaml
@@ -19,7 +19,6 @@ spec:
       type: string
     - name: cloud-credential-key
       type: string
-      default: "qe-cloud-credentials-us-east-1"
       description: The key secret from konflux-test-infra-secret where all AWS ROSA configurations are stored.
     - name: replicas
       description: 'The number of replicas for the cluster nodes.'


### PR DESCRIPTION
Adding cloud-credential-key parameter is to make AWS account configurable, we will switch AWS account to our own

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new pipeline parameter for cloud credential key, allowing users to specify AWS ROSA configuration secrets when running pipelines.

* **Chores**
  * Removed the default value from the cloud credential key parameter in one of the pipelines, requiring explicit input for this parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->