### PR TITLE
remove test quay configuration

### DIFF
--- a/integration-tests/config/rhads-config
+++ b/integration-tests/config/rhads-config
@@ -1,6 +1,6 @@
 OCP="4.16,4.17,4.18"
 ACS="local"
-REGISTRY="quay.io,artifactory,nexus"
+REGISTRY="quay,artifactory,nexus"
 TPA="local"
 SCM="github,gitlab,bitbucket"
 PIPELINE="tekton,actions,gitlabci,jenkins"

--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -6,7 +6,7 @@
       {
         "git": "github",
         "ci": "tekton",
-        "registry": "quay.io",
+        "registry": "quay",
         "tpa": "local",
         "acs": "local"
       },

--- a/integration-tests/scripts/README.md
+++ b/integration-tests/scripts/README.md
@@ -33,9 +33,8 @@ export tpa_config="remote"
 export registry_config="quay,artifactory,nexus"
 ```
 
-**Options**: `quay`, `quay.io`, `artifactory`, `nexus` (can be multiple values)
-- `quay`: Uses local Quay registry installed in the cluster
-- `quay.io`: Integrates with external Quay.io service
+**Options**: `quay`, `artifactory`, `nexus` (can be multiple values)
+- `quay`: Integrates with external Quay.io service
 - `artifactory`: Integrates with Artifactory registry
 - `nexus`: Integrates with Nexus registry
 - Multiple values: Comma-separated list to integrate with multiple registries

--- a/integration-tests/scripts/install.sh
+++ b/integration-tests/scripts/install.sh
@@ -132,22 +132,9 @@ gitlab_integration() {
   fi
 }
 
-# Workaround: This function has to be called before tssc import "installer/config.yaml" into cluster.
-# Currently, the tssc `config` subcommand lacks the ability to modify property values stored in cluster
-disable_quay() {
-  # if "quay" is not in registry_config array, then disable Quay installation
-  # Update the YAML anchor &quayEnabled from true to false (line 42 in config.yaml)
-  if [[ ! " ${registry_config[*]} " =~ " quay " ]]; then
-    echo "[INFO] Disable Quay installation by setting &quayEnabled anchor to false"
-    sed -i 's/enabled: &quayEnabled true/enabled: \&quayEnabled false/' "${config_file}"
-  else
-    echo "[INFO] Quay is in registry_config array, keeping &quayEnabled anchor as true"
-  fi
-}
-
-quayio_integration() {
-  if [[ " ${registry_config[*]} " =~  quay.io ]]; then
-    echo "[INFO] Configure quay.io integration into TSSC"
+quay_integration() {
+  if [[ " ${registry_config[*]} " =~  quay ]]; then
+    echo "[INFO] Configure quay integration into TSSC"
 
     QUAY__DOCKERCONFIGJSON="${QUAY__DOCKERCONFIGJSON:-$(cat /usr/local/rhtap-cli-install/quay-dockerconfig-json)}"
     QUAY__API_TOKEN="${QUAY__API_TOKEN:-$(cat /usr/local/rhtap-cli-install/quay-api-token)}"
@@ -241,7 +228,6 @@ nexus_integration() {
 create_cluster_config() {
   echo "[INFO] Creating the installer's cluster configuration"
   update_dh_catalog_url
-  disable_quay
   disable_acs
   disable_tpa
   
@@ -272,7 +258,7 @@ install_tssc() {
   github_integration
   gitlab_integration
   bitbucket_integration
-  quayio_integration
+  quay_integration
   artifactory_integration
   nexus_integration
 


### PR DESCRIPTION
In context of pr https://github.com/redhat-appstudio/rhtap-cli/pull/1029, removing quay installation specific data from test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify registry configuration options, removing references to "quay.io" and updating descriptions for "quay".
* **Chores**
  * Updated configuration files and scripts to replace "quay.io" with "quay" for registry settings.
  * Simplified and renamed integration script functions related to Quay registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->