### PR TITLE
Fix the acs-quay assertion

### DIFF
--- a/installer/charts/tssc-integrations/templates/acs/pod.yaml
+++ b/installer/charts/tssc-integrations/templates/acs/pod.yaml
@@ -90,7 +90,7 @@ spec:
         allowPrivilegeEscalation: false
   {{- end }}
   {{- $secretQuay := (lookup "v1" "Secret" .Release.Namespace "tssc-quay-integration") }}
-  {{- if and (or $integrations.acs.enabled $integrations.quay.enabled) $secretQuay }}
+  {{- if and $integrations.acs.enabled $secretQuay }}
     {{- $noop = false }}
     #
     # Create the Quay integration.


### PR DESCRIPTION
Since Quay is no longer installed by the installer, there isn't an entry for it under integrations. Instead, the presence of the quay secret in the cluster is sufficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the conditions for creating the Quay integration container to require ACS integration to be enabled and the Quay secret to exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->