### PR TITLE
Fixing ephemeral-storage unknown field warn

### DIFF
--- a/installer/charts/tssc-pipelines/templates/tektonconfig/patch_tekton_config.yaml
+++ b/installer/charts/tssc-pipelines/templates/tektonconfig/patch_tekton_config.yaml
@@ -16,8 +16,8 @@ spec:
         - name: patch-tekton-config
           image: registry.redhat.io/openshift4/ose-cli:latest
           resources:
-            ephemeral-storage: 100Mi
             limits:
+              ephemeral-storage: 100Mi
               memory: 128Mi
             requests:
               memory: 100Mi


### PR DESCRIPTION
File ephemeral storage is under resources.limits not under resources 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated how ephemeral storage resource limits are specified for improved configuration consistency. No impact on memory or CPU settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->