### PR TITLE
feat: Upgrade ACS to 4.8

### DIFF
--- a/installer/charts/tssc-acs-test/Chart.yaml
+++ b/installer/charts/tssc-acs-test/Chart.yaml
@@ -4,4 +4,4 @@ name: tssc-acs-test
 description: TSSC Advanced Cluster Security
 type: application
 version: "1.6.0"
-appVersion: "4.7"
+appVersion: "4.8"

--- a/installer/charts/tssc-acs/Chart.yaml
+++ b/installer/charts/tssc-acs/Chart.yaml
@@ -4,4 +4,4 @@ name: tssc-acs
 description: TSSC Advanced Cluster Security
 type: application
 version: "1.6.0"
-appVersion: "4.7"
+appVersion: "4.8"

--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -53,7 +53,7 @@ subscriptions:
     enabled: false
     description: Red Hat Advanced Cluster Security Operator
     apiResource: centrals.platform.stackrox.io
-    channel: rhacs-4.7
+    channel: rhacs-4.8
     namespace: rhacs-operator
     name: rhacs-operator
     source: redhat-operators


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version references from 4.7 to 4.8 in deployment configurations.
  * Changed operator channel for the Red Hat Advanced Cluster Security Operator to 4.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->