### PR TITLE
added ocp node parameters in pipeline

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -2,204 +2,214 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-    name: e2e-main-pipeline
-    namespace: rhtap-shared-team-tenant
-    labels:
-        appstudio.openshift.io/component: rhtap-cli
-        appstudio.openshift.io/application: rhtap-cli
+  name: e2e-main-pipeline
+  namespace: rhtap-shared-team-tenant
+  labels:
+    appstudio.openshift.io/component: rhtap-cli
+    appstudio.openshift.io/application: rhtap-cli
 spec:
-    params:
+  params:
+    - name: SNAPSHOT
+      description: "The JSON string representing the snapshot of the application under test."
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: konflux-test-infra-secret
+      description: The name of secret where testing infrastructures credentials are stored.
+      type: string
+    - name: cloud-credential-key
+      description: The key secret from konflux-test-infra-secret where all AWS ROSA configurations are stored.
+      type: string
+    - name: ocp-instance-type
+      description: 'The type of machine to use for the cluster nodes.'
+      default: "m5.2xlarge"
+      type: string
+    - name: ocp-replicas
+      description: 'The number of replicas for the cluster nodes.'
+      default: "3"
+      type: string
+  tasks:
+    - name: test-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: common/tasks/test-metadata/0.2/test-metadata.yaml
+      params:
         - name: SNAPSHOT
-          description: "The JSON string representing the snapshot of the application under test."
-          default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
-          type: string
-        - name: konflux-test-infra-secret
-          description: The name of secret where testing infrastructures credentials are stored.
-          type: string
-        - name: cloud-credential-key
-          description: The key secret from konflux-test-infra-secret where all AWS ROSA configurations are stored.
-          type: string
-    tasks:
-        - name: test-metadata
-          taskRef:
-              resolver: git
-              params:
-                  - name: url
-                    value: https://github.com/konflux-ci/konflux-qe-definitions.git
-                  - name: revision
-                    value: main
-                  - name: pathInRepo
-                    value: common/tasks/test-metadata/0.2/test-metadata.yaml
-          params:
+          value: $(params.SNAPSHOT)
+        - name: test-name
+          value: $(context.pipelineRun.name)
+    - name: process-rhads-config
+      taskSpec:
+        volumes:
+          - name: shared-data
+            emptyDir: {}
+        results:
+          - name: rhads-config
+            description: JSON formatted configuration data
+        steps:
+          - name: get-rhads-config
+            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+            env:
+              - name: JOB_SPEC
+                value: $(tasks.test-metadata.results.job-spec)
+            volumeMounts:
+              - name: shared-data
+                mountPath: /shared
+            script: |
+              #!/usr/bin/env bash
+
+              echo "Downloading rhads-config file:"
+              GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
+              REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
+              BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+
+              rhads_config_file_location="integration-tests/config/rhads-config"
+              curl -o rhads-config https://raw.githubusercontent.com/$REPO_ORG/$GIT_REPO/refs/heads/$BRANCH/$rhads_config_file_location
+
+              cat rhads-config | tee $(results.rhads-config.path)
+    - name: start-nested-pipelines
+      params:
+        - name: job-spec
+          value: "$(tasks.test-metadata.results.job-spec)"
+      runAfter:
+        - test-metadata
+        - process-rhads-config
+      taskSpec:
+        steps:
+          - name: start-pipeline
+            image: quay.io/openshift-pipeline/ci
+            env:
               - name: SNAPSHOT
                 value: $(params.SNAPSHOT)
-              - name: test-name
-                value: $(context.pipelineRun.name)
-        - name: process-rhads-config
-          taskSpec:
-              volumes:
-                  - name: shared-data
-                    emptyDir: {}
-              results:
-                  - name: rhads-config
-                    description: JSON formatted configuration data
-              steps:
-                  - name: get-rhads-config
-                    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
-                    env:
-                        - name: JOB_SPEC
-                          value: $(tasks.test-metadata.results.job-spec)
-                    volumeMounts:
-                        - name: shared-data
-                          mountPath: /shared
-                    script: |
-                        #!/usr/bin/env bash
+              - name: JOB_SPEC
+                value: $(tasks.test-metadata.results.job-spec)
+              - name: RHADS_CONFIG
+                value: $(tasks.process-rhads-config.results.rhads-config)
+              - name: KONFLUX_APPLICATION_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/application']
+              - name: KONFLUX_COMPONENT_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/component']
+              - name: KONFLUX_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            script: |
+              #!/usr/bin/env bash
 
-                        echo "Downloading rhads-config file:"
-                        GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
-                        REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
-                        BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+              # Load the RHADS configuration
+              RHADS_CONFIG_CONTENT=$(echo $RHADS_CONFIG)
+              echo "$RHADS_CONFIG_CONTENT"
 
-                        rhads_config_file_location="integration-tests/config/rhads-config"
-                        curl -o rhads-config https://raw.githubusercontent.com/$REPO_ORG/$GIT_REPO/refs/heads/$BRANCH/$rhads_config_file_location
+              # get the tssc image and tssc-test image from the snapshot
+              tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="rhtap-cli").containerImage')
+              tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
 
-                        cat rhads-config | tee $(results.rhads-config.path)
-        - name: start-nested-pipelines
-          params:
-              - name: job-spec
-                value: "$(tasks.test-metadata.results.job-spec)"
-          runAfter:
-              - test-metadata
-              - process-rhads-config
-          taskSpec:
-              steps:
-                  - name: start-pipeline
-                    image: quay.io/openshift-pipeline/ci
-                    env:
-                        - name: SNAPSHOT
-                          value: $(params.SNAPSHOT)
-                        - name: JOB_SPEC
-                          value: $(tasks.test-metadata.results.job-spec)
-                        - name: RHADS_CONFIG
-                          value: $(tasks.process-rhads-config.results.rhads-config)
-                        - name: KONFLUX_APPLICATION_NAME
-                          valueFrom:
-                              fieldRef:
-                                  fieldPath: metadata.labels['appstudio.openshift.io/application']
-                        - name: KONFLUX_COMPONENT_NAME
-                          valueFrom:
-                              fieldRef:
-                                  fieldPath: metadata.labels['appstudio.openshift.io/component']
-                        - name: KONFLUX_NAMESPACE
-                          valueFrom:
-                              fieldRef:
-                                  fieldPath: metadata.namespace
-                    script: |
-                        #!/usr/bin/env bash
+              # Extract OCP versions from RHADS config
+              [[ $RHADS_CONFIG_CONTENT =~ OCP=\"([^\"]+)\" ]] && IFS=',' read -ra OCP_VERSIONS <<< "${BASH_REMATCH[1]}"
 
-                        # Load the RHADS configuration
-                        RHADS_CONFIG_CONTENT=$(echo $RHADS_CONFIG)
-                        echo "$RHADS_CONFIG_CONTENT"
+              echo "Running tests for OCP versions: ${OCP_VERSIONS[*]}"
 
-                        # get the tssc image and tssc-test image from the snapshot
-                        tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="rhtap-cli").containerImage')
-                        tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
-
-                        # Extract OCP versions from RHADS config
-                        [[ $RHADS_CONFIG_CONTENT =~ OCP=\"([^\"]+)\" ]] && IFS=',' read -ra OCP_VERSIONS <<< "${BASH_REMATCH[1]}"
-
-                        echo "Running tests for OCP versions: ${OCP_VERSIONS[*]}"
-
-                        # Waits for condition for all started pipelines
-                        function waitFor() {
-                            CONDITION=$1 MESSAGE_RUNNING=$2 MESSAGE_DONE=$3 timeout --foreground 120m /bin/bash -c '
-                              #deserialize plrs array
-                              set -x
-                              read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
-                              echo "${PIPELINERUNS_ARRAY[*]}"
-                              while true; do
-                                CONDITION_MET=false
-                                for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-                                  if eval "$CONDITION"; then
-                                    #something is still running. Break this cycle and wait one minute.
-                                    CONDITION_MET=true
-                                    break
-                                  fi
-                                done
-                                if $CONDITION_MET ; then
-                                  echo "$MESSAGE_RUNNING"
-                                  sleep 60
-                                else
-                                  echo "$MESSAGE_DONE"
-                                  break
-                                fi
-                              done
-                            '
-                        }
-
-                        set -euo pipefail
-
-                        GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
-                        KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
-
-                        if [[ "${GIT_REPO}" = "rhtap-cli" ]]; then
-                          REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
-                          BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
-                        else
-                          REPO_ORG="redhat-appstudio"
-                          BRANCH="main"
+              # Waits for condition for all started pipelines
+              function waitFor() {
+                  CONDITION=$1 MESSAGE_RUNNING=$2 MESSAGE_DONE=$3 timeout --foreground 120m /bin/bash -c '
+                    #deserialize plrs array
+                    set -x
+                    read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
+                    echo "${PIPELINERUNS_ARRAY[*]}"
+                    while true; do
+                      CONDITION_MET=false
+                      for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
+                        if eval "$CONDITION"; then
+                          #something is still running. Break this cycle and wait one minute.
+                          CONDITION_MET=true
+                          break
                         fi
+                      done
+                      if $CONDITION_MET ; then
+                        echo "$MESSAGE_RUNNING"
+                        sleep 60
+                      else
+                        echo "$MESSAGE_DONE"
+                        break
+                      fi
+                    done
+                  '
+              }
 
-                        PIPELINERUNS_ARRAY=()
+              set -euo pipefail
 
-                        # Loop through each OCP version and start a sub-pipeline for each
-                        for OCP_VERSION in "${OCP_VERSIONS[@]}"; do
-                          echo "Starting sub-pipeline for OCP version: $OCP_VERSION"
+              GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
+              KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
 
-                          PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/rhtap-cli/refs/heads/$BRANCH/integration-tests/pipelines/rhtap-cli-e2e.yaml \
-                            --param ocp-version="$OCP_VERSION"\
-                            --param job-spec="$JOB_SPEC"\
-                            --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
-                            --param rhads-config="$RHADS_CONFIG_CONTENT" \
-                            --param cloud-credential-key="$(params.cloud-credential-key)" \
-                            $(if [[ "${tssc_image}" != "" ]]; then echo "--param tssc-image=${tssc_image}"; fi) \
-                            $(if [[ "${tssc_test_image}" != "" ]]; then echo "--param tssc-test-image=${tssc_test_image}"; fi) \
-                            --use-param-defaults \
-                            --labels "appstudio.openshift.io/component=${KONFLUX_COMPONENT_NAME}" \
-                            --labels "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}" \
-                            --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
-                            --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
-                            --labels "custom.appstudio.openshift.io/main-pipeline-run=$(context.pipelineRun.name)" \
-                            --prefix-name "e2e-$OCP_VERSION"\
-                            -o name)
+              if [[ "${GIT_REPO}" = "rhtap-cli" ]]; then
+                REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
+                BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+              else
+                REPO_ORG="redhat-appstudio"
+                BRANCH="main"
+              fi
 
-                          echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
-                          PIPELINERUNS_ARRAY+=($PIPELINE_RUN)
-                        done
+              PIPELINERUNS_ARRAY=()
 
-                        #Serialize plrs array to be able to export it as var
-                        export PIPELINERUNS_ARRAY_SERIALIZED="${PIPELINERUNS_ARRAY[*]}"
+              # Loop through each OCP version and start a sub-pipeline for each
+              for OCP_VERSION in "${OCP_VERSIONS[@]}"; do
+                echo "Starting sub-pipeline for OCP version: $OCP_VERSION"
 
-                        waitFor '! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null' "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
-                        waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
+                PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/rhtap-cli/refs/heads/$BRANCH/integration-tests/pipelines/rhtap-cli-e2e.yaml \
+                  --param ocp-version="$OCP_VERSION"\
+                  --param job-spec="$JOB_SPEC"\
+                  --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
+                  --param rhads-config="$RHADS_CONFIG_CONTENT" \
+                  --param cloud-credential-key="$(params.cloud-credential-key)" \
+                  --param machine-type="$(params.ocp-instance-type)" \
+                  --param replicas="$(params.ocp-replicas)" \
+                  $(if [[ "${tssc_image}" != "" ]]; then echo "--param tssc-image=${tssc_image}"; fi) \
+                  $(if [[ "${tssc_test_image}" != "" ]]; then echo "--param tssc-test-image=${tssc_test_image}"; fi) \
+                  --use-param-defaults \
+                  --labels "appstudio.openshift.io/component=${KONFLUX_COMPONENT_NAME}" \
+                  --labels "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}" \
+                  --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
+                  --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
+                  --labels "custom.appstudio.openshift.io/main-pipeline-run=$(context.pipelineRun.name)" \
+                  --prefix-name "e2e-$OCP_VERSION"\
+                  -o name)
 
-                        ## Explore and report status of all failed pipelineruns. Fail if anything failed
-                        SOME_PIPELINE_FAILED=false
-                        SOME_PIPELINE_SUCCEEDED=false
-                        for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-                          if [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "False" ]]; then
-                            if ! $SOME_PIPELINE_FAILED ; then
-                              echo "List of failed PLRs:"
-                            fi
-                            echo "${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
-                            SOME_PIPELINE_FAILED=true
-                          elif [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "True" ]]; then
-                            SOME_PIPELINE_SUCCEEDED=true
-                          fi
-                        done
-                        if $SOME_PIPELINE_SUCCEEDED ; then
-                          exit 0
-                        fi
-                        if $SOME_PIPELINE_FAILED ; then
-                          exit 1
-                        fi
+                echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
+                PIPELINERUNS_ARRAY+=($PIPELINE_RUN)
+              done
+
+              #Serialize plrs array to be able to export it as var
+              export PIPELINERUNS_ARRAY_SERIALIZED="${PIPELINERUNS_ARRAY[*]}"
+
+              waitFor '! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null' "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
+              waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
+
+              ## Explore and report status of all failed pipelineruns. Fail if anything failed
+              SOME_PIPELINE_FAILED=false
+              SOME_PIPELINE_SUCCEEDED=false
+              for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
+                if [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "False" ]]; then
+                  if ! $SOME_PIPELINE_FAILED ; then
+                    echo "List of failed PLRs:"
+                  fi
+                  echo "${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
+                  SOME_PIPELINE_FAILED=true
+                elif [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "True" ]]; then
+                  SOME_PIPELINE_SUCCEEDED=true
+                fi
+              done
+              if $SOME_PIPELINE_SUCCEEDED ; then
+                exit 0
+              fi
+              if $SOME_PIPELINE_FAILED ; then
+                exit 1
+              fi

--- a/integration-tests/pipelines/rhtap-cli-e2e.yaml
+++ b/integration-tests/pipelines/rhtap-cli-e2e.yaml
@@ -22,11 +22,9 @@ spec:
       description: The key secret from konflux-test-infra-secret where all AWS ROSA configurations are stored.
     - name: replicas
       description: 'The number of replicas for the cluster nodes.'
-      default: "3"
       type: string
     - name: machine-type
       description: 'The type of machine to use for the cluster nodes.'
-      default: "m6i.4xlarge"
       type: string
     - name: oci-container-repo
       default: 'quay.io/konflux-test-storage/rhtap-team/rhtap-cli'


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new parameters for secret management, cloud credentials, machine type, and replica count to the main pipeline.
  * Introduced a task to automatically download and process external configuration files for pipeline runs.

* **Improvements**
  * Enhanced pipeline flexibility by allowing customization of machine type and replica count when starting nested pipelines.
  * Improved pipeline file clarity and formatting for easier maintenance.

* **Changes**
  * Removed default values for machine type and replica count in the CLI E2E pipeline, requiring explicit parameter specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->