### PR TITLE
RHTAP-5290 Add pict step in e2e pipeline for periodic jobs

### DIFF
--- a/integration-tests/config/periodic/periodic.pict
+++ b/integration-tests/config/periodic/periodic.pict
@@ -3,27 +3,21 @@
 #
 
 OCP: 4.19, 4.18, 4.17
-AUTH: github, gitlab
-ACS: new, hosted
-Registry: quay.io, artifactory, nexus
-TPA: new, hosted
+ACS: local, remote
+Registry: quay, artifactory, nexus
+TPA: local, remote
 SCM: github, gitlab, bitbucket
-Pipeline: tekton, gitlabci, actions, jenkins
+Pipeline: tekton, gitlabci, githubactions, jenkins
 
 # Constraints (copied from default.pict)
 ## Parameter value validation. This doesn't work with the current pict docker image, we can uncomment it when we figure out it in future
-[ACS] IN {"new", "hosted"};
-[Registry] IN {"quay.io", "artifactory", "nexus"};
-[TPA] IN {"new", "hosted"};
+[ACS] IN {"local", "remote"};
+[Registry] IN {"quay", "artifactory", "nexus"};
+[TPA] IN {"local", "remote"};
 [SCM] IN {"github", "gitlab", "bitbucket"};
-[Pipeline] IN {"tekton", "jenkins", "gitlabci", "actions"};
-[AUTH] IN {"github", "gitlab"};
-
-## SCM and AUTH must match for GitHub and GitLab
-IF [SCM] = "github" THEN [AUTH] = "github";
-IF [SCM] = "gitlab" THEN [AUTH] = "gitlab";
+[Pipeline] IN {"tekton", "jenkins", "gitlabci", "githubactions"};
 
 ## Pipeline restrictions based on SCM
-IF [SCM] = "github" THEN [Pipeline] IN {"tekton", "jenkins", "actions"};
+IF [SCM] = "github" THEN [Pipeline] IN {"tekton", "jenkins", "githubactions"};
 IF [SCM] = "gitlab" THEN [Pipeline] IN {"tekton", "jenkins", "gitlabci"};
 IF [SCM] = "bitbucket" THEN [Pipeline] IN {"tekton", "jenkins"};

--- a/integration-tests/config/periodic/periodic.pict
+++ b/integration-tests/config/periodic/periodic.pict
@@ -2,7 +2,7 @@
 # This is file used for github periodic job
 #
 
-OCP: 4.18, 4.17, 4.16
+OCP: 4.19, 4.18, 4.17
 AUTH: github, gitlab
 ACS: new, hosted
 Registry: quay.io, artifactory, nexus

--- a/integration-tests/config/periodic/periodic.pict
+++ b/integration-tests/config/periodic/periodic.pict
@@ -1,0 +1,29 @@
+#
+# This is file used for github periodic job
+#
+
+OCP: 4.18, 4.17, 4.16
+AUTH: github, gitlab
+ACS: new, hosted
+Registry: quay.io, artifactory, nexus
+TPA: new, hosted
+SCM: github, gitlab, bitbucket
+Pipeline: tekton, gitlabci, actions, jenkins
+
+# Constraints (copied from default.pict)
+## Parameter value validation. This doesn't work with the current pict docker image, we can uncomment it when we figure out it in future
+[ACS] IN {"new", "hosted"};
+[Registry] IN {"quay.io", "artifactory", "nexus"};
+[TPA] IN {"new", "hosted"};
+[SCM] IN {"github", "gitlab", "bitbucket"};
+[Pipeline] IN {"tekton", "jenkins", "gitlabci", "actions"};
+[AUTH] IN {"github", "gitlab"};
+
+## SCM and AUTH must match for GitHub and GitLab
+IF [SCM] = "github" THEN [AUTH] = "github";
+IF [SCM] = "gitlab" THEN [AUTH] = "gitlab";
+
+## Pipeline restrictions based on SCM
+IF [SCM] = "github" THEN [Pipeline] IN {"tekton", "jenkins", "actions"};
+IF [SCM] = "gitlab" THEN [Pipeline] IN {"tekton", "jenkins", "gitlabci"};
+IF [SCM] = "bitbucket" THEN [Pipeline] IN {"tekton", "jenkins"};

