### PR TITLE
[RHTAPUI-54] Adds UI tests task to e2e pipeline

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -21,6 +21,9 @@ In order to succesfully run this integration test one must:
         * `bitbucket-username`
         * `bitbucket-app-password`
         * `rhdh-github-webhook-secret`
+        * `github-username`
+        * `github-password`
+        * `github-2fa-secret`
         * `github_token`
         * `rhdh-github-app-id`
         * `rhdh-github-private-key`

--- a/integration-tests/pipelines/rhtap-cli-e2e.yaml
+++ b/integration-tests/pipelines/rhtap-cli-e2e.yaml
@@ -161,6 +161,28 @@ spec:
           value: $(tasks.create-oci-container.results.oci-container)
         - name: tssc-test-image
           value: $(params.tssc-test-image)
+    - name: rhtap-ui-tests
+      runAfter:
+        - rhtap-e2e-tests
+      onError: continue
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/tssc-test.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: integration-tests/tasks/tssc-ui.yaml
+      params:
+        - name: job-spec
+          value: $(params.job-spec)
+        - name: ocp-login-command
+          value: "$(tasks.provision-rosa.results.ocp-login-command)"
+        - name: oci-container
+          value: $(tasks.create-oci-container.results.oci-container)
+        - name: tssc-test-image
+          value: $(params.tssc-test-image)
   finally:
     - name: deprovision-rosa-collect-artifacts
       taskRef:


### PR DESCRIPTION
This PR integrates UI tests to CI pipeline and switches the order of git providers in DH config to make Github the default for sign in page.

Please do not merge this PR before https://github.com/redhat-appstudio/tssc-test/pull/58 is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new UI test task to the end-to-end installation pipeline, which runs automatically after existing tests.

* **Documentation**
  * Updated integration test documentation to include additional required GitHub credentials for setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->