--- a/integration-tests/config/periodic/testplan_template.json
+++ b/integration-tests/config/periodic/testplan_template.json
@@ -4,11 +4,11 @@
     ],
     "tssc": [
         {
-            "git": "github",
-            "ci": "tekton",
-            "registry": "quay.io",
-            "tpa": "local",
-            "acs": "local"
+            "git": "SCM_PROVIDER",
+            "ci": "CI_PROVIDER",
+            "registry": "REGISTRY",
+            "tpa": "TPA_PROVIDER",
+            "acs": "ACS_PROVIDER"
         }
     ],
     "tests": [

--- a/integration-tests/config/periodic/testplan_template.json
+++ b/integration-tests/config/periodic/testplan_template.json
@@ -1,0 +1,18 @@
+{
+    "templates": [
+        "go"
+    ],
+    "tssc": [
+        {
+            "git": "github",
+            "ci": "tekton",
+            "registry": "quay.io",
+            "tpa": "local",
+            "acs": "local"
+        }
+    ],
+    "tests": [
+        "test1",
+        "test2"
+    ]
+}

--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -27,10 +27,6 @@ spec:
       description: 'The number of replicas for the cluster nodes.'
       default: "3"
       type: string
-    - name: use-periodic-configs
-      description: 'Enable periodic testing mode with multiple configurations generated from PICT file'
-      default: "false"
-      type: string
   tasks:
     - name: test-metadata
       taskRef:
@@ -47,7 +43,6 @@ spec:
           value: $(params.SNAPSHOT)
         - name: test-name
           value: $(context.pipelineRun.name)
-
     - name: process-rhads-config
       taskSpec:
         volumes:
@@ -55,144 +50,32 @@ spec:
             emptyDir: {}
         results:
           - name: rhads-config
-            description: JSON formatted configuration data (single config or array of configs)
+            description: JSON formatted configuration data
         steps:
-          - name: download-pict-file
+          - name: get-rhads-config
             image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
             env:
               - name: JOB_SPEC
                 value: $(tasks.test-metadata.results.job-spec)
-              - name: USE_PERIODIC_CONFIGS
-                value: $(params.use-periodic-configs)
             volumeMounts:
               - name: shared-data
                 mountPath: /shared
             script: |
               #!/usr/bin/env bash
-              set -euo pipefail
-
-              if [[ "$USE_PERIODIC_CONFIGS" == "true" ]]; then
-                echo "Using periodic configurations generated from PICT"
-                # Download periodic.pict file
-                curl -o /shared/periodic.pict https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/periodic.pict
-                cat /shared/periodic.pict
-              else
-                echo "Using traditional single rhads-config file"
-                GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
-                REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
-                # Determine the branch name for the curl command.
-                # If source_repo_branch starts with "refs/heads/", strip that prefix; otherwise, use as is.
-                BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
-                if [[ "$BRANCH" == refs/heads/* ]]; then
-                  BRANCH="${BRANCH#refs/heads/}"
-                fi
-
-                rhads_config_file_location="integration-tests/config/rhads-config"
-                curl -o /shared/rhads-config https://raw.githubusercontent.com/$REPO_ORG/$GIT_REPO/refs/heads/$BRANCH/$rhads_config_file_location
+              echo "Downloading rhads-config file:"
+              GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
+              REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
+              # Determine the branch name for the curl command.
+              # If source_repo_branch starts with "refs/heads/", strip that prefix; otherwise, use as is.
+              BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+              if [[ "$BRANCH" == refs/heads/* ]]; then
+                BRANCH="${BRANCH#refs/heads/}"
               fi
-          - name: generate-pict-output
-            image: quay.io/apodhrad/pict:latest
-            env:
-              - name: USE_PERIODIC_CONFIGS
-                value: $(params.use-periodic-configs)
-            volumeMounts:
-              - name: shared-data
-                mountPath: /shared
-            script: |
-              #!/usr/bin/env bash
-              set -euo pipefail
-              if [[ "$USE_PERIODIC_CONFIGS" == "true" ]]; then
-                echo "Running PICT to generate test configurations..."
-                cd /shared
-                pict periodic.pict -r -o:1 > pict_output.txt
-                cat pict_output.txt
-              fi
-          - name: process-config
-            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
-            env:
-              - name: USE_PERIODIC_CONFIGS
-                value: $(params.use-periodic-configs)
-            volumeMounts:
-              - name: shared-data
-                mountPath: /shared
-            script: |
-              #!/usr/bin/env bash
-              set -euo pipefail
 
-              if [[ "$USE_PERIODIC_CONFIGS" == "true" ]]; then
-                echo "Converting PICT output to RHADS configuration format..."
-                cd /shared
-                # Debug: Check if pict_output.txt exists and show its content
-                if [[ ! -f pict_output.txt ]]; then
-                  echo "ERROR: pict_output.txt not found!"
-                  ls -la /shared/
-                  exit 1
-                fi
-                echo "Content of pict_output.txt:"
-                cat pict_output.txt
-                echo "--- End of pict_output.txt ---"
-                # Download testplan template
-                echo "Downloading testplan template..."
-                curl -o testplan_template.json https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/testplan_template.json
-                if [[ ! -f testplan_template.json ]]; then
-                  echo "ERROR: Failed to download testplan_template.json"
-                  exit 1
-                fi
-                echo "Testplan template content:"
-                cat testplan_template.json
-                # Convert PICT output to multiple RHADS configurations
-                CONFIG_COUNT=0
-                OUTPUT_FILE="/tmp/rhads_output.txt"
-                > "$OUTPUT_FILE"  # Initialize empty file
-                while IFS=$'\t' read -r -a fields; do
-                  echo "Processing line: ${fields[*]}"
-                  if [[ "${fields[0]}" != "OCP" && -n "${fields[0]:-}" ]]; then  # Skip header line and empty lines
-                    if [[ $CONFIG_COUNT -gt 0 ]]; then
-                      echo "---CONFIG_SEPARATOR---" >> "$OUTPUT_FILE"
-                    fi
-                    # Build RHADS config format for this PICT line
-                    echo "OCP=\"${fields[0]:-4.18}\"" >> "$OUTPUT_FILE"
-                    echo "AUTH=\"${fields[1]:-github}\"" >> "$OUTPUT_FILE"
-                    echo "ACS=\"${fields[2]:-new}\"" >> "$OUTPUT_FILE"
-                    echo "REGISTRY=\"${fields[3]:-quay.io}\"" >> "$OUTPUT_FILE"
-                    echo "TPA=\"${fields[4]:-new}\"" >> "$OUTPUT_FILE"
-                    echo "SCM=\"${fields[5]:-github}\"" >> "$OUTPUT_FILE"
-                    echo "PIPELINE=\"${fields[6]:-tekton}\"" >> "$OUTPUT_FILE"
-                    # Generate corresponding testplan
-                    echo "---TESTPLAN_START---" >> "$OUTPUT_FILE"
-                    # Extract values for testplan
-                    SCM_VALUE="${fields[5]:-github}"
-                    PIPELINE_VALUE="${fields[6]:-tekton}"
-                    REGISTRY_VALUE="${fields[3]:-quay.io}"
-                    TPA_VALUE="${fields[4]:-new}"
-                    ACS_VALUE="${fields[2]:-new}"
-                    # Create testplan by replacing placeholders in template more precisely
-                    sed "s/\"git\": \"github\"/\"git\": \"$SCM_VALUE\"/g; s/\"ci\": \"tekton\"/\"ci\": \"$PIPELINE_VALUE\"/g; s/\"registry\": \"quay.io\"/\"registry\": \"$REGISTRY_VALUE\"/g; s/\"tpa\": \"local\"/\"tpa\": \"$TPA_VALUE\"/g; s/\"acs\": \"local\"/\"acs\": \"$ACS_VALUE\"/g" testplan_template.json >> "$OUTPUT_FILE"
-                    echo "---TESTPLAN_END---" >> "$OUTPUT_FILE"
-                    CONFIG_COUNT=$((CONFIG_COUNT + 1))
-                    echo "Generated configuration $CONFIG_COUNT with testplan"
-                  else
-                    echo "Skipping line: ${fields[*]}"
-                  fi
-                done < pict_output.txt
-                echo "Generated $CONFIG_COUNT RHADS configurations with testplans"
-                # Copy output to result path
-                echo "Final output:"
-                cat "$OUTPUT_FILE"
-                cat "$OUTPUT_FILE" > "$(results.rhads-config.path)"
-              else
-                echo "Using traditional single configuration"
-                # Return single config content directly
-                if [[ ! -f /shared/rhads-config ]]; then
-                  echo "ERROR: /shared/rhads-config not found!"
-                  ls -la /shared/
-                  exit 1
-                fi
-                cat /shared/rhads-config > "$(results.rhads-config.path)"
-              fi
-              echo "Configuration processing completed successfully"
-      runAfter:
-        - test-metadata
+              rhads_config_file_location="integration-tests/config/rhads-config"
+              curl -o rhads-config https://raw.githubusercontent.com/$REPO_ORG/$GIT_REPO/refs/heads/$BRANCH/$rhads_config_file_location
+
+              cat rhads-config | tee $(results.rhads-config.path)
     - name: start-nested-pipelines
       params:
         - name: job-spec
@@ -211,8 +94,6 @@ spec:
                 value: $(tasks.test-metadata.results.job-spec)
               - name: RHADS_CONFIG
                 value: $(tasks.process-rhads-config.results.rhads-config)
-              - name: USE_PERIODIC_CONFIGS
-                value: $(params.use-periodic-configs)
               - name: KONFLUX_APPLICATION_NAME
                 valueFrom:
                   fieldRef:
@@ -227,167 +108,19 @@ spec:
                     fieldPath: metadata.namespace
             script: |
               #!/usr/bin/env bash
-              set -euo pipefail
 
-              echo "Processing RHADS configuration(s)..."
+              # Load the RHADS configuration
+              RHADS_CONFIG_CONTENT=$(echo $RHADS_CONFIG)
+              echo "$RHADS_CONFIG_CONTENT"
+
               # get the tssc image and tssc-test image from the snapshot
               tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-cli").containerImage')
               tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
 
-              GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
-              KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
+              # Extract OCP versions from RHADS config
+              [[ $RHADS_CONFIG_CONTENT =~ OCP=\"([^\"]+)\" ]] && IFS=',' read -ra OCP_VERSIONS <<< "${BASH_REMATCH[1]}"
 
-              if [[ "${GIT_REPO}" = "rhtap-cli" ]]; then
-                REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
-                BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
-              else
-                REPO_ORG="redhat-appstudio"
-                BRANCH="main"
-              fi
-
-              PIPELINERUNS_ARRAY=()
-
-              if [[ "$USE_PERIODIC_CONFIGS" == "true" ]]; then
-                echo "Running in periodic mode with multiple configurations"
-                echo "Processing RHADS configurations:"
-                echo "$RHADS_CONFIG"
-                # Split configurations by separator and process each one
-                echo "Splitting configurations using bash string manipulation..."
-                # Count configurations for informational purposes
-                CONFIG_COUNT=$(echo "$RHADS_CONFIG" | grep -o -e "---CONFIG_SEPARATOR---" | wc -l)
-                CONFIG_COUNT=$((CONFIG_COUNT + 1))  # Add 1 because there's one more config than separators
-                echo "Found $CONFIG_COUNT configurations to process"
-                # Create a pipeline for every RHADS config using pure bash string manipulation
-                CONFIG_INDEX=0
-                # Split the configurations using bash string manipulation
-                REMAINING_CONFIG="$RHADS_CONFIG"
-                while [[ -n "$REMAINING_CONFIG" ]]; do
-                  # Find the next separator
-                  if [[ "$REMAINING_CONFIG" == *"---CONFIG_SEPARATOR---"* ]]; then
-                    # Extract config before separator
-                    FULL_CONFIG="${REMAINING_CONFIG%%---CONFIG_SEPARATOR---*}"
-                    # Remove processed config and separator from remaining
-                    REMAINING_CONFIG="${REMAINING_CONFIG#*---CONFIG_SEPARATOR---}"
-                    echo "$FULL_CONFIG"
-                  else
-                    # Last config (no separator after it)
-                    FULL_CONFIG="$REMAINING_CONFIG"
-                    REMAINING_CONFIG=""
-                  fi
-                  # Trim whitespace from config
-                  FULL_CONFIG=$(echo "$FULL_CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-                  echo "DEBUG - Config after trimming:"
-                  echo "$FULL_CONFIG"
-                  # if [[ -n "$FULL_CONFIG" ]]; then  # Skip empty configs
-                     #((CONFIG_INDEX++))
-                     CONFIG_INDEX=$(( $CONFIG_INDEX + 1 ))
-                     echo "==================== Configuration $CONFIG_INDEX ===================="
-                     echo "$FULL_CONFIG"
-                     echo "================================================================"
-                     # Split RHADS config and testplan
-                     if [[ "$FULL_CONFIG" == *"---TESTPLAN_START---"* ]]; then
-                       # Extract RHADS config (before testplan)
-                       CONFIG="${FULL_CONFIG%%---TESTPLAN_START---*}"
-                       # Extract testplan (between markers)
-                       TESTPLAN_PART="${FULL_CONFIG#*---TESTPLAN_START---}"
-                       TESTPLAN="${TESTPLAN_PART%%---TESTPLAN_END---*}"
-                       # Trim whitespace from both parts
-                       CONFIG=$(echo "$CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-                       TESTPLAN=$(echo "$TESTPLAN" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-                       echo "RHADS Config:"
-                       echo "$CONFIG"
-                       echo "Testplan:"
-                       echo "$TESTPLAN"
-                       # Encode testplan to base64
-                       TESTPLAN_B64=$(echo "$TESTPLAN" | base64 -w 0)
-                       echo "Testplan base64: $TESTPLAN_B64"
-                     else
-                       # No testplan found, use config as-is
-                       CONFIG="$FULL_CONFIG"
-                       TESTPLAN_B64=""
-                       echo "No testplan found for this configuration"
-                     fi
-                     # Extract OCP version from this configuration
-                     if [[ $CONFIG =~ OCP=\"([^\"]+)\" ]]; then
-                       OCP_VERSION="${BASH_REMATCH[1]}"
-                       echo "Successfully extracted OCP version: $OCP_VERSION from configuration $CONFIG_INDEX"
-                       echo "About to start sub-pipeline for OCP version: $OCP_VERSION (Configuration $CONFIG_INDEX)"
-                       echo "Pipeline command will be executed now..."
-
-                       #PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/rhtap-cli/refs/heads/$BRANCH/integration-tests/pipelines/rhtap-cli-e2e.yaml \
-                       PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/pipelines/rhtap-cli-e2e.yaml \
-                         --param ocp-version="$OCP_VERSION"\
-                         --param job-spec="$JOB_SPEC"\
-                         --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
-                         --param rhads-config="$CONFIG" \
-                         $(if [[ -n "$TESTPLAN_B64" ]]; then echo "--param testplan=$TESTPLAN_B64"; fi) \
-                         --param cloud-credential-key="$(params.cloud-credential-key)" \
-                         --param machine-type="$(params.ocp-instance-type)" \
-                         --param replicas="$(params.ocp-replicas)" \
-                         $(if [[ "${tssc_image}" != "" ]]; then echo "--param tssc-image=${tssc_image}"; fi) \
-                         $(if [[ "${tssc_test_image}" != "" ]]; then echo "--param tssc-test-image=${tssc_test_image}"; fi) \
-                         --use-param-defaults \
-                         --labels "appstudio.openshift.io/component=${KONFLUX_COMPONENT_NAME}" \
-                         --labels "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}" \
-                         --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
-                         --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
-                         --labels "custom.appstudio.openshift.io/main-pipeline-run=$(context.pipelineRun.name)" \
-                         --prefix-name "e2e-$OCP_VERSION-config$CONFIG_INDEX"\
-                         -o name)
-
-                       echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
-                       PIPELINERUNS_ARRAY+=($PIPELINE_RUN)
-                     else
-                       echo "Warning: Could not extract OCP version from configuration $CONFIG_INDEX"
-                     fi
-                   # else
-                   #   echo "Skipping empty configuration"
-                   # fi
-                done
-                echo "Started $CONFIG_INDEX sub-pipelines for periodic testing"
-              else
-                echo "Running in traditional mode with single configuration"
-                # Traditional single config mode - use content directly
-                RHADS_CONFIG_CONTENT="$RHADS_CONFIG"
-                echo "==================== Single Configuration ===================="
-                echo "$RHADS_CONFIG_CONTENT"
-                echo "=============================================================="
-
-                # Extract OCP versions from RHADS config
-                [[ $RHADS_CONFIG_CONTENT =~ OCP=\"([^\"]+)\" ]] && IFS=',' read -ra OCP_VERSIONS <<< "${BASH_REMATCH[1]}"
-                  # Loop through each OCP version and start a sub-pipeline for each
-                  for OCP_VERSION in "${OCP_VERSIONS[@]}"; do
-                    echo "Found OCP version: $OCP_VERSION"
-                    echo "Creating single pipeline with traditional RHADS config"
-
-                    # Create a single pipeline for this configuration
-                    echo "Starting sub-pipeline for OCP version: $OCP_VERSION"
-
-                    PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/rhtap-cli/refs/heads/$BRANCH/integration-tests/pipelines/rhtap-cli-e2e.yaml \
-                      --param ocp-version="$OCP_VERSION"\
-                      --param job-spec="$JOB_SPEC"\
-                      --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
-                      --param rhads-config="$RHADS_CONFIG_CONTENT" \
-                      --param cloud-credential-key="$(params.cloud-credential-key)" \
-                      --param machine-type="$(params.ocp-instance-type)" \
-                      --param replicas="$(params.ocp-replicas)" \
-                      $(if [[ "${tssc_image}" != "" ]]; then echo "--param tssc-image=${tssc_image}"; fi) \
-                      $(if [[ "${tssc_test_image}" != "" ]]; then echo "--param tssc-test-image=${tssc_test_image}"; fi) \
-                      --use-param-defaults \
-                      --labels "appstudio.openshift.io/component=${KONFLUX_COMPONENT_NAME}" \
-                      --labels "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}" \
-                      --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
-                      --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
-                      --labels "custom.appstudio.openshift.io/main-pipeline-run=$(context.pipelineRun.name)" \
-                      --prefix-name "e2e-$OCP_VERSION"\
-                      -o name)
-
-                    echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
-                    PIPELINERUNS_ARRAY+=($PIPELINE_RUN)
-                  done
-              fi
-
-              echo "Total pipelines started: ${#PIPELINERUNS_ARRAY[@]}"
+              echo "Running tests for OCP versions: ${OCP_VERSIONS[*]}"
 
               # Waits for condition for all started pipelines
               function waitFor() {
@@ -420,7 +153,6 @@ spec:
 
               GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
               KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
-
               if [[ "${GIT_REPO}" = "tssc-cli" ]]; then
                 REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
                 BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
@@ -434,7 +166,6 @@ spec:
               # Loop through each OCP version and start a sub-pipeline for each
               for OCP_VERSION in "${OCP_VERSIONS[@]}"; do
                 echo "Starting sub-pipeline for OCP version: $OCP_VERSION"
-
                 PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/tssc-cli/refs/heads/$BRANCH/integration-tests/pipelines/tssc-cli-e2e.yaml \
                   --param ocp-version="$OCP_VERSION"\
                   --param job-spec="$JOB_SPEC"\
@@ -465,7 +196,7 @@ spec:
               waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "" ]]' "Waiting for nested pipelinerun status to be set. Waiting 1 minute" "Nested pipelinerun status is set"
               waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
 
-              # Explore and report status of all failed pipelineruns. Fail if anything failed
+              ## Explore and report status of all failed pipelineruns. Fail if anything failed
               SOME_PIPELINE_FAILED=false
               SOME_PIPELINE_SUCCEEDED=false
               for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do

--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -77,141 +77,34 @@ spec:
 
               cat rhads-config | tee $(results.rhads-config.path)
     - name: start-nested-pipelines
-      params:
-        - name: job-spec
-          value: "$(tasks.test-metadata.results.job-spec)"
       runAfter:
         - test-metadata
         - process-rhads-config
-      taskSpec:
-        steps:
-          - name: start-pipeline
-            image: quay.io/openshift-pipeline/ci
-            env:
-              - name: SNAPSHOT
-                value: $(params.SNAPSHOT)
-              - name: JOB_SPEC
-                value: $(tasks.test-metadata.results.job-spec)
-              - name: RHADS_CONFIG
-                value: $(tasks.process-rhads-config.results.rhads-config)
-              - name: KONFLUX_APPLICATION_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.labels['appstudio.openshift.io/application']
-              - name: KONFLUX_COMPONENT_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.labels['appstudio.openshift.io/component']
-              - name: KONFLUX_NAMESPACE
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.namespace
-            script: |
-              #!/usr/bin/env bash
-
-              # Load the RHADS configuration
-              RHADS_CONFIG_CONTENT=$(echo $RHADS_CONFIG)
-              echo "$RHADS_CONFIG_CONTENT"
-
-              # get the tssc image and tssc-test image from the snapshot
-              tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-cli").containerImage')
-              tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
-
-              # Extract OCP versions from RHADS config
-              [[ $RHADS_CONFIG_CONTENT =~ OCP=\"([^\"]+)\" ]] && IFS=',' read -ra OCP_VERSIONS <<< "${BASH_REMATCH[1]}"
-
-              echo "Running tests for OCP versions: ${OCP_VERSIONS[*]}"
-
-              # Waits for condition for all started pipelines
-              function waitFor() {
-                  CONDITION=$1 MESSAGE_RUNNING=$2 MESSAGE_DONE=$3 timeout --foreground 120m /bin/bash -c '
-                    #deserialize plrs array
-                    set -x
-                    read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
-                    echo "${PIPELINERUNS_ARRAY[*]}"
-                    while true; do
-                      CONDITION_MET=false
-                      for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-                        if eval "$CONDITION"; then
-                          #something is still running. Break this cycle and wait one minute.
-                          CONDITION_MET=true
-                          break
-                        fi
-                      done
-                      if $CONDITION_MET ; then
-                        echo "$MESSAGE_RUNNING"
-                        sleep 60
-                      else
-                        echo "$MESSAGE_DONE"
-                        break
-                      fi
-                    done
-                  '
-              }
-
-              set -euo pipefail
-
-              GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
-              KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
-              if [[ "${GIT_REPO}" = "tssc-cli" ]]; then
-                REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
-                BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
-              else
-                REPO_ORG="redhat-appstudio"
-                BRANCH="main"
-              fi
-
-              PIPELINERUNS_ARRAY=()
-
-              # Loop through each OCP version and start a sub-pipeline for each
-              for OCP_VERSION in "${OCP_VERSIONS[@]}"; do
-                echo "Starting sub-pipeline for OCP version: $OCP_VERSION"
-                PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/tssc-cli/refs/heads/$BRANCH/integration-tests/pipelines/tssc-cli-e2e.yaml \
-                  --param ocp-version="$OCP_VERSION"\
-                  --param job-spec="$JOB_SPEC"\
-                  --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
-                  --param rhads-config="$RHADS_CONFIG_CONTENT" \
-                  --param cloud-credential-key="$(params.cloud-credential-key)" \
-                  --param machine-type="$(params.ocp-instance-type)" \
-                  --param replicas="$(params.ocp-replicas)" \
-                  $(if [[ "${tssc_image}" != "" ]]; then echo "--param tssc-image=${tssc_image}"; fi) \
-                  $(if [[ "${tssc_test_image}" != "" ]]; then echo "--param tssc-test-image=${tssc_test_image}"; fi) \
-                  --use-param-defaults \
-                  --labels "appstudio.openshift.io/component=${KONFLUX_COMPONENT_NAME}" \
-                  --labels "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}" \
-                  --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
-                  --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
-                  --labels "custom.appstudio.openshift.io/main-pipeline-run=$(context.pipelineRun.name)" \
-                  --prefix-name "e2e-$OCP_VERSION"\
-                  -o name)
-
-                echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
-                PIPELINERUNS_ARRAY+=($PIPELINE_RUN)
-              done
-
-              #Serialize plrs array to be able to export it as var
-              export PIPELINERUNS_ARRAY_SERIALIZED="${PIPELINERUNS_ARRAY[*]}"
-
-              waitFor '! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null' "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
-              waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "" ]]' "Waiting for nested pipelinerun status to be set. Waiting 1 minute" "Nested pipelinerun status is set"
-              waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
-
-              ## Explore and report status of all failed pipelineruns. Fail if anything failed
-              SOME_PIPELINE_FAILED=false
-              SOME_PIPELINE_SUCCEEDED=false
-              for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-                if [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "False" ]]; then
-                  if ! $SOME_PIPELINE_FAILED ; then
-                    echo "List of failed PLRs:"
-                  fi
-                  echo "${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
-                  SOME_PIPELINE_FAILED=true
-                elif [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "True" ]]; then
-                  SOME_PIPELINE_SUCCEEDED=true
-                fi
-              done
-              if $SOME_PIPELINE_SUCCEEDED ; then
-                exit 0
-              fi
-              # If we reach here, no pipelines succeeded - fail the main pipeline
-              exit 1
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/jkopriva/tssc-cli.git
+          - name: revision
+            value: RHTAP-5290
+          - name: pathInRepo
+            value: integration-tests/tasks/start-pipelines.yaml
+      params:
+        - name: snapshot
+          value: $(params.SNAPSHOT)
+        - name: job-spec
+          value: $(tasks.test-metadata.results.job-spec)
+        - name: rhads-config
+          value: $(tasks.process-rhads-config.results.rhads-config)
+        - name: mode
+          value: "single"
+        - name: konflux-test-infra-secret
+          value: $(params.konflux-test-infra-secret)
+        - name: cloud-credential-key
+          value: $(params.cloud-credential-key)
+        - name: ocp-instance-type
+          value: $(params.ocp-instance-type)
+        - name: ocp-replicas
+          value: $(params.ocp-replicas)
+        - name: context-pipeline-run-name
+          value: $(context.pipelineRun.name)

--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -44,38 +44,18 @@ spec:
         - name: test-name
           value: $(context.pipelineRun.name)
     - name: process-rhads-config
-      taskSpec:
-        volumes:
-          - name: shared-data
-            emptyDir: {}
-        results:
-          - name: rhads-config
-            description: JSON formatted configuration data
-        steps:
-          - name: get-rhads-config
-            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
-            env:
-              - name: JOB_SPEC
-                value: $(tasks.test-metadata.results.job-spec)
-            volumeMounts:
-              - name: shared-data
-                mountPath: /shared
-            script: |
-              #!/usr/bin/env bash
-              echo "Downloading rhads-config file:"
-              GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
-              REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
-              # Determine the branch name for the curl command.
-              # If source_repo_branch starts with "refs/heads/", strip that prefix; otherwise, use as is.
-              BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
-              if [[ "$BRANCH" == refs/heads/* ]]; then
-                BRANCH="${BRANCH#refs/heads/}"
-              fi
-
-              rhads_config_file_location="integration-tests/config/rhads-config"
-              curl -o rhads-config https://raw.githubusercontent.com/$REPO_ORG/$GIT_REPO/refs/heads/$BRANCH/$rhads_config_file_location
-
-              cat rhads-config | tee $(results.rhads-config.path)
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/jkopriva/tssc-cli.git
+          - name: revision
+            value: RHTAP-5290
+          - name: pathInRepo
+            value: integration-tests/tasks/get-rhads-config.yaml
+      params:
+        - name: job-spec
+          value: $(tasks.test-metadata.results.job-spec)
     - name: start-nested-pipelines
       runAfter:
         - test-metadata

--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -27,6 +27,10 @@ spec:
       description: 'The number of replicas for the cluster nodes.'
       default: "3"
       type: string
+    - name: use-periodic-configs
+      description: 'Enable periodic testing mode with multiple configurations generated from PICT file'
+      default: "false"
+      type: string
   tasks:
     - name: test-metadata
       taskRef:
@@ -43,6 +47,7 @@ spec:
           value: $(params.SNAPSHOT)
         - name: test-name
           value: $(context.pipelineRun.name)
+
     - name: process-rhads-config
       taskSpec:
         volumes:
@@ -50,33 +55,144 @@ spec:
             emptyDir: {}
         results:
           - name: rhads-config
-            description: JSON formatted configuration data
+            description: JSON formatted configuration data (single config or array of configs)
         steps:
-          - name: get-rhads-config
+          - name: download-pict-file
             image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
             env:
               - name: JOB_SPEC
                 value: $(tasks.test-metadata.results.job-spec)
+              - name: USE_PERIODIC_CONFIGS
+                value: $(params.use-periodic-configs)
             volumeMounts:
               - name: shared-data
                 mountPath: /shared
             script: |
               #!/usr/bin/env bash
+              set -euo pipefail
 
-              echo "Downloading rhads-config file:"
-              GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
-              REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
-              # Determine the branch name for the curl command.
-              # If source_repo_branch starts with "refs/heads/", strip that prefix; otherwise, use as is.
-              BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
-              if [[ "$BRANCH" == refs/heads/* ]]; then
-                BRANCH="${BRANCH#refs/heads/}"
+              if [[ "$USE_PERIODIC_CONFIGS" == "true" ]]; then
+                echo "Using periodic configurations generated from PICT"
+                # Download periodic.pict file
+                curl -o /shared/periodic.pict https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/periodic.pict
+                cat /shared/periodic.pict
+              else
+                echo "Using traditional single rhads-config file"
+                GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
+                REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
+                # Determine the branch name for the curl command.
+                # If source_repo_branch starts with "refs/heads/", strip that prefix; otherwise, use as is.
+                BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+                if [[ "$BRANCH" == refs/heads/* ]]; then
+                  BRANCH="${BRANCH#refs/heads/}"
+                fi
+
+                rhads_config_file_location="integration-tests/config/rhads-config"
+                curl -o /shared/rhads-config https://raw.githubusercontent.com/$REPO_ORG/$GIT_REPO/refs/heads/$BRANCH/$rhads_config_file_location
               fi
+          - name: generate-pict-output
+            image: quay.io/apodhrad/pict:latest
+            env:
+              - name: USE_PERIODIC_CONFIGS
+                value: $(params.use-periodic-configs)
+            volumeMounts:
+              - name: shared-data
+                mountPath: /shared
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              if [[ "$USE_PERIODIC_CONFIGS" == "true" ]]; then
+                echo "Running PICT to generate test configurations..."
+                cd /shared
+                pict periodic.pict -r -o:1 > pict_output.txt
+                cat pict_output.txt
+              fi
+          - name: process-config
+            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+            env:
+              - name: USE_PERIODIC_CONFIGS
+                value: $(params.use-periodic-configs)
+            volumeMounts:
+              - name: shared-data
+                mountPath: /shared
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
 
-              rhads_config_file_location="integration-tests/config/rhads-config"
-              curl -o rhads-config https://raw.githubusercontent.com/$REPO_ORG/$GIT_REPO/refs/heads/$BRANCH/$rhads_config_file_location
-
-              cat rhads-config | tee $(results.rhads-config.path)
+              if [[ "$USE_PERIODIC_CONFIGS" == "true" ]]; then
+                echo "Converting PICT output to RHADS configuration format..."
+                cd /shared
+                # Debug: Check if pict_output.txt exists and show its content
+                if [[ ! -f pict_output.txt ]]; then
+                  echo "ERROR: pict_output.txt not found!"
+                  ls -la /shared/
+                  exit 1
+                fi
+                echo "Content of pict_output.txt:"
+                cat pict_output.txt
+                echo "--- End of pict_output.txt ---"
+                # Download testplan template
+                echo "Downloading testplan template..."
+                curl -o testplan_template.json https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/testplan_template.json
+                if [[ ! -f testplan_template.json ]]; then
+                  echo "ERROR: Failed to download testplan_template.json"
+                  exit 1
+                fi
+                echo "Testplan template content:"
+                cat testplan_template.json
+                # Convert PICT output to multiple RHADS configurations
+                CONFIG_COUNT=0
+                OUTPUT_FILE="/tmp/rhads_output.txt"
+                > "$OUTPUT_FILE"  # Initialize empty file
+                while IFS=$'\t' read -r -a fields; do
+                  echo "Processing line: ${fields[*]}"
+                  if [[ "${fields[0]}" != "OCP" && -n "${fields[0]:-}" ]]; then  # Skip header line and empty lines
+                    if [[ $CONFIG_COUNT -gt 0 ]]; then
+                      echo "---CONFIG_SEPARATOR---" >> "$OUTPUT_FILE"
+                    fi
+                    # Build RHADS config format for this PICT line
+                    echo "OCP=\"${fields[0]:-4.18}\"" >> "$OUTPUT_FILE"
+                    echo "AUTH=\"${fields[1]:-github}\"" >> "$OUTPUT_FILE"
+                    echo "ACS=\"${fields[2]:-new}\"" >> "$OUTPUT_FILE"
+                    echo "REGISTRY=\"${fields[3]:-quay.io}\"" >> "$OUTPUT_FILE"
+                    echo "TPA=\"${fields[4]:-new}\"" >> "$OUTPUT_FILE"
+                    echo "SCM=\"${fields[5]:-github}\"" >> "$OUTPUT_FILE"
+                    echo "PIPELINE=\"${fields[6]:-tekton}\"" >> "$OUTPUT_FILE"
+                    # Generate corresponding testplan
+                    echo "---TESTPLAN_START---" >> "$OUTPUT_FILE"
+                    # Extract values for testplan
+                    SCM_VALUE="${fields[5]:-github}"
+                    PIPELINE_VALUE="${fields[6]:-tekton}"
+                    REGISTRY_VALUE="${fields[3]:-quay.io}"
+                    TPA_VALUE="${fields[4]:-new}"
+                    ACS_VALUE="${fields[2]:-new}"
+                    # Create testplan by replacing placeholders in template more precisely
+                    sed "s/\"git\": \"github\"/\"git\": \"$SCM_VALUE\"/g; s/\"ci\": \"tekton\"/\"ci\": \"$PIPELINE_VALUE\"/g; s/\"registry\": \"quay.io\"/\"registry\": \"$REGISTRY_VALUE\"/g; s/\"tpa\": \"local\"/\"tpa\": \"$TPA_VALUE\"/g; s/\"acs\": \"local\"/\"acs\": \"$ACS_VALUE\"/g" testplan_template.json >> "$OUTPUT_FILE"
+                    echo "---TESTPLAN_END---" >> "$OUTPUT_FILE"
+                    CONFIG_COUNT=$((CONFIG_COUNT + 1))
+                    echo "Generated configuration $CONFIG_COUNT with testplan"
+                  else
+                    echo "Skipping line: ${fields[*]}"
+                  fi
+                done < pict_output.txt
+                echo "Generated $CONFIG_COUNT RHADS configurations with testplans"
+                # Copy output to result path
+                echo "Final output:"
+                cat "$OUTPUT_FILE"
+                cat "$OUTPUT_FILE" > "$(results.rhads-config.path)"
+              else
+                echo "Using traditional single configuration"
+                # Return single config content directly
+                if [[ ! -f /shared/rhads-config ]]; then
+                  echo "ERROR: /shared/rhads-config not found!"
+                  ls -la /shared/
+                  exit 1
+                fi
+                cat /shared/rhads-config > "$(results.rhads-config.path)"
+              fi
+              echo "Configuration processing completed successfully"
+      runAfter:
+        - test-metadata
     - name: start-nested-pipelines
       params:
         - name: job-spec
@@ -95,6 +211,8 @@ spec:
                 value: $(tasks.test-metadata.results.job-spec)
               - name: RHADS_CONFIG
                 value: $(tasks.process-rhads-config.results.rhads-config)
+              - name: USE_PERIODIC_CONFIGS
+                value: $(params.use-periodic-configs)
               - name: KONFLUX_APPLICATION_NAME
                 valueFrom:
                   fieldRef:
@@ -109,19 +227,167 @@ spec:
                     fieldPath: metadata.namespace
             script: |
               #!/usr/bin/env bash
+              set -euo pipefail
 
-              # Load the RHADS configuration
-              RHADS_CONFIG_CONTENT=$(echo $RHADS_CONFIG)
-              echo "$RHADS_CONFIG_CONTENT"
-
+              echo "Processing RHADS configuration(s)..."
               # get the tssc image and tssc-test image from the snapshot
               tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-cli").containerImage')
               tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
 
-              # Extract OCP versions from RHADS config
-              [[ $RHADS_CONFIG_CONTENT =~ OCP=\"([^\"]+)\" ]] && IFS=',' read -ra OCP_VERSIONS <<< "${BASH_REMATCH[1]}"
+              GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
+              KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
 
-              echo "Running tests for OCP versions: ${OCP_VERSIONS[*]}"
+              if [[ "${GIT_REPO}" = "rhtap-cli" ]]; then
+                REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
+                BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+              else
+                REPO_ORG="redhat-appstudio"
+                BRANCH="main"
+              fi
+
+              PIPELINERUNS_ARRAY=()
+
+              if [[ "$USE_PERIODIC_CONFIGS" == "true" ]]; then
+                echo "Running in periodic mode with multiple configurations"
+                echo "Processing RHADS configurations:"
+                echo "$RHADS_CONFIG"
+                # Split configurations by separator and process each one
+                echo "Splitting configurations using bash string manipulation..."
+                # Count configurations for informational purposes
+                CONFIG_COUNT=$(echo "$RHADS_CONFIG" | grep -o -e "---CONFIG_SEPARATOR---" | wc -l)
+                CONFIG_COUNT=$((CONFIG_COUNT + 1))  # Add 1 because there's one more config than separators
+                echo "Found $CONFIG_COUNT configurations to process"
+                # Create a pipeline for every RHADS config using pure bash string manipulation
+                CONFIG_INDEX=0
+                # Split the configurations using bash string manipulation
+                REMAINING_CONFIG="$RHADS_CONFIG"
+                while [[ -n "$REMAINING_CONFIG" ]]; do
+                  # Find the next separator
+                  if [[ "$REMAINING_CONFIG" == *"---CONFIG_SEPARATOR---"* ]]; then
+                    # Extract config before separator
+                    FULL_CONFIG="${REMAINING_CONFIG%%---CONFIG_SEPARATOR---*}"
+                    # Remove processed config and separator from remaining
+                    REMAINING_CONFIG="${REMAINING_CONFIG#*---CONFIG_SEPARATOR---}"
+                    echo "$FULL_CONFIG"
+                  else
+                    # Last config (no separator after it)
+                    FULL_CONFIG="$REMAINING_CONFIG"
+                    REMAINING_CONFIG=""
+                  fi
+                  # Trim whitespace from config
+                  FULL_CONFIG=$(echo "$FULL_CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                  echo "DEBUG - Config after trimming:"
+                  echo "$FULL_CONFIG"
+                  # if [[ -n "$FULL_CONFIG" ]]; then  # Skip empty configs
+                     #((CONFIG_INDEX++))
+                     CONFIG_INDEX=$(( $CONFIG_INDEX + 1 ))
+                     echo "==================== Configuration $CONFIG_INDEX ===================="
+                     echo "$FULL_CONFIG"
+                     echo "================================================================"
+                     # Split RHADS config and testplan
+                     if [[ "$FULL_CONFIG" == *"---TESTPLAN_START---"* ]]; then
+                       # Extract RHADS config (before testplan)
+                       CONFIG="${FULL_CONFIG%%---TESTPLAN_START---*}"
+                       # Extract testplan (between markers)
+                       TESTPLAN_PART="${FULL_CONFIG#*---TESTPLAN_START---}"
+                       TESTPLAN="${TESTPLAN_PART%%---TESTPLAN_END---*}"
+                       # Trim whitespace from both parts
+                       CONFIG=$(echo "$CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                       TESTPLAN=$(echo "$TESTPLAN" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                       echo "RHADS Config:"
+                       echo "$CONFIG"
+                       echo "Testplan:"
+                       echo "$TESTPLAN"
+                       # Encode testplan to base64
+                       TESTPLAN_B64=$(echo "$TESTPLAN" | base64 -w 0)
+                       echo "Testplan base64: $TESTPLAN_B64"
+                     else
+                       # No testplan found, use config as-is
+                       CONFIG="$FULL_CONFIG"
+                       TESTPLAN_B64=""
+                       echo "No testplan found for this configuration"
+                     fi
+                     # Extract OCP version from this configuration
+                     if [[ $CONFIG =~ OCP=\"([^\"]+)\" ]]; then
+                       OCP_VERSION="${BASH_REMATCH[1]}"
+                       echo "Successfully extracted OCP version: $OCP_VERSION from configuration $CONFIG_INDEX"
+                       echo "About to start sub-pipeline for OCP version: $OCP_VERSION (Configuration $CONFIG_INDEX)"
+                       echo "Pipeline command will be executed now..."
+
+                       #PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/rhtap-cli/refs/heads/$BRANCH/integration-tests/pipelines/rhtap-cli-e2e.yaml \
+                       PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/pipelines/rhtap-cli-e2e.yaml \
+                         --param ocp-version="$OCP_VERSION"\
+                         --param job-spec="$JOB_SPEC"\
+                         --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
+                         --param rhads-config="$CONFIG" \
+                         $(if [[ -n "$TESTPLAN_B64" ]]; then echo "--param testplan=$TESTPLAN_B64"; fi) \
+                         --param cloud-credential-key="$(params.cloud-credential-key)" \
+                         --param machine-type="$(params.ocp-instance-type)" \
+                         --param replicas="$(params.ocp-replicas)" \
+                         $(if [[ "${tssc_image}" != "" ]]; then echo "--param tssc-image=${tssc_image}"; fi) \
+                         $(if [[ "${tssc_test_image}" != "" ]]; then echo "--param tssc-test-image=${tssc_test_image}"; fi) \
+                         --use-param-defaults \
+                         --labels "appstudio.openshift.io/component=${KONFLUX_COMPONENT_NAME}" \
+                         --labels "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}" \
+                         --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
+                         --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
+                         --labels "custom.appstudio.openshift.io/main-pipeline-run=$(context.pipelineRun.name)" \
+                         --prefix-name "e2e-$OCP_VERSION-config$CONFIG_INDEX"\
+                         -o name)
+
+                       echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
+                       PIPELINERUNS_ARRAY+=($PIPELINE_RUN)
+                     else
+                       echo "Warning: Could not extract OCP version from configuration $CONFIG_INDEX"
+                     fi
+                   # else
+                   #   echo "Skipping empty configuration"
+                   # fi
+                done
+                echo "Started $CONFIG_INDEX sub-pipelines for periodic testing"
+              else
+                echo "Running in traditional mode with single configuration"
+                # Traditional single config mode - use content directly
+                RHADS_CONFIG_CONTENT="$RHADS_CONFIG"
+                echo "==================== Single Configuration ===================="
+                echo "$RHADS_CONFIG_CONTENT"
+                echo "=============================================================="
+
+                # Extract OCP versions from RHADS config
+                [[ $RHADS_CONFIG_CONTENT =~ OCP=\"([^\"]+)\" ]] && IFS=',' read -ra OCP_VERSIONS <<< "${BASH_REMATCH[1]}"
+                  # Loop through each OCP version and start a sub-pipeline for each
+                  for OCP_VERSION in "${OCP_VERSIONS[@]}"; do
+                    echo "Found OCP version: $OCP_VERSION"
+                    echo "Creating single pipeline with traditional RHADS config"
+
+                    # Create a single pipeline for this configuration
+                    echo "Starting sub-pipeline for OCP version: $OCP_VERSION"
+
+                    PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/rhtap-cli/refs/heads/$BRANCH/integration-tests/pipelines/rhtap-cli-e2e.yaml \
+                      --param ocp-version="$OCP_VERSION"\
+                      --param job-spec="$JOB_SPEC"\
+                      --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
+                      --param rhads-config="$RHADS_CONFIG_CONTENT" \
+                      --param cloud-credential-key="$(params.cloud-credential-key)" \
+                      --param machine-type="$(params.ocp-instance-type)" \
+                      --param replicas="$(params.ocp-replicas)" \
+                      $(if [[ "${tssc_image}" != "" ]]; then echo "--param tssc-image=${tssc_image}"; fi) \
+                      $(if [[ "${tssc_test_image}" != "" ]]; then echo "--param tssc-test-image=${tssc_test_image}"; fi) \
+                      --use-param-defaults \
+                      --labels "appstudio.openshift.io/component=${KONFLUX_COMPONENT_NAME}" \
+                      --labels "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}" \
+                      --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
+                      --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
+                      --labels "custom.appstudio.openshift.io/main-pipeline-run=$(context.pipelineRun.name)" \
+                      --prefix-name "e2e-$OCP_VERSION"\
+                      -o name)
+
+                    echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
+                    PIPELINERUNS_ARRAY+=($PIPELINE_RUN)
+                  done
+              fi
+
+              echo "Total pipelines started: ${#PIPELINERUNS_ARRAY[@]}"
 
               # Waits for condition for all started pipelines
               function waitFor() {
@@ -199,7 +465,7 @@ spec:
               waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "" ]]' "Waiting for nested pipelinerun status to be set. Waiting 1 minute" "Nested pipelinerun status is set"
               waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
 
-              ## Explore and report status of all failed pipelineruns. Fail if anything failed
+              # Explore and report status of all failed pipelineruns. Fail if anything failed
               SOME_PIPELINE_FAILED=false
               SOME_PIPELINE_SUCCEEDED=false
               for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do

--- a/integration-tests/pipelines/e2e-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-periodic-pipeline.yaml
@@ -5,8 +5,8 @@ metadata:
   name: e2e-periodic-pipeline
   namespace: rhtap-shared-team-tenant
   labels:
-    appstudio.openshift.io/component: rhtap-cli
-    appstudio.openshift.io/application: rhtap-cli
+    appstudio.openshift.io/component: tssc-cli
+    appstudio.openshift.io/application: tssc-cli
 spec:
   description: |-
     Pipeline for periodic testing with multiple configurations generated from PICT file.
@@ -70,7 +70,7 @@ spec:
 
               echo "Using periodic configurations generated from PICT"
               # Download periodic.pict file
-              curl -o /shared/periodic.pict https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/periodic.pict
+              curl -o /shared/periodic.pict https://raw.githubusercontent.com/jkopriva/tssc-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/periodic.pict
               cat /shared/periodic.pict
           - name: generate-pict-output
             image: quay.io/apodhrad/pict:latest
@@ -106,7 +106,7 @@ spec:
               echo "--- End of pict_output.txt ---"
               # Download testplan template
               echo "Downloading testplan template..."
-              curl -o testplan_template.json https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/testplan_template.json
+              curl -o testplan_template.json https://raw.githubusercontent.com/jkopriva/tssc-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/testplan_template.json
               if [[ ! -f testplan_template.json ]]; then
                 echo "ERROR: Failed to download testplan_template.json"
                 exit 1
@@ -161,202 +161,31 @@ spec:
       runAfter:
         - test-metadata
         - process-periodic-configs
-      taskSpec:
-        steps:
-          - name: start-pipeline
-            image: quay.io/openshift-pipeline/ci
-            env:
-              - name: SNAPSHOT
-                value: $(params.SNAPSHOT)
-              - name: JOB_SPEC
-                value: $(tasks.test-metadata.results.job-spec)
-              - name: RHADS_CONFIG
-                value: $(tasks.process-periodic-configs.results.rhads-config)
-              - name: KONFLUX_APPLICATION_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.labels['appstudio.openshift.io/application']
-              - name: KONFLUX_COMPONENT_NAME
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.labels['appstudio.openshift.io/component']
-              - name: KONFLUX_NAMESPACE
-                valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.namespace
-            script: |
-              #!/usr/bin/env bash
-              set -euo pipefail
-
-              echo "Processing periodic RHADS configurations..."
-              # get the tssc image and tssc-test image from the snapshot
-              tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="rhtap-cli").containerImage')
-              tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
-
-              GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
-              KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
-
-              if [[ "${GIT_REPO}" = "rhtap-cli" ]]; then
-                REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
-                BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
-              else
-                REPO_ORG="redhat-appstudio"
-                BRANCH="main"
-              fi
-
-              PIPELINERUNS_ARRAY=()
-
-              echo "Running in periodic mode with multiple configurations"
-              echo "Processing RHADS configurations:"
-              echo "$RHADS_CONFIG"
-              # Split configurations by separator and process each one
-              echo "Splitting configurations using bash string manipulation..."
-              
-              # Count configurations for informational purposes
-              CONFIG_COUNT=$(echo "$RHADS_CONFIG" | grep -o -e "---CONFIG_SEPARATOR---" | wc -l)
-              CONFIG_COUNT=$((CONFIG_COUNT + 1))  # Add 1 because there's one more config than separators
-              echo "Found $CONFIG_COUNT configurations to process"
-              
-              # Create a pipeline for every RHADS config using pure bash string manipulation
-              CONFIG_INDEX=0
-              # Split the configurations using bash string manipulation
-              REMAINING_CONFIG="$RHADS_CONFIG"
-              while [[ -n "$REMAINING_CONFIG" ]]; do
-                # Find the next separator
-                if [[ "$REMAINING_CONFIG" == *"---CONFIG_SEPARATOR---"* ]]; then
-                  # Extract config before separator
-                  FULL_CONFIG="${REMAINING_CONFIG%%---CONFIG_SEPARATOR---*}"
-                  # Remove processed config and separator from remaining
-                  REMAINING_CONFIG="${REMAINING_CONFIG#*---CONFIG_SEPARATOR---}"
-                  echo "$FULL_CONFIG"
-                else
-                  # Last config (no separator after it)
-                  FULL_CONFIG="$REMAINING_CONFIG"
-                  REMAINING_CONFIG=""
-                fi
-                # Trim whitespace from config
-                FULL_CONFIG=$(echo "$FULL_CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-                echo "DEBUG - Config after trimming:"
-                echo "$FULL_CONFIG"
-                
-                CONFIG_INDEX=$(( $CONFIG_INDEX + 1 ))
-                echo "==================== Configuration $CONFIG_INDEX ===================="
-                echo "$FULL_CONFIG"
-                echo "================================================================"
-                
-                # Split RHADS config and testplan
-                if [[ "$FULL_CONFIG" == *"---TESTPLAN_START---"* ]]; then
-                  # Extract RHADS config (before testplan)
-                  CONFIG="${FULL_CONFIG%%---TESTPLAN_START---*}"
-                  # Extract testplan (between markers)
-                  TESTPLAN_PART="${FULL_CONFIG#*---TESTPLAN_START---}"
-                  TESTPLAN="${TESTPLAN_PART%%---TESTPLAN_END---*}"
-                  # Trim whitespace from both parts
-                  CONFIG=$(echo "$CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-                  TESTPLAN=$(echo "$TESTPLAN" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-                  echo "RHADS Config:"
-                  echo "$CONFIG"
-                  echo "Testplan:"
-                  echo "$TESTPLAN"
-                  # Encode testplan to base64
-                  TESTPLAN_B64=$(echo "$TESTPLAN" | base64 -w 0)
-                  echo "Testplan base64: $TESTPLAN_B64"
-                else
-                  # No testplan found, use config as-is
-                  CONFIG="$FULL_CONFIG"
-                  TESTPLAN_B64=""
-                  echo "No testplan found for this configuration"
-                fi
-                
-                # Extract OCP version from this configuration
-                if [[ $CONFIG =~ OCP=\"([^\"]+)\" ]]; then
-                  OCP_VERSION="${BASH_REMATCH[1]}"
-                  echo "Successfully extracted OCP version: $OCP_VERSION from configuration $CONFIG_INDEX"
-                  echo "About to start sub-pipeline for OCP version: $OCP_VERSION (Configuration $CONFIG_INDEX)"
-                  echo "Pipeline command will be executed now..."
-
-                  PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/pipelines/rhtap-cli-e2e.yaml \
-                    --param ocp-version="$OCP_VERSION"\
-                    --param job-spec="$JOB_SPEC"\
-                    --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
-                    --param rhads-config="$CONFIG" \
-                    $(if [[ -n "$TESTPLAN_B64" ]]; then echo "--param testplan=$TESTPLAN_B64"; fi) \
-                    --param cloud-credential-key="$(params.cloud-credential-key)" \
-                    --param machine-type="$(params.ocp-instance-type)" \
-                    --param replicas="$(params.ocp-replicas)" \
-                    $(if [[ "${tssc_image}" != "" ]]; then echo "--param tssc-image=${tssc_image}"; fi) \
-                    $(if [[ "${tssc_test_image}" != "" ]]; then echo "--param tssc-test-image=${tssc_test_image}"; fi) \
-                    --use-param-defaults \
-                    --labels "appstudio.openshift.io/component=${KONFLUX_COMPONENT_NAME}" \
-                    --labels "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}" \
-                    --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
-                    --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
-                    --labels "custom.appstudio.openshift.io/main-pipeline-run=$(context.pipelineRun.name)" \
-                    --prefix-name "e2e-$OCP_VERSION-config$CONFIG_INDEX"\
-                    -o name)
-
-                  echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
-                  PIPELINERUNS_ARRAY+=($PIPELINE_RUN)
-                else
-                  echo "Warning: Could not extract OCP version from configuration $CONFIG_INDEX"
-                fi
-              done
-              echo "Started $CONFIG_INDEX sub-pipelines for periodic testing"
-
-              echo "Total pipelines started: ${#PIPELINERUNS_ARRAY[@]}"
-
-              # Waits for condition for all started pipelines
-              function waitFor() {
-                  CONDITION=$1 MESSAGE_RUNNING=$2 MESSAGE_DONE=$3 timeout --foreground 120m /bin/bash -c '
-                    #deserialize plrs array
-                    set -x
-                    read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
-                    echo "${PIPELINERUNS_ARRAY[*]}"
-                    while true; do
-                      CONDITION_MET=false
-                      for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-                        if eval "$CONDITION"; then
-                          #something is still running. Break this cycle and wait one minute.
-                          CONDITION_MET=true
-                          break
-                        fi
-                      done
-                      if $CONDITION_MET ; then
-                        echo "$MESSAGE_RUNNING"
-                        sleep 60
-                      else
-                        echo "$MESSAGE_DONE"
-                        break
-                      fi
-                    done
-                  '
-              }
-
-              #Serialize plrs array to be able to export it as var
-              export PIPELINERUNS_ARRAY_SERIALIZED="${PIPELINERUNS_ARRAY[*]}"
-
-              waitFor '! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null' "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
-              waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "" ]]' "Waiting for nested pipelinerun status to be set. Waiting 1 minute" "Nested pipelinerun status is set"
-              waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
-
-              # Explore and report status of all failed pipelineruns. Fail if anything failed
-              SOME_PIPELINE_FAILED=false
-              SOME_PIPELINE_SUCCEEDED=false
-              for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-                if [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "False" ]]; then
-                  if ! $SOME_PIPELINE_FAILED ; then
-                    echo "List of failed PLRs:"
-                  fi
-                  echo "${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
-                  SOME_PIPELINE_FAILED=true
-                elif [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "True" ]]; then
-                  SOME_PIPELINE_SUCCEEDED=true
-                fi
-              done
-              if $SOME_PIPELINE_SUCCEEDED ; then
-                exit 0
-              fi
-              if $SOME_PIPELINE_FAILED ; then
-                exit 1
-              fi
-              echo "Pipeline processing completed successfully"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/jkopriva/tssc-cli.git
+          - name: revision
+            value: RHTAP-5290
+          - name: pathInRepo
+            value: integration-tests/tasks/start-pipelines.yaml
+      params:
+        - name: snapshot
+          value: $(params.SNAPSHOT)
+        - name: job-spec
+          value: $(tasks.test-metadata.results.job-spec)
+        - name: rhads-config
+          value: $(tasks.process-periodic-configs.results.rhads-config)
+        - name: mode
+          value: "periodic"
+        - name: konflux-test-infra-secret
+          value: $(params.konflux-test-infra-secret)
+        - name: cloud-credential-key
+          value: $(params.cloud-credential-key)
+        - name: ocp-instance-type
+          value: $(params.ocp-instance-type)
+        - name: ocp-replicas
+          value: $(params.ocp-replicas)
+        - name: context-pipeline-run-name
+          value: $(context.pipelineRun.name)

--- a/integration-tests/pipelines/e2e-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-periodic-pipeline.yaml
@@ -46,117 +46,19 @@ spec:
           value: $(params.SNAPSHOT)
         - name: test-name
           value: $(context.pipelineRun.name)
-
     - name: process-periodic-configs
-      taskSpec:
-        volumes:
-          - name: shared-data
-            emptyDir: {}
-        results:
-          - name: rhads-config
-            description: JSON formatted configuration data (array of configs from PICT)
-        steps:
-          - name: download-pict-file
-            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
-            env:
-              - name: JOB_SPEC
-                value: $(tasks.test-metadata.results.job-spec)
-            volumeMounts:
-              - name: shared-data
-                mountPath: /shared
-            script: |
-              #!/usr/bin/env bash
-              set -euo pipefail
-
-              echo "Using periodic configurations generated from PICT"
-              # Download periodic.pict file
-              curl -o /shared/periodic.pict https://raw.githubusercontent.com/jkopriva/tssc-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/periodic.pict
-              cat /shared/periodic.pict
-          - name: generate-pict-output
-            image: quay.io/apodhrad/pict:latest
-            volumeMounts:
-              - name: shared-data
-                mountPath: /shared
-            script: |
-              #!/usr/bin/env bash
-              set -euo pipefail
-              echo "Running PICT to generate test configurations..."
-              cd /shared
-              pict periodic.pict -r -o:1 > pict_output.txt
-              cat pict_output.txt
-          - name: process-config
-            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
-            volumeMounts:
-              - name: shared-data
-                mountPath: /shared
-            script: |
-              #!/usr/bin/env bash
-              set -euo pipefail
-
-              echo "Converting PICT output to RHADS configuration format..."
-              cd /shared
-              # Debug: Check if pict_output.txt exists and show its content
-              if [[ ! -f pict_output.txt ]]; then
-                echo "ERROR: pict_output.txt not found!"
-                ls -la /shared/
-                exit 1
-              fi
-              echo "Content of pict_output.txt:"
-              cat pict_output.txt
-              echo "--- End of pict_output.txt ---"
-              # Download testplan template
-              echo "Downloading testplan template..."
-              curl -o testplan_template.json https://raw.githubusercontent.com/jkopriva/tssc-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/testplan_template.json
-              if [[ ! -f testplan_template.json ]]; then
-                echo "ERROR: Failed to download testplan_template.json"
-                exit 1
-              fi
-              echo "Testplan template content:"
-              cat testplan_template.json
-              # Convert PICT output to multiple RHADS configurations
-              CONFIG_COUNT=0
-              OUTPUT_FILE="/tmp/rhads_output.txt"
-              > "$OUTPUT_FILE"  # Initialize empty file
-              while IFS=$'\t' read -r -a fields; do
-                echo "Processing line: ${fields[*]}"
-                if [[ "${fields[0]}" != "OCP" && -n "${fields[0]:-}" ]]; then  # Skip header line and empty lines
-                  if [[ $CONFIG_COUNT -gt 0 ]]; then
-                    echo "---CONFIG_SEPARATOR---" >> "$OUTPUT_FILE"
-                  fi
-                  # Build RHADS config format for this PICT line
-                  echo "OCP=\"${fields[0]:-4.18}\"" >> "$OUTPUT_FILE"
-                  echo "AUTH=\"${fields[1]:-github}\"" >> "$OUTPUT_FILE"
-                  echo "ACS=\"${fields[2]:-new}\"" >> "$OUTPUT_FILE"
-                  echo "REGISTRY=\"${fields[3]:-quay.io}\"" >> "$OUTPUT_FILE"
-                  echo "TPA=\"${fields[4]:-new}\"" >> "$OUTPUT_FILE"
-                  echo "SCM=\"${fields[5]:-github}\"" >> "$OUTPUT_FILE"
-                  echo "PIPELINE=\"${fields[6]:-tekton}\"" >> "$OUTPUT_FILE"
-                  # Generate corresponding testplan
-                  echo "---TESTPLAN_START---" >> "$OUTPUT_FILE"
-                  # Extract values for testplan
-                  SCM_VALUE="${fields[5]:-github}"
-                  PIPELINE_VALUE="${fields[6]:-tekton}"
-                  REGISTRY_VALUE="${fields[3]:-quay.io}"
-                  TPA_VALUE="${fields[4]:-new}"
-                  ACS_VALUE="${fields[2]:-new}"
-                  # Create testplan by replacing placeholders in template more precisely
-                  sed "s/\"git\": \"github\"/\"git\": \"$SCM_VALUE\"/g; s/\"ci\": \"tekton\"/\"ci\": \"$PIPELINE_VALUE\"/g; s/\"registry\": \"quay.io\"/\"registry\": \"$REGISTRY_VALUE\"/g; s/\"tpa\": \"local\"/\"tpa\": \"$TPA_VALUE\"/g; s/\"acs\": \"local\"/\"acs\": \"$ACS_VALUE\"/g" testplan_template.json >> "$OUTPUT_FILE"
-                  echo "---TESTPLAN_END---" >> "$OUTPUT_FILE"
-                  CONFIG_COUNT=$((CONFIG_COUNT + 1))
-                  echo "Generated configuration $CONFIG_COUNT with testplan"
-                else
-                  echo "Skipping line: ${fields[*]}"
-                fi
-              done < pict_output.txt
-              echo "Generated $CONFIG_COUNT RHADS configurations with testplans"
-              # Copy output to result path
-              echo "Final output:"
-              cat "$OUTPUT_FILE"
-              cat "$OUTPUT_FILE" > "$(results.rhads-config.path)"
-              echo "Configuration processing completed successfully"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+          - name: revision
+          - name: pathInRepo
+            value: integration-tests/tasks/process-periodic-configs.yaml
+      params:
+        - name: job-spec
+          value: $(tasks.test-metadata.results.job-spec)
       runAfter:
         - test-metadata
-
     - name: start-periodic-pipelines
       runAfter:
         - test-metadata

--- a/integration-tests/pipelines/e2e-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-periodic-pipeline.yaml
@@ -1,0 +1,362 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: e2e-periodic-pipeline
+  namespace: rhtap-shared-team-tenant
+  labels:
+    appstudio.openshift.io/component: rhtap-cli
+    appstudio.openshift.io/application: rhtap-cli
+spec:
+  description: |-
+    Pipeline for periodic testing with multiple configurations generated from PICT file.
+    This pipeline processes PICT combinations and creates multiple test configurations.
+  params:
+    - name: SNAPSHOT
+      description: "The JSON string representing the snapshot of the application under test."
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: konflux-test-infra-secret
+      description: The name of secret where testing infrastructures credentials are stored.
+      type: string
+    - name: cloud-credential-key
+      description: The key secret from konflux-test-infra-secret where all AWS ROSA configurations are stored.
+      type: string
+    - name: ocp-instance-type
+      description: 'The type of machine to use for the cluster nodes.'
+      default: "m5.2xlarge"
+      type: string
+    - name: ocp-replicas
+      description: 'The number of replicas for the cluster nodes.'
+      default: "3"
+      type: string
+  tasks:
+    - name: test-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: common/tasks/test-metadata/0.2/test-metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: test-name
+          value: $(context.pipelineRun.name)
+
+    - name: process-periodic-configs
+      taskSpec:
+        volumes:
+          - name: shared-data
+            emptyDir: {}
+        results:
+          - name: rhads-config
+            description: JSON formatted configuration data (array of configs from PICT)
+        steps:
+          - name: download-pict-file
+            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+            env:
+              - name: JOB_SPEC
+                value: $(tasks.test-metadata.results.job-spec)
+            volumeMounts:
+              - name: shared-data
+                mountPath: /shared
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              echo "Using periodic configurations generated from PICT"
+              # Download periodic.pict file
+              curl -o /shared/periodic.pict https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/periodic.pict
+              cat /shared/periodic.pict
+          - name: generate-pict-output
+            image: quay.io/apodhrad/pict:latest
+            volumeMounts:
+              - name: shared-data
+                mountPath: /shared
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              echo "Running PICT to generate test configurations..."
+              cd /shared
+              pict periodic.pict -r -o:1 > pict_output.txt
+              cat pict_output.txt
+          - name: process-config
+            image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+            volumeMounts:
+              - name: shared-data
+                mountPath: /shared
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              echo "Converting PICT output to RHADS configuration format..."
+              cd /shared
+              # Debug: Check if pict_output.txt exists and show its content
+              if [[ ! -f pict_output.txt ]]; then
+                echo "ERROR: pict_output.txt not found!"
+                ls -la /shared/
+                exit 1
+              fi
+              echo "Content of pict_output.txt:"
+              cat pict_output.txt
+              echo "--- End of pict_output.txt ---"
+              # Download testplan template
+              echo "Downloading testplan template..."
+              curl -o testplan_template.json https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/testplan_template.json
+              if [[ ! -f testplan_template.json ]]; then
+                echo "ERROR: Failed to download testplan_template.json"
+                exit 1
+              fi
+              echo "Testplan template content:"
+              cat testplan_template.json
+              # Convert PICT output to multiple RHADS configurations
+              CONFIG_COUNT=0
+              OUTPUT_FILE="/tmp/rhads_output.txt"
+              > "$OUTPUT_FILE"  # Initialize empty file
+              while IFS=$'\t' read -r -a fields; do
+                echo "Processing line: ${fields[*]}"
+                if [[ "${fields[0]}" != "OCP" && -n "${fields[0]:-}" ]]; then  # Skip header line and empty lines
+                  if [[ $CONFIG_COUNT -gt 0 ]]; then
+                    echo "---CONFIG_SEPARATOR---" >> "$OUTPUT_FILE"
+                  fi
+                  # Build RHADS config format for this PICT line
+                  echo "OCP=\"${fields[0]:-4.18}\"" >> "$OUTPUT_FILE"
+                  echo "AUTH=\"${fields[1]:-github}\"" >> "$OUTPUT_FILE"
+                  echo "ACS=\"${fields[2]:-new}\"" >> "$OUTPUT_FILE"
+                  echo "REGISTRY=\"${fields[3]:-quay.io}\"" >> "$OUTPUT_FILE"
+                  echo "TPA=\"${fields[4]:-new}\"" >> "$OUTPUT_FILE"
+                  echo "SCM=\"${fields[5]:-github}\"" >> "$OUTPUT_FILE"
+                  echo "PIPELINE=\"${fields[6]:-tekton}\"" >> "$OUTPUT_FILE"
+                  # Generate corresponding testplan
+                  echo "---TESTPLAN_START---" >> "$OUTPUT_FILE"
+                  # Extract values for testplan
+                  SCM_VALUE="${fields[5]:-github}"
+                  PIPELINE_VALUE="${fields[6]:-tekton}"
+                  REGISTRY_VALUE="${fields[3]:-quay.io}"
+                  TPA_VALUE="${fields[4]:-new}"
+                  ACS_VALUE="${fields[2]:-new}"
+                  # Create testplan by replacing placeholders in template more precisely
+                  sed "s/\"git\": \"github\"/\"git\": \"$SCM_VALUE\"/g; s/\"ci\": \"tekton\"/\"ci\": \"$PIPELINE_VALUE\"/g; s/\"registry\": \"quay.io\"/\"registry\": \"$REGISTRY_VALUE\"/g; s/\"tpa\": \"local\"/\"tpa\": \"$TPA_VALUE\"/g; s/\"acs\": \"local\"/\"acs\": \"$ACS_VALUE\"/g" testplan_template.json >> "$OUTPUT_FILE"
+                  echo "---TESTPLAN_END---" >> "$OUTPUT_FILE"
+                  CONFIG_COUNT=$((CONFIG_COUNT + 1))
+                  echo "Generated configuration $CONFIG_COUNT with testplan"
+                else
+                  echo "Skipping line: ${fields[*]}"
+                fi
+              done < pict_output.txt
+              echo "Generated $CONFIG_COUNT RHADS configurations with testplans"
+              # Copy output to result path
+              echo "Final output:"
+              cat "$OUTPUT_FILE"
+              cat "$OUTPUT_FILE" > "$(results.rhads-config.path)"
+              echo "Configuration processing completed successfully"
+      runAfter:
+        - test-metadata
+
+    - name: start-periodic-pipelines
+      runAfter:
+        - test-metadata
+        - process-periodic-configs
+      taskSpec:
+        steps:
+          - name: start-pipeline
+            image: quay.io/openshift-pipeline/ci
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: JOB_SPEC
+                value: $(tasks.test-metadata.results.job-spec)
+              - name: RHADS_CONFIG
+                value: $(tasks.process-periodic-configs.results.rhads-config)
+              - name: KONFLUX_APPLICATION_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/application']
+              - name: KONFLUX_COMPONENT_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/component']
+              - name: KONFLUX_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              echo "Processing periodic RHADS configurations..."
+              # get the tssc image and tssc-test image from the snapshot
+              tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="rhtap-cli").containerImage')
+              tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
+
+              GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
+              KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
+
+              if [[ "${GIT_REPO}" = "rhtap-cli" ]]; then
+                REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
+                BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+              else
+                REPO_ORG="redhat-appstudio"
+                BRANCH="main"
+              fi
+
+              PIPELINERUNS_ARRAY=()
+
+              echo "Running in periodic mode with multiple configurations"
+              echo "Processing RHADS configurations:"
+              echo "$RHADS_CONFIG"
+              # Split configurations by separator and process each one
+              echo "Splitting configurations using bash string manipulation..."
+              
+              # Count configurations for informational purposes
+              CONFIG_COUNT=$(echo "$RHADS_CONFIG" | grep -o -e "---CONFIG_SEPARATOR---" | wc -l)
+              CONFIG_COUNT=$((CONFIG_COUNT + 1))  # Add 1 because there's one more config than separators
+              echo "Found $CONFIG_COUNT configurations to process"
+              
+              # Create a pipeline for every RHADS config using pure bash string manipulation
+              CONFIG_INDEX=0
+              # Split the configurations using bash string manipulation
+              REMAINING_CONFIG="$RHADS_CONFIG"
+              while [[ -n "$REMAINING_CONFIG" ]]; do
+                # Find the next separator
+                if [[ "$REMAINING_CONFIG" == *"---CONFIG_SEPARATOR---"* ]]; then
+                  # Extract config before separator
+                  FULL_CONFIG="${REMAINING_CONFIG%%---CONFIG_SEPARATOR---*}"
+                  # Remove processed config and separator from remaining
+                  REMAINING_CONFIG="${REMAINING_CONFIG#*---CONFIG_SEPARATOR---}"
+                  echo "$FULL_CONFIG"
+                else
+                  # Last config (no separator after it)
+                  FULL_CONFIG="$REMAINING_CONFIG"
+                  REMAINING_CONFIG=""
+                fi
+                # Trim whitespace from config
+                FULL_CONFIG=$(echo "$FULL_CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                echo "DEBUG - Config after trimming:"
+                echo "$FULL_CONFIG"
+                
+                CONFIG_INDEX=$(( $CONFIG_INDEX + 1 ))
+                echo "==================== Configuration $CONFIG_INDEX ===================="
+                echo "$FULL_CONFIG"
+                echo "================================================================"
+                
+                # Split RHADS config and testplan
+                if [[ "$FULL_CONFIG" == *"---TESTPLAN_START---"* ]]; then
+                  # Extract RHADS config (before testplan)
+                  CONFIG="${FULL_CONFIG%%---TESTPLAN_START---*}"
+                  # Extract testplan (between markers)
+                  TESTPLAN_PART="${FULL_CONFIG#*---TESTPLAN_START---}"
+                  TESTPLAN="${TESTPLAN_PART%%---TESTPLAN_END---*}"
+                  # Trim whitespace from both parts
+                  CONFIG=$(echo "$CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                  TESTPLAN=$(echo "$TESTPLAN" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                  echo "RHADS Config:"
+                  echo "$CONFIG"
+                  echo "Testplan:"
+                  echo "$TESTPLAN"
+                  # Encode testplan to base64
+                  TESTPLAN_B64=$(echo "$TESTPLAN" | base64 -w 0)
+                  echo "Testplan base64: $TESTPLAN_B64"
+                else
+                  # No testplan found, use config as-is
+                  CONFIG="$FULL_CONFIG"
+                  TESTPLAN_B64=""
+                  echo "No testplan found for this configuration"
+                fi
+                
+                # Extract OCP version from this configuration
+                if [[ $CONFIG =~ OCP=\"([^\"]+)\" ]]; then
+                  OCP_VERSION="${BASH_REMATCH[1]}"
+                  echo "Successfully extracted OCP version: $OCP_VERSION from configuration $CONFIG_INDEX"
+                  echo "About to start sub-pipeline for OCP version: $OCP_VERSION (Configuration $CONFIG_INDEX)"
+                  echo "Pipeline command will be executed now..."
+
+                  PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/pipelines/rhtap-cli-e2e.yaml \
+                    --param ocp-version="$OCP_VERSION"\
+                    --param job-spec="$JOB_SPEC"\
+                    --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \
+                    --param rhads-config="$CONFIG" \
+                    $(if [[ -n "$TESTPLAN_B64" ]]; then echo "--param testplan=$TESTPLAN_B64"; fi) \
+                    --param cloud-credential-key="$(params.cloud-credential-key)" \
+                    --param machine-type="$(params.ocp-instance-type)" \
+                    --param replicas="$(params.ocp-replicas)" \
+                    $(if [[ "${tssc_image}" != "" ]]; then echo "--param tssc-image=${tssc_image}"; fi) \
+                    $(if [[ "${tssc_test_image}" != "" ]]; then echo "--param tssc-test-image=${tssc_test_image}"; fi) \
+                    --use-param-defaults \
+                    --labels "appstudio.openshift.io/component=${KONFLUX_COMPONENT_NAME}" \
+                    --labels "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}" \
+                    --labels "pipelines.appstudio.openshift.io/type=$(context.pipelineRun.name)" \
+                    --labels "test.appstudio.openshift.io/scenario=pr-e2e-tests" \
+                    --labels "custom.appstudio.openshift.io/main-pipeline-run=$(context.pipelineRun.name)" \
+                    --prefix-name "e2e-$OCP_VERSION-config$CONFIG_INDEX"\
+                    -o name)
+
+                  echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
+                  PIPELINERUNS_ARRAY+=($PIPELINE_RUN)
+                else
+                  echo "Warning: Could not extract OCP version from configuration $CONFIG_INDEX"
+                fi
+              done
+              echo "Started $CONFIG_INDEX sub-pipelines for periodic testing"
+
+              echo "Total pipelines started: ${#PIPELINERUNS_ARRAY[@]}"
+
+              # Waits for condition for all started pipelines
+              function waitFor() {
+                  CONDITION=$1 MESSAGE_RUNNING=$2 MESSAGE_DONE=$3 timeout --foreground 120m /bin/bash -c '
+                    #deserialize plrs array
+                    set -x
+                    read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
+                    echo "${PIPELINERUNS_ARRAY[*]}"
+                    while true; do
+                      CONDITION_MET=false
+                      for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
+                        if eval "$CONDITION"; then
+                          #something is still running. Break this cycle and wait one minute.
+                          CONDITION_MET=true
+                          break
+                        fi
+                      done
+                      if $CONDITION_MET ; then
+                        echo "$MESSAGE_RUNNING"
+                        sleep 60
+                      else
+                        echo "$MESSAGE_DONE"
+                        break
+                      fi
+                    done
+                  '
+              }
+
+              #Serialize plrs array to be able to export it as var
+              export PIPELINERUNS_ARRAY_SERIALIZED="${PIPELINERUNS_ARRAY[*]}"
+
+              waitFor '! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null' "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
+              waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "" ]]' "Waiting for nested pipelinerun status to be set. Waiting 1 minute" "Nested pipelinerun status is set"
+              waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
+
+              # Explore and report status of all failed pipelineruns. Fail if anything failed
+              SOME_PIPELINE_FAILED=false
+              SOME_PIPELINE_SUCCEEDED=false
+              for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
+                if [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "False" ]]; then
+                  if ! $SOME_PIPELINE_FAILED ; then
+                    echo "List of failed PLRs:"
+                  fi
+                  echo "${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
+                  SOME_PIPELINE_FAILED=true
+                elif [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "True" ]]; then
+                  SOME_PIPELINE_SUCCEEDED=true
+                fi
+              done
+              if $SOME_PIPELINE_SUCCEEDED ; then
+                exit 0
+              fi
+              if $SOME_PIPELINE_FAILED ; then
+                exit 1
+              fi
+              echo "Pipeline processing completed successfully"

--- a/integration-tests/pipelines/e2e-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-periodic-pipeline.yaml
@@ -30,6 +30,7 @@ spec:
       description: 'The number of replicas for the cluster nodes.'
       default: "3"
       type: string
+
   tasks:
     - name: test-metadata
       taskRef:
@@ -51,7 +52,9 @@ spec:
         resolver: git
         params:
           - name: url
+            value: https://github.com/jkopriva/tssc-cli.git
           - name: revision
+            value: RHTAP-5290
           - name: pathInRepo
             value: integration-tests/tasks/process-periodic-configs.yaml
       params:

--- a/integration-tests/pipelines/tssc-cli-e2e.yaml
+++ b/integration-tests/pipelines/tssc-cli-e2e.yaml
@@ -50,6 +50,10 @@ spec:
       type: string
       description: "Image from where the `tssc-test` binary will be extracted (from path /usr/local/bin)."
       default: "quay.io/redhat-user-workloads/rhtap-shared-team-tenant/tssc-test:latest"
+    - name: testplan
+      type: string
+      description: 'Optional testplan.json content encoded in base64 format. If not provided, testplan will be downloaded from the repository.'
+      default: ""
   tasks:
     - name: rosa-hcp-metadata
       taskRef:
@@ -147,9 +151,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/tssc-test.git
+            value: https://github.com/jkopriva/tssc-test.git
           - name: revision
-            value: main
+            value: RHTAP-5290
           - name: pathInRepo
             value: integration-tests/tasks/tssc-e2e.yaml
       params:
@@ -183,6 +187,8 @@ spec:
           value: $(tasks.create-oci-container.results.oci-container)
         - name: tssc-test-image
           value: $(params.tssc-test-image)
+        - name: testplan
+          value: $(params.testplan)
   finally:
     - name: deprovision-rosa-collect-artifacts
       taskRef:

--- a/integration-tests/pipelines/tssc-cli-e2e.yaml
+++ b/integration-tests/pipelines/tssc-cli-e2e.yaml
@@ -151,9 +151,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/jkopriva/tssc-test.git
+            value: https://github.com/redhat-appstudio/tssc-test.git
           - name: revision
-            value: RHTAP-5290
+            value: main
           - name: pathInRepo
             value: integration-tests/tasks/tssc-e2e.yaml
       params:

--- a/integration-tests/tasks/get-rhads-config.yaml
+++ b/integration-tests/tasks/get-rhads-config.yaml
@@ -16,7 +16,7 @@ spec:
       type: string
   results:
     - name: rhads-config
-      description: "The RHADS configuration content"
+      description: "The RHADS configuration content (base64 encoded)"
   steps:
     - name: get-rhads-config
       image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
@@ -40,4 +40,8 @@ spec:
         rhads_config_file_location="integration-tests/config/rhads-config"
         curl -o rhads-config https://raw.githubusercontent.com/$REPO_ORG/$GIT_REPO/refs/heads/$BRANCH/$rhads_config_file_location
 
-        cat rhads-config | tee $(results.rhads-config.path)
+        echo "Original rhads-config content:"
+        cat rhads-config
+        
+        echo "Encoding rhads-config to base64:"
+        cat rhads-config | base64 -w 0 | tee $(results.rhads-config.path)

--- a/integration-tests/tasks/get-rhads-config.yaml
+++ b/integration-tests/tasks/get-rhads-config.yaml
@@ -42,6 +42,5 @@ spec:
 
         echo "Original rhads-config content:"
         cat rhads-config
-        
         echo "Encoding rhads-config to base64:"
         cat rhads-config | base64 -w 0 | tee $(results.rhads-config.path)

--- a/integration-tests/tasks/get-rhads-config.yaml
+++ b/integration-tests/tasks/get-rhads-config.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: get-rhads-config
+  annotations:
+    tekton.dev/displayName: "Get RHADS Config"
+    tekton.dev/categories: "Pipeline"
+    tekton.dev/tags: "config,rhads"
+spec:
+  description: >-
+    This task downloads and provides the RHADS configuration file from the repository.
+  params:
+    - name: job-spec
+      description: "Job specification metadata"
+      type: string
+  results:
+    - name: rhads-config
+      description: "The RHADS configuration content"
+  steps:
+    - name: get-rhads-config
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+      env:
+        - name: JOB_SPEC
+          value: $(params.job-spec)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        echo "Downloading rhads-config file:"
+        GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
+        REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
+        # Determine the branch name for the curl command.
+        # If source_repo_branch starts with "refs/heads/", strip that prefix; otherwise, use as is.
+        BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+        if [[ "$BRANCH" == refs/heads/* ]]; then
+          BRANCH="${BRANCH#refs/heads/}"
+        fi
+
+        rhads_config_file_location="integration-tests/config/rhads-config"
+        curl -o rhads-config https://raw.githubusercontent.com/$REPO_ORG/$GIT_REPO/refs/heads/$BRANCH/$rhads_config_file_location
+
+        cat rhads-config | tee $(results.rhads-config.path)

--- a/integration-tests/tasks/process-periodic-configs.yaml
+++ b/integration-tests/tasks/process-periodic-configs.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: process-periodic-configs
+  annotations:
+    tekton.dev/displayName: "Process Periodic Configs"
+    tekton.dev/categories: "Pipeline"
+    tekton.dev/tags: "config,periodic,pict"
+spec:
+  description: >-
+    This task processes periodic configurations using PICT to generate multiple test configurations
+    with corresponding testplans for comprehensive testing.
+  params:
+    - name: job-spec
+      description: "Job specification metadata"
+      type: string
+  results:
+    - name: rhads-config
+      description: "JSON formatted configuration data (array of configs from PICT)"
+  steps:
+    - name: download-pict-file
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+      env:
+        - name: JOB_SPEC
+          value: $(params.job-spec)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        echo "Using periodic configurations generated from PICT"
+        # Download periodic.pict file
+        curl -o periodic.pict https://raw.githubusercontent.com/jkopriva/tssc-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/periodic.pict
+
+        cat periodic.pict
+
+    - name: generate-pict-output
+      image: quay.io/apodhrad/pict:latest
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        echo "Running PICT to generate test configurations..."
+        pict periodic.pict -r -o:1 > pict_output.txt
+        cat pict_output.txt
+
+    - name: process-config
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        echo "Converting PICT output to RHADS configuration format..."
+        # Debug: Check if pict_output.txt exists and show its content
+        if [[ ! -f pict_output.txt ]]; then
+          echo "ERROR: pict_output.txt not found!"
+          ls -la
+          exit 1
+        fi
+        echo "Content of pict_output.txt:"
+        cat pict_output.txt
+        echo "--- End of pict_output.txt ---"
+        # Download testplan template
+        echo "Downloading testplan template..."
+        curl -o testplan_template.json https://raw.githubusercontent.com/jkopriva/tssc-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/testplan_template.json
+
+        if [[ ! -f testplan_template.json ]]; then
+          echo "ERROR: Failed to download testplan_template.json"
+          exit 1
+        fi
+        echo "Testplan template content:"
+        cat testplan_template.json
+        # Convert PICT output to multiple RHADS configurations
+        CONFIG_COUNT=0
+        OUTPUT_FILE="/tmp/rhads_output.txt"
+        > "$OUTPUT_FILE"  # Initialize empty file
+        while IFS=$'\t' read -r -a fields; do
+          echo "Processing line: ${fields[*]}"
+          if [[ "${fields[0]}" != "OCP" && -n "${fields[0]:-}" ]]; then  # Skip header line and empty lines
+            if [[ $CONFIG_COUNT -gt 0 ]]; then
+              echo "---CONFIG_SEPARATOR---" >> "$OUTPUT_FILE"
+            fi
+            # Build RHADS config format for this PICT line
+            echo "OCP=\"${fields[0]:-4.18}\"" >> "$OUTPUT_FILE"
+            echo "AUTH=\"${fields[1]:-github}\"" >> "$OUTPUT_FILE"
+            echo "ACS=\"${fields[2]:-new}\"" >> "$OUTPUT_FILE"
+            echo "REGISTRY=\"${fields[3]:-quay.io}\"" >> "$OUTPUT_FILE"
+            echo "TPA=\"${fields[4]:-new}\"" >> "$OUTPUT_FILE"
+            echo "SCM=\"${fields[5]:-github}\"" >> "$OUTPUT_FILE"
+            echo "PIPELINE=\"${fields[6]:-tekton}\"" >> "$OUTPUT_FILE"
+            # Generate corresponding testplan
+            echo "---TESTPLAN_START---" >> "$OUTPUT_FILE"
+            # Extract values for testplan
+            SCM_VALUE="${fields[5]:-github}"
+            PIPELINE_VALUE="${fields[6]:-tekton}"
+            REGISTRY_VALUE="${fields[3]:-quay.io}"
+            TPA_VALUE="${fields[4]:-new}"
+            ACS_VALUE="${fields[2]:-new}"
+            # Create testplan by replacing placeholders in template more precisely
+            sed "s/\"git\": \"github\"/\"git\": \"$SCM_VALUE\"/g; s/\"ci\": \"tekton\"/\"ci\": \"$PIPELINE_VALUE\"/g; s/\"registry\": \"quay.io\"/\"registry\": \"$REGISTRY_VALUE\"/g; s/\"tpa\": \"local\"/\"tpa\": \"$TPA_VALUE\"/g; s/\"acs\": \"local\"/\"acs\": \"$ACS_VALUE\"/g" testplan_template.json >> "$OUTPUT_FILE"
+            echo "---TESTPLAN_END---" >> "$OUTPUT_FILE"
+            CONFIG_COUNT=$((CONFIG_COUNT + 1))
+            echo "Generated configuration $CONFIG_COUNT with testplan"
+          else
+            echo "Skipping line: ${fields[*]}"
+          fi
+        done < pict_output.txt
+        echo "Generated $CONFIG_COUNT RHADS configurations with testplans"
+        # Copy output to result path
+        echo "Final output:"
+        cat "$OUTPUT_FILE"
+        cat "$OUTPUT_FILE" > "$(results.rhads-config.path)"
+        echo "Configuration processing completed successfully"

--- a/integration-tests/tasks/process-periodic-configs.yaml
+++ b/integration-tests/tasks/process-periodic-configs.yaml
@@ -17,7 +17,11 @@ spec:
       type: string
   results:
     - name: rhads-config
-      description: "JSON formatted configuration data (array of configs from PICT)"
+      description: "JSON formatted configuration data (array of configs from PICT, base64 encoded)"
+    - name: periodic-pict
+      description: "Periodic PICT file content for sharing between steps"
+    - name: pict-output
+      description: "PICT output content for sharing between steps"
   steps:
     - name: download-pict-file
       image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
@@ -33,6 +37,8 @@ spec:
         curl -o periodic.pict https://raw.githubusercontent.com/jkopriva/tssc-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/periodic.pict
 
         cat periodic.pict
+        # Store the content as a result for the next step
+        cat periodic.pict > $(results.periodic-pict.path)
 
     - name: generate-pict-output
       image: quay.io/apodhrad/pict:latest
@@ -40,8 +46,12 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
         echo "Running PICT to generate test configurations..."
+        # Get the periodic.pict content from the previous step
+        cat $(results.periodic-pict.path) > periodic.pict
         pict periodic.pict -r -o:1 > pict_output.txt
         cat pict_output.txt
+        # Store the PICT output as a result for the next step
+        cat pict_output.txt > $(results.pict-output.path)
 
     - name: process-config
       image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
@@ -50,6 +60,13 @@ spec:
         set -euo pipefail
 
         echo "Converting PICT output to RHADS configuration format..."
+        # Get the PICT output from the previous step
+        cat $(results.pict-output.path) > pict_output.txt
+        
+        # Set local variable for maximum configurations (0 = all configurations)
+        MAX_CONFIGS=1  # Change this value to limit configurations (e.g., 5, 10, etc.)
+        echo "Maximum configurations requested: $MAX_CONFIGS (0 = all configurations)"
+        
         # Debug: Check if pict_output.txt exists and show its content
         if [[ ! -f pict_output.txt ]]; then
           echo "ERROR: pict_output.txt not found!"
@@ -59,6 +76,7 @@ spec:
         echo "Content of pict_output.txt:"
         cat pict_output.txt
         echo "--- End of pict_output.txt ---"
+        
         # Download testplan template
         echo "Downloading testplan template..."
         curl -o testplan_template.json https://raw.githubusercontent.com/jkopriva/tssc-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/testplan_template.json
@@ -69,6 +87,7 @@ spec:
         fi
         echo "Testplan template content:"
         cat testplan_template.json
+        
         # Convert PICT output to multiple RHADS configurations
         CONFIG_COUNT=0
         OUTPUT_FILE="/tmp/rhads_output.txt"
@@ -76,6 +95,12 @@ spec:
         while IFS=$'\t' read -r -a fields; do
           echo "Processing line: ${fields[*]}"
           if [[ "${fields[0]}" != "OCP" && -n "${fields[0]:-}" ]]; then  # Skip header line and empty lines
+            # Check if we've reached the maximum number of configurations
+            if [[ $MAX_CONFIGS -gt 0 && $CONFIG_COUNT -ge $MAX_CONFIGS ]]; then
+              echo "Reached maximum number of configurations ($MAX_CONFIGS), stopping processing"
+              break
+            fi
+            
             if [[ $CONFIG_COUNT -gt 0 ]]; then
               echo "---CONFIG_SEPARATOR---" >> "$OUTPUT_FILE"
             fi
@@ -105,8 +130,17 @@ spec:
           fi
         done < pict_output.txt
         echo "Generated $CONFIG_COUNT RHADS configurations with testplans"
+        if [[ $MAX_CONFIGS -gt 0 ]]; then
+          echo "Limited to $MAX_CONFIGS configurations as requested"
+        else
+          echo "No limit applied - processed all available configurations"
+        fi
         # Copy output to result path
         echo "Final output:"
         cat "$OUTPUT_FILE"
-        cat "$OUTPUT_FILE" > "$(results.rhads-config.path)"
-        echo "Configuration processing completed successfully"
+        #cat "$OUTPUT_FILE" > "$(results.rhads-config.path)"
+
+        echo "Encoding rhads-config to base64:"
+        cat "$OUTPUT_FILE" | base64 -w 0 | tee $(results.rhads-config.path)
+        
+        echo "Configuration count: $CONFIG_COUNT"

--- a/integration-tests/tasks/process-periodic-configs.yaml
+++ b/integration-tests/tasks/process-periodic-configs.yaml
@@ -62,11 +62,9 @@ spec:
         echo "Converting PICT output to RHADS configuration format..."
         # Get the PICT output from the previous step
         cat $(results.pict-output.path) > pict_output.txt
-        
         # Set local variable for maximum configurations (0 = all configurations)
         MAX_CONFIGS=1  # Change this value to limit configurations (e.g., 5, 10, etc.)
         echo "Maximum configurations requested: $MAX_CONFIGS (0 = all configurations)"
-        
         # Debug: Check if pict_output.txt exists and show its content
         if [[ ! -f pict_output.txt ]]; then
           echo "ERROR: pict_output.txt not found!"
@@ -76,7 +74,6 @@ spec:
         echo "Content of pict_output.txt:"
         cat pict_output.txt
         echo "--- End of pict_output.txt ---"
-        
         # Download testplan template
         echo "Downloading testplan template..."
         curl -o testplan_template.json https://raw.githubusercontent.com/jkopriva/tssc-cli/refs/heads/RHTAP-5290/integration-tests/config/periodic/testplan_template.json
@@ -87,14 +84,19 @@ spec:
         fi
         echo "Testplan template content:"
         cat testplan_template.json
-        
         # Convert PICT output to multiple RHADS configurations
         CONFIG_COUNT=0
         OUTPUT_FILE="/tmp/rhads_output.txt"
         > "$OUTPUT_FILE"  # Initialize empty file
         while IFS=$'\t' read -r -a fields; do
           echo "Processing line: ${fields[*]}"
+          echo "DEBUG: Number of fields: ${#fields[@]}"
           if [[ "${fields[0]}" != "OCP" && -n "${fields[0]:-}" ]]; then  # Skip header line and empty lines
+            # Validate that we have enough fields
+            if [[ ${#fields[@]} -lt 6 ]]; then
+              echo "ERROR: Expected at least 6 fields, got ${#fields[@]} fields: ${fields[*]}"
+              exit 1
+            fi
             # Check if we've reached the maximum number of configurations
             if [[ $MAX_CONFIGS -gt 0 && $CONFIG_COUNT -ge $MAX_CONFIGS ]]; then
               echo "Reached maximum number of configurations ($MAX_CONFIGS), stopping processing"
@@ -106,20 +108,27 @@ spec:
             fi
             # Build RHADS config format for this PICT line
             echo "OCP=\"${fields[0]:-4.18}\"" >> "$OUTPUT_FILE"
-            echo "AUTH=\"${fields[1]:-github}\"" >> "$OUTPUT_FILE"
-            echo "ACS=\"${fields[2]:-new}\"" >> "$OUTPUT_FILE"
-            echo "REGISTRY=\"${fields[3]:-quay.io}\"" >> "$OUTPUT_FILE"
-            echo "TPA=\"${fields[4]:-new}\"" >> "$OUTPUT_FILE"
-            echo "SCM=\"${fields[5]:-github}\"" >> "$OUTPUT_FILE"
-            echo "PIPELINE=\"${fields[6]:-tekton}\"" >> "$OUTPUT_FILE"
+            # Derive AUTH from SCM (github/gitlab/bitbucket -> github/gitlab)
+            SCM_VALUE="${fields[4]:-github}"
+            if [[ "$SCM_VALUE" == "bitbucket" ]]; then
+              AUTH_VALUE="github"  # bitbucket uses github auth
+            else
+              AUTH_VALUE="$SCM_VALUE"
+            fi
+            echo "AUTH=\"$AUTH_VALUE\"" >> "$OUTPUT_FILE"
+            echo "ACS=\"${fields[1]:-local}\"" >> "$OUTPUT_FILE"
+            echo "REGISTRY=\"${fields[2]:-quay}\"" >> "$OUTPUT_FILE"
+            echo "TPA=\"${fields[3]:-local}\"" >> "$OUTPUT_FILE"
+            echo "SCM=\"${fields[4]:-github}\"" >> "$OUTPUT_FILE"
+            echo "PIPELINE=\"${fields[5]:-tekton}\"" >> "$OUTPUT_FILE"
             # Generate corresponding testplan
             echo "---TESTPLAN_START---" >> "$OUTPUT_FILE"
             # Extract values for testplan
-            SCM_VALUE="${fields[5]:-github}"
-            PIPELINE_VALUE="${fields[6]:-tekton}"
-            REGISTRY_VALUE="${fields[3]:-quay.io}"
-            TPA_VALUE="${fields[4]:-new}"
-            ACS_VALUE="${fields[2]:-new}"
+            SCM_VALUE="${fields[4]:-github}"
+            PIPELINE_VALUE="${fields[5]:-tekton}"
+            REGISTRY_VALUE="${fields[2]:-quay}"
+            TPA_VALUE="${fields[3]:-local}"
+            ACS_VALUE="${fields[1]:-local}"
             # Create testplan by replacing placeholders in template more precisely
             sed "s/SCM_PROVIDER/$SCM_VALUE/g; s/CI_PROVIDER/$PIPELINE_VALUE/g; s/REGISTRY/$REGISTRY_VALUE/g; s/TPA_PROVIDER/$TPA_VALUE/g; s/ACS_PROVIDER/$ACS_VALUE/g" testplan_template.json >> "$OUTPUT_FILE"
             echo "---TESTPLAN_END---" >> "$OUTPUT_FILE"

--- a/integration-tests/tasks/process-periodic-configs.yaml
+++ b/integration-tests/tasks/process-periodic-configs.yaml
@@ -102,7 +102,6 @@ spec:
               echo "Reached maximum number of configurations ($MAX_CONFIGS), stopping processing"
               break
             fi
-            
             if [[ $CONFIG_COUNT -gt 0 ]]; then
               echo "---CONFIG_SEPARATOR---" >> "$OUTPUT_FILE"
             fi
@@ -150,5 +149,4 @@ spec:
 
         echo "Encoding rhads-config to base64:"
         cat "$OUTPUT_FILE" | base64 -w 0 | tee $(results.rhads-config.path)
-        
         echo "Configuration count: $CONFIG_COUNT"

--- a/integration-tests/tasks/process-periodic-configs.yaml
+++ b/integration-tests/tasks/process-periodic-configs.yaml
@@ -121,7 +121,7 @@ spec:
             TPA_VALUE="${fields[4]:-new}"
             ACS_VALUE="${fields[2]:-new}"
             # Create testplan by replacing placeholders in template more precisely
-            sed "s/\"git\": \"github\"/\"git\": \"$SCM_VALUE\"/g; s/\"ci\": \"tekton\"/\"ci\": \"$PIPELINE_VALUE\"/g; s/\"registry\": \"quay.io\"/\"registry\": \"$REGISTRY_VALUE\"/g; s/\"tpa\": \"local\"/\"tpa\": \"$TPA_VALUE\"/g; s/\"acs\": \"local\"/\"acs\": \"$ACS_VALUE\"/g" testplan_template.json >> "$OUTPUT_FILE"
+            sed "s/SCM_PROVIDER/$SCM_VALUE/g; s/CI_PROVIDER/$PIPELINE_VALUE/g; s/REGISTRY/$REGISTRY_VALUE/g; s/TPA_PROVIDER/$TPA_VALUE/g; s/ACS_PROVIDER/$ACS_VALUE/g" testplan_template.json >> "$OUTPUT_FILE"
             echo "---TESTPLAN_END---" >> "$OUTPUT_FILE"
             CONFIG_COUNT=$((CONFIG_COUNT + 1))
             echo "Generated configuration $CONFIG_COUNT with testplan"
@@ -138,7 +138,6 @@ spec:
         # Copy output to result path
         echo "Final output:"
         cat "$OUTPUT_FILE"
-        #cat "$OUTPUT_FILE" > "$(results.rhads-config.path)"
 
         echo "Encoding rhads-config to base64:"
         cat "$OUTPUT_FILE" | base64 -w 0 | tee $(results.rhads-config.path)

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -9,7 +9,7 @@ metadata:
     tekton.dev/tags: "pipeline,start,rhtap"
 spec:
   description: >-
-    This task starts one or more rhtap-cli-e2e pipelines based on configuration.
+    This task starts one or more tssc-cli-e2e pipelines based on configuration.
     It supports both single configuration mode and periodic configuration mode
     (multiple configs with separators and testplans).
   params:
@@ -58,7 +58,6 @@ spec:
           value: $(params.rhads-config)
         - name: MODE
           value: $(params.mode)
-
         - name: CONTEXT_PIPELINE_RUN_NAME
           value: $(params.context-pipeline-run-name)
         - name: KONFLUX_TEST_INFRA_SECRET
@@ -69,30 +68,32 @@ spec:
           value: $(params.ocp-instance-type)
         - name: OCP_REPLICAS
           value: $(params.ocp-replicas)
+        - name: KONFLUX_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KONFLUX_APPLICATION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/application']
+        - name: KONFLUX_COMPONENT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
 
         echo "Starting pipelines in mode: $MODE"
-        # Extract konflux metadata from current pod environment
-        # These environment variables are automatically set by Tekton
-        KONFLUX_NAMESPACE="${KONFLUX_NAMESPACE:-$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)}"
-        # Extract labels from the current pipeline run using oc/kubectl
-        CURRENT_PR=$(oc get pipelinerun -n "${KONFLUX_NAMESPACE}" --field-selector metadata.name="${CONTEXT_PIPELINE_RUN_NAME}" -o json 2>/dev/null || echo '{}')
-        KONFLUX_APPLICATION_NAME=$(echo "$CURRENT_PR" | jq -r '.items[0].metadata.labels["appstudio.openshift.io/application"] // "rhtap-cli"')
-        KONFLUX_COMPONENT_NAME=$(echo "$CURRENT_PR" | jq -r '.items[0].metadata.labels["appstudio.openshift.io/component"] // "rhtap-cli"')
-        # Fallback values if extraction fails
-        KONFLUX_APPLICATION_NAME="${KONFLUX_APPLICATION_NAME:-rhtap-cli}"
-        KONFLUX_COMPONENT_NAME="${KONFLUX_COMPONENT_NAME:-rhtap-cli}"
         echo "Using Konflux metadata: namespace=$KONFLUX_NAMESPACE, app=$KONFLUX_APPLICATION_NAME, component=$KONFLUX_COMPONENT_NAME"
         # Extract images from snapshot
-        tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="rhtap-cli").containerImage')
+        tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-cli").containerImage')
         tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
 
         GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
         KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
 
-        if [[ "${GIT_REPO}" = "rhtap-cli" ]]; then
+        if [[ "${GIT_REPO}" = "tssc-cli" ]]; then
           REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
           BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
         else
@@ -110,7 +111,6 @@ spec:
           local config_suffix="$4"
           echo "Starting pipeline for OCP version: $ocp_version"
           local pipeline_run
-          
           # Build the tkn command with proper parameter handling
           local tkn_params=(
             "--param" "ocp-version=$ocp_version"
@@ -122,7 +122,7 @@ spec:
             "--param" "machine-type=$OCP_INSTANCE_TYPE"
             "--param" "replicas=$OCP_REPLICAS"
           )
-          
+
           # Add optional image parameters
           if [[ "${tssc_image}" != "" ]]; then
             tkn_params+=("--param" "tssc-image=${tssc_image}")
@@ -130,7 +130,7 @@ spec:
           if [[ "${tssc_test_image}" != "" ]]; then
             tkn_params+=("--param" "tssc-test-image=${tssc_test_image}")
           fi
-          
+
           # Add labels and other flags
           tkn_params+=(
             "--use-param-defaults"
@@ -142,10 +142,9 @@ spec:
             "--prefix-name" "e2e-$ocp_version$config_suffix"
             "-o" "name"
           )
-          
           echo "Starting pipeline with testplan (${#testplan_b64} chars): ${testplan_b64:0:50}..."
-          pipeline_run=$(tkn pipeline start -f https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/pipelines/rhtap-cli-e2e.yaml "${tkn_params[@]}")
-          #pipeline_run=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/rhtap-cli/refs/heads/$BRANCH/integration-tests/pipelines/rhtap-cli-e2e.yaml "${tkn_params[@]}")
+          pipeline_run=$(tkn pipeline start -f https://raw.githubusercontent.com/jkopriva/tssc-cli/refs/heads/RHTAP-5290/integration-tests/pipelines/tssc-cli-e2e.yaml "${tkn_params[@]}")
+          #pipeline_run=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/tssc-cli/refs/heads/$BRANCH/integration-tests/pipelines/tssc-cli-e2e.yaml "${tkn_params[@]}")
           echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${pipeline_run}"
           PIPELINERUNS_ARRAY+=($pipeline_run)
         }

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -172,10 +172,8 @@ spec:
             SEPARATOR_COUNT=0
             echo "DEBUG: No separators found, setting SEPARATOR_COUNT=0"
           fi
-          
           CONFIG_COUNT=$((SEPARATOR_COUNT + 1))  # Add 1 because there's one more config than separators
           echo "Found $CONFIG_COUNT configurations to process"
-          
           # Handle single configuration case
           if [[ $CONFIG_COUNT -eq 1 ]]; then
             echo "Processing single configuration in periodic mode..."
@@ -186,7 +184,6 @@ spec:
             echo "==================== Configuration $CONFIG_INDEX ===================="
             echo "$FULL_CONFIG"
             echo "================================================================"
-            
             # Split RHADS config and testplan
             if [[ "$FULL_CONFIG" == *"---TESTPLAN_START---"* ]]; then
               # Extract RHADS config (before testplan)
@@ -210,7 +207,6 @@ spec:
               TESTPLAN_B64=""
               echo "No testplan found for this configuration"
             fi
-            
             # Extract OCP version from this configuration
             if [[ $CONFIG =~ OCP=\"([^\"]+)\" ]]; then
               OCP_VERSION="${BASH_REMATCH[1]}"
@@ -301,7 +297,6 @@ spec:
         fi
 
         echo "Total pipelines started: ${#PIPELINERUNS_ARRAY[@]}"
-        
         # Validate that we started at least one pipeline
         if [[ ${#PIPELINERUNS_ARRAY[@]} -eq 0 ]]; then
           echo "ERROR: No pipelines were started. Check the configuration data and OCP version extraction."

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -87,13 +87,11 @@ spec:
 
         echo "Starting pipelines in mode: $MODE"
         echo "Using Konflux metadata: namespace=$KONFLUX_NAMESPACE, app=$KONFLUX_APPLICATION_NAME, component=$KONFLUX_COMPONENT_NAME"
-        
         # Decode base64 encoded rhads-config
         echo "Decoding base64 encoded rhads-config..."
         DECODED_RHADS_CONFIG=$(echo "$RHADS_CONFIG" | base64 -d)
         echo "Decoded rhads-config content:"
         echo "$DECODED_RHADS_CONFIG"
-        
         # Extract images from snapshot
         tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-cli").containerImage')
         tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
@@ -161,21 +159,12 @@ spec:
           echo "Processing periodic configurations..."
           echo "RHADS Config data:"
           echo "$DECODED_RHADS_CONFIG"
-          
           # Validate that we have some content
           if [[ -z "$DECODED_RHADS_CONFIG" ]]; then
             echo "ERROR: No RHADS configuration data found"
             exit 1
           fi
-          
-          # Validate that the configuration contains expected content
-          if [[ ! "$DECODED_RHADS_CONFIG" =~ OCP= ]]; then
-            echo "ERROR: RHADS configuration does not contain OCP version information"
-            echo "Configuration content: $DECODED_RHADS_CONFIG"
-            exit 1
-          fi
-          
-          # Count configurations for informational purposes
+          # Count configurations
           if echo "$DECODED_RHADS_CONFIG" | grep -q "---CONFIG_SEPARATOR---"; then
             SEPARATOR_COUNT=$(echo "$DECODED_RHADS_CONFIG" | grep -o -e "---CONFIG_SEPARATOR---" | wc -l)
             echo "DEBUG: Found $SEPARATOR_COUNT separators using grep"
@@ -187,7 +176,7 @@ spec:
           CONFIG_COUNT=$((SEPARATOR_COUNT + 1))  # Add 1 because there's one more config than separators
           echo "Found $CONFIG_COUNT configurations to process"
           
-          # Handle single configuration case more robustly
+          # Handle single configuration case
           if [[ $CONFIG_COUNT -eq 1 ]]; then
             echo "Processing single configuration in periodic mode..."
             FULL_CONFIG="$DECODED_RHADS_CONFIG"
@@ -234,8 +223,7 @@ spec:
               exit 1
             fi
           else
-            # Multiple configurations - use the existing separator-based logic
-            echo "DEBUG: CONFIG_COUNT is not 1, using multiple configuration logic"
+            # Multiple configurations
             echo "Processing multiple configurations using separator logic..."
             # Create a pipeline for every RHADS config using pure bash string manipulation
             CONFIG_INDEX=0

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -20,7 +20,7 @@ spec:
       description: "Job specification metadata"
       type: string
     - name: rhads-config
-      description: "RHADS configuration data (single config or array of configs with separators)"
+      description: "RHADS configuration data (single config or array of configs with separators, base64 encoded)"
       type: string
     - name: mode
       description: "Pipeline mode: 'single' for single config, 'periodic' for multiple configs with separators"
@@ -43,6 +43,7 @@ spec:
     - name: context-pipeline-run-name
       description: "Context pipeline run name for labeling"
       type: string
+      default: ""
   results:
     - name: pipeline-runs
       description: "Array of started pipeline run names"
@@ -86,6 +87,13 @@ spec:
 
         echo "Starting pipelines in mode: $MODE"
         echo "Using Konflux metadata: namespace=$KONFLUX_NAMESPACE, app=$KONFLUX_APPLICATION_NAME, component=$KONFLUX_COMPONENT_NAME"
+        
+        # Decode base64 encoded rhads-config
+        echo "Decoding base64 encoded rhads-config..."
+        DECODED_RHADS_CONFIG=$(echo "$RHADS_CONFIG" | base64 -d)
+        echo "Decoded rhads-config content:"
+        echo "$DECODED_RHADS_CONFIG"
+        
         # Extract images from snapshot
         tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-cli").containerImage')
         tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
@@ -152,15 +160,87 @@ spec:
         if [[ "$MODE" == "periodic" ]]; then
           echo "Processing periodic configurations..."
           echo "RHADS Config data:"
-          echo "$RHADS_CONFIG"
+          echo "$DECODED_RHADS_CONFIG"
+          
+          # Validate that we have some content
+          if [[ -z "$DECODED_RHADS_CONFIG" ]]; then
+            echo "ERROR: No RHADS configuration data found"
+            exit 1
+          fi
+          
+          # Validate that the configuration contains expected content
+          if [[ ! "$DECODED_RHADS_CONFIG" =~ OCP= ]]; then
+            echo "ERROR: RHADS configuration does not contain OCP version information"
+            echo "Configuration content: $DECODED_RHADS_CONFIG"
+            exit 1
+          fi
+          
           # Count configurations for informational purposes
-          CONFIG_COUNT=$(echo "$RHADS_CONFIG" | grep -o -e "---CONFIG_SEPARATOR---" | wc -l)
-          CONFIG_COUNT=$((CONFIG_COUNT + 1))  # Add 1 because there's one more config than separators
+          if echo "$DECODED_RHADS_CONFIG" | grep -q "---CONFIG_SEPARATOR---"; then
+            SEPARATOR_COUNT=$(echo "$DECODED_RHADS_CONFIG" | grep -o -e "---CONFIG_SEPARATOR---" | wc -l)
+            echo "DEBUG: Found $SEPARATOR_COUNT separators using grep"
+          else
+            SEPARATOR_COUNT=0
+            echo "DEBUG: No separators found, setting SEPARATOR_COUNT=0"
+          fi
+          
+          CONFIG_COUNT=$((SEPARATOR_COUNT + 1))  # Add 1 because there's one more config than separators
           echo "Found $CONFIG_COUNT configurations to process"
-          # Create a pipeline for every RHADS config using pure bash string manipulation
-          CONFIG_INDEX=0
-          # Split the configurations using bash string manipulation
-          REMAINING_CONFIG="$RHADS_CONFIG"
+          
+          # Handle single configuration case more robustly
+          if [[ $CONFIG_COUNT -eq 1 ]]; then
+            echo "Processing single configuration in periodic mode..."
+            FULL_CONFIG="$DECODED_RHADS_CONFIG"
+            # Trim whitespace from config
+            FULL_CONFIG=$(echo "$FULL_CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            CONFIG_INDEX=1
+            echo "==================== Configuration $CONFIG_INDEX ===================="
+            echo "$FULL_CONFIG"
+            echo "================================================================"
+            
+            # Split RHADS config and testplan
+            if [[ "$FULL_CONFIG" == *"---TESTPLAN_START---"* ]]; then
+              # Extract RHADS config (before testplan)
+              CONFIG="${FULL_CONFIG%%---TESTPLAN_START---*}"
+              # Extract testplan (between markers)
+              TESTPLAN_PART="${FULL_CONFIG#*---TESTPLAN_START---}"
+              TESTPLAN="${TESTPLAN_PART%%---TESTPLAN_END---*}"
+              # Trim whitespace from both parts
+              CONFIG=$(echo "$CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              TESTPLAN=$(echo "$TESTPLAN" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              echo "RHADS Config:"
+              echo "$CONFIG"
+              echo "Testplan:"
+              echo "$TESTPLAN"
+              # Encode testplan to base64
+              TESTPLAN_B64=$(echo "$TESTPLAN" | base64 -w 0)
+              echo "Testplan base64: $TESTPLAN_B64"
+            else
+              # No testplan found, use config as-is
+              CONFIG="$FULL_CONFIG"
+              TESTPLAN_B64=""
+              echo "No testplan found for this configuration"
+            fi
+            
+            # Extract OCP version from this configuration
+            if [[ $CONFIG =~ OCP=\"([^\"]+)\" ]]; then
+              OCP_VERSION="${BASH_REMATCH[1]}"
+              echo "Successfully extracted OCP version: $OCP_VERSION from configuration $CONFIG_INDEX"
+              # Start pipeline using shared function
+              start_single_pipeline "$OCP_VERSION" "$CONFIG" "$TESTPLAN_B64" "-config$CONFIG_INDEX"
+            else
+              echo "ERROR: Could not extract OCP version from configuration $CONFIG_INDEX"
+              echo "Configuration content: $CONFIG"
+              exit 1
+            fi
+          else
+            # Multiple configurations - use the existing separator-based logic
+            echo "DEBUG: CONFIG_COUNT is not 1, using multiple configuration logic"
+            echo "Processing multiple configurations using separator logic..."
+            # Create a pipeline for every RHADS config using pure bash string manipulation
+            CONFIG_INDEX=0
+            # Split the configurations using bash string manipulation
+            REMAINING_CONFIG="$DECODED_RHADS_CONFIG"
           while [[ -n "$REMAINING_CONFIG" ]]; do
             # Find the next separator
             if [[ "$REMAINING_CONFIG" == *"---CONFIG_SEPARATOR---"* ]]; then
@@ -209,13 +289,16 @@ spec:
               # Start pipeline using shared function
               start_single_pipeline "$OCP_VERSION" "$CONFIG" "$TESTPLAN_B64" "-config$CONFIG_INDEX"
             else
-              echo "Warning: Could not extract OCP version from configuration $CONFIG_INDEX"
+              echo "ERROR: Could not extract OCP version from configuration $CONFIG_INDEX"
+              echo "Configuration content: $CONFIG"
+              exit 1
             fi
-          done
-          echo "Started $CONFIG_INDEX sub-pipelines for periodic testing"
+                      done
+            echo "Started $CONFIG_INDEX sub-pipelines for periodic testing"
+          fi
         else
           echo "Processing single configuration..."
-          RHADS_CONFIG_CONTENT=$(echo "$RHADS_CONFIG")
+          RHADS_CONFIG_CONTENT=$(echo "$DECODED_RHADS_CONFIG")
           echo "Configuration:"
           echo "$RHADS_CONFIG_CONTENT"
           # Extract OCP versions from RHADS config
@@ -230,6 +313,12 @@ spec:
         fi
 
         echo "Total pipelines started: ${#PIPELINERUNS_ARRAY[@]}"
+        
+        # Validate that we started at least one pipeline
+        if [[ ${#PIPELINERUNS_ARRAY[@]} -eq 0 ]]; then
+          echo "ERROR: No pipelines were started. Check the configuration data and OCP version extraction."
+          exit 1
+        fi
 
         # Store results
         printf '%s\n' "${PIPELINERUNS_ARRAY[@]}" | jq -R . | jq -s . > $(results.pipeline-runs.path)

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -1,0 +1,299 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: start-pipelines
+  annotations:
+    tekton.dev/displayName: "Start Pipelines"
+    tekton.dev/categories: "Pipeline"
+    tekton.dev/tags: "pipeline,start,rhtap"
+spec:
+  description: >-
+    This task starts one or more rhtap-cli-e2e pipelines based on configuration.
+    It supports both single configuration mode and periodic configuration mode
+    (multiple configs with separators and testplans).
+  params:
+    - name: snapshot
+      description: "The JSON string representing the snapshot of the application under test."
+      type: string
+    - name: job-spec
+      description: "Job specification metadata"
+      type: string
+    - name: rhads-config
+      description: "RHADS configuration data (single config or array of configs with separators)"
+      type: string
+    - name: mode
+      description: "Pipeline mode: 'single' for single config, 'periodic' for multiple configs with separators"
+      type: string
+      default: "single"
+    - name: konflux-test-infra-secret
+      description: "The name of secret where testing infrastructures credentials are stored"
+      type: string
+    - name: cloud-credential-key
+      description: "The key secret from konflux-test-infra-secret where all AWS ROSA configurations are stored"
+      type: string
+    - name: ocp-instance-type
+      description: "The type of machine to use for the cluster nodes"
+      type: string
+      default: "m5.2xlarge"
+    - name: ocp-replicas
+      description: "The number of replicas for the cluster nodes"
+      type: string
+      default: "3"
+    - name: context-pipeline-run-name
+      description: "Context pipeline run name for labeling"
+      type: string
+  results:
+    - name: pipeline-runs
+      description: "Array of started pipeline run names"
+  steps:
+    - name: start-pipelines
+      image: quay.io/openshift-pipeline/ci
+      env:
+        - name: SNAPSHOT
+          value: $(params.snapshot)
+        - name: JOB_SPEC
+          value: $(params.job-spec)
+        - name: RHADS_CONFIG
+          value: $(params.rhads-config)
+        - name: MODE
+          value: $(params.mode)
+
+        - name: CONTEXT_PIPELINE_RUN_NAME
+          value: $(params.context-pipeline-run-name)
+        - name: KONFLUX_TEST_INFRA_SECRET
+          value: $(params.konflux-test-infra-secret)
+        - name: CLOUD_CREDENTIAL_KEY
+          value: $(params.cloud-credential-key)
+        - name: OCP_INSTANCE_TYPE
+          value: $(params.ocp-instance-type)
+        - name: OCP_REPLICAS
+          value: $(params.ocp-replicas)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        echo "Starting pipelines in mode: $MODE"
+        # Extract konflux metadata from current pod environment
+        # These environment variables are automatically set by Tekton
+        KONFLUX_NAMESPACE="${KONFLUX_NAMESPACE:-$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)}"
+        # Extract labels from the current pipeline run using oc/kubectl
+        CURRENT_PR=$(oc get pipelinerun -n "${KONFLUX_NAMESPACE}" --field-selector metadata.name="${CONTEXT_PIPELINE_RUN_NAME}" -o json 2>/dev/null || echo '{}')
+        KONFLUX_APPLICATION_NAME=$(echo "$CURRENT_PR" | jq -r '.items[0].metadata.labels["appstudio.openshift.io/application"] // "rhtap-cli"')
+        KONFLUX_COMPONENT_NAME=$(echo "$CURRENT_PR" | jq -r '.items[0].metadata.labels["appstudio.openshift.io/component"] // "rhtap-cli"')
+        # Fallback values if extraction fails
+        KONFLUX_APPLICATION_NAME="${KONFLUX_APPLICATION_NAME:-rhtap-cli}"
+        KONFLUX_COMPONENT_NAME="${KONFLUX_COMPONENT_NAME:-rhtap-cli}"
+        echo "Using Konflux metadata: namespace=$KONFLUX_NAMESPACE, app=$KONFLUX_APPLICATION_NAME, component=$KONFLUX_COMPONENT_NAME"
+        # Extract images from snapshot
+        tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="rhtap-cli").containerImage')
+        tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
+
+        GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
+        KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
+
+        if [[ "${GIT_REPO}" = "rhtap-cli" ]]; then
+          REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
+          BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+        else
+          REPO_ORG="redhat-appstudio"
+          BRANCH="main"
+        fi
+
+        PIPELINERUNS_ARRAY=()
+
+        # Function to start a single pipeline
+        start_single_pipeline() {
+          local ocp_version="$1"
+          local config="$2"
+          local testplan_b64="$3"
+          local config_suffix="$4"
+          echo "Starting pipeline for OCP version: $ocp_version"
+          local pipeline_run
+          
+          # Build the tkn command with proper parameter handling
+          local tkn_params=(
+            "--param" "ocp-version=$ocp_version"
+            "--param" "job-spec=$JOB_SPEC"
+            "--param" "konflux-test-infra-secret=$KONFLUX_TEST_INFRA_SECRET"
+            "--param" "rhads-config=$config"
+            "--param" "testplan=${testplan_b64:-}"
+            "--param" "cloud-credential-key=$CLOUD_CREDENTIAL_KEY"
+            "--param" "machine-type=$OCP_INSTANCE_TYPE"
+            "--param" "replicas=$OCP_REPLICAS"
+          )
+          
+          # Add optional image parameters
+          if [[ "${tssc_image}" != "" ]]; then
+            tkn_params+=("--param" "tssc-image=${tssc_image}")
+          fi
+          if [[ "${tssc_test_image}" != "" ]]; then
+            tkn_params+=("--param" "tssc-test-image=${tssc_test_image}")
+          fi
+          
+          # Add labels and other flags
+          tkn_params+=(
+            "--use-param-defaults"
+            "--labels" "appstudio.openshift.io/component=${KONFLUX_COMPONENT_NAME}"
+            "--labels" "appstudio.openshift.io/application=${KONFLUX_APPLICATION_NAME}"
+            "--labels" "pipelines.appstudio.openshift.io/type=${CONTEXT_PIPELINE_RUN_NAME}"
+            "--labels" "test.appstudio.openshift.io/scenario=pr-e2e-tests"
+            "--labels" "custom.appstudio.openshift.io/main-pipeline-run=${CONTEXT_PIPELINE_RUN_NAME}"
+            "--prefix-name" "e2e-$ocp_version$config_suffix"
+            "-o" "name"
+          )
+          
+          echo "Starting pipeline with testplan (${#testplan_b64} chars): ${testplan_b64:0:50}..."
+          pipeline_run=$(tkn pipeline start -f https://raw.githubusercontent.com/jkopriva/rhtap-cli/refs/heads/RHTAP-5290/integration-tests/pipelines/rhtap-cli-e2e.yaml "${tkn_params[@]}")
+          #pipeline_run=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/rhtap-cli/refs/heads/$BRANCH/integration-tests/pipelines/rhtap-cli-e2e.yaml "${tkn_params[@]}")
+          echo "Started new pipelinerun: ${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${pipeline_run}"
+          PIPELINERUNS_ARRAY+=($pipeline_run)
+        }
+
+        if [[ "$MODE" == "periodic" ]]; then
+          echo "Processing periodic configurations..."
+          echo "RHADS Config data:"
+          echo "$RHADS_CONFIG"
+          # Count configurations for informational purposes
+          CONFIG_COUNT=$(echo "$RHADS_CONFIG" | grep -o -e "---CONFIG_SEPARATOR---" | wc -l)
+          CONFIG_COUNT=$((CONFIG_COUNT + 1))  # Add 1 because there's one more config than separators
+          echo "Found $CONFIG_COUNT configurations to process"
+          # Create a pipeline for every RHADS config using pure bash string manipulation
+          CONFIG_INDEX=0
+          # Split the configurations using bash string manipulation
+          REMAINING_CONFIG="$RHADS_CONFIG"
+          while [[ -n "$REMAINING_CONFIG" ]]; do
+            # Find the next separator
+            if [[ "$REMAINING_CONFIG" == *"---CONFIG_SEPARATOR---"* ]]; then
+              # Extract config before separator
+              FULL_CONFIG="${REMAINING_CONFIG%%---CONFIG_SEPARATOR---*}"
+              # Remove processed config and separator from remaining
+              REMAINING_CONFIG="${REMAINING_CONFIG#*---CONFIG_SEPARATOR---}"
+            else
+              # Last config (no separator after it)
+              FULL_CONFIG="$REMAINING_CONFIG"
+              REMAINING_CONFIG=""
+            fi
+            # Trim whitespace from config
+            FULL_CONFIG=$(echo "$FULL_CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            CONFIG_INDEX=$(( $CONFIG_INDEX + 1 ))
+            echo "==================== Configuration $CONFIG_INDEX ===================="
+            echo "$FULL_CONFIG"
+            echo "================================================================"
+            # Split RHADS config and testplan
+            if [[ "$FULL_CONFIG" == *"---TESTPLAN_START---"* ]]; then
+              # Extract RHADS config (before testplan)
+              CONFIG="${FULL_CONFIG%%---TESTPLAN_START---*}"
+              # Extract testplan (between markers)
+              TESTPLAN_PART="${FULL_CONFIG#*---TESTPLAN_START---}"
+              TESTPLAN="${TESTPLAN_PART%%---TESTPLAN_END---*}"
+              # Trim whitespace from both parts
+              CONFIG=$(echo "$CONFIG" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              TESTPLAN=$(echo "$TESTPLAN" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              echo "RHADS Config:"
+              echo "$CONFIG"
+              echo "Testplan:"
+              echo "$TESTPLAN"
+              # Encode testplan to base64
+              TESTPLAN_B64=$(echo "$TESTPLAN" | base64 -w 0)
+              echo "Testplan base64: $TESTPLAN_B64"
+            else
+              # No testplan found, use config as-is
+              CONFIG="$FULL_CONFIG"
+              TESTPLAN_B64=""
+              echo "No testplan found for this configuration"
+            fi
+            # Extract OCP version from this configuration
+            if [[ $CONFIG =~ OCP=\"([^\"]+)\" ]]; then
+              OCP_VERSION="${BASH_REMATCH[1]}"
+              echo "Successfully extracted OCP version: $OCP_VERSION from configuration $CONFIG_INDEX"
+              # Start pipeline using shared function
+              start_single_pipeline "$OCP_VERSION" "$CONFIG" "$TESTPLAN_B64" "-config$CONFIG_INDEX"
+            else
+              echo "Warning: Could not extract OCP version from configuration $CONFIG_INDEX"
+            fi
+          done
+          echo "Started $CONFIG_INDEX sub-pipelines for periodic testing"
+        else
+          echo "Processing single configuration..."
+          RHADS_CONFIG_CONTENT=$(echo "$RHADS_CONFIG")
+          echo "Configuration:"
+          echo "$RHADS_CONFIG_CONTENT"
+          # Extract OCP versions from RHADS config
+          [[ $RHADS_CONFIG_CONTENT =~ OCP=\"([^\"]+)\" ]] && IFS=',' read -ra OCP_VERSIONS <<< "${BASH_REMATCH[1]}"
+          echo "Running tests for OCP versions: ${OCP_VERSIONS[*]}"
+          # Loop through each OCP version and start a sub-pipeline for each
+          for OCP_VERSION in "${OCP_VERSIONS[@]}"; do
+            echo "Starting sub-pipeline for OCP version: $OCP_VERSION"
+            # Start pipeline using shared function
+            start_single_pipeline "$OCP_VERSION" "$RHADS_CONFIG_CONTENT" "" ""
+          done
+        fi
+
+        echo "Total pipelines started: ${#PIPELINERUNS_ARRAY[@]}"
+
+        # Store results
+        printf '%s\n' "${PIPELINERUNS_ARRAY[@]}" | jq -R . | jq -s . > $(results.pipeline-runs.path)
+
+        # Wait for completion function
+        waitFor() {
+          local CONDITION="$1"
+          local MESSAGE_RUNNING="$2"
+          local MESSAGE_DONE="$3"
+          export CONDITION MESSAGE_RUNNING MESSAGE_DONE
+          timeout --foreground 120m /bin/bash -c '
+            #deserialize plrs array
+            set -x
+            read -r -a PIPELINERUNS_ARRAY <<< "$PIPELINERUNS_ARRAY_SERIALIZED"
+            echo "${PIPELINERUNS_ARRAY[*]}"
+            while [[ ${#PIPELINERUNS_ARRAY[@]} -gt 0 ]]; do
+              # Create a new array to store pipelines that are still running
+              STILL_RUNNING=()
+              for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
+                if eval "$CONDITION"; then
+                  # Pipeline is still running, keep it in the array
+                  STILL_RUNNING+=("$PIPELINE_RUN")
+                else
+                  # Pipeline is finished, remove it from the array
+                  echo "Pipeline $PIPELINE_RUN has finished"
+                fi
+              done
+              # Update the array with only running pipelines
+              PIPELINERUNS_ARRAY=("${STILL_RUNNING[@]}")
+              if [[ ${#PIPELINERUNS_ARRAY[@]} -gt 0 ]]; then
+                echo "$MESSAGE_RUNNING (${#PIPELINERUNS_ARRAY[@]} pipelines remaining)"
+                sleep 60
+              else
+                echo "$MESSAGE_DONE"
+                break
+              fi
+            done
+          '
+        }
+
+        #Serialize plrs array to be able to export it as var
+        export PIPELINERUNS_ARRAY_SERIALIZED="${PIPELINERUNS_ARRAY[*]}"
+
+        waitFor '! oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} &>/dev/null' "Pipelines are still starting. Waiting 1 minute" "All pipelines have started"
+        waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "" ]]' "Waiting for nested pipelinerun status to be set. Waiting 1 minute" "Nested pipelinerun status is set"
+        waitFor '[[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "Unknown" ]]' "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
+
+        # Explore and report status of all failed pipelineruns. Fail if anything failed
+        SOME_PIPELINE_FAILED=false
+        SOME_PIPELINE_SUCCEEDED=false
+        for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
+          if [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "False" ]]; then
+            if ! $SOME_PIPELINE_FAILED ; then
+              echo "List of failed PLRs:"
+            fi
+            echo "${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
+            SOME_PIPELINE_FAILED=true
+          elif [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "True" ]]; then
+            SOME_PIPELINE_SUCCEEDED=true
+          fi
+        done
+        if $SOME_PIPELINE_SUCCEEDED ; then
+          exit 0
+        fi
+        # If we reach here, no pipelines succeeded - fail the main pipeline
+        exit 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a periodic E2E Tekton pipeline, a PICT configuration and testplan template, plus tasks to generate/process PICTs, produce RHADS configs, fetch RHADS config, and start sub‑pipelines (supports "single" and "periodic" modes).

- **Refactor**
  - Replaced large inline pipeline steps with reusable external Git-resolved tasks to simplify orchestration and parameter/result wiring.

- **Tests**
  - Added an optional base64-encoded testplan parameter and propagated it to relevant test tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->