### PR TITLE
Rename its pipelines from rhtap to tssc

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -5,8 +5,8 @@ metadata:
   name: e2e-main-pipeline
   namespace: rhtap-shared-team-tenant
   labels:
-    appstudio.openshift.io/component: rhtap-cli
-    appstudio.openshift.io/application: rhtap-cli
+    appstudio.openshift.io/component: tssc-cli
+    appstudio.openshift.io/application: tssc-cli
 spec:
   params:
     - name: SNAPSHOT
@@ -110,7 +110,7 @@ spec:
               echo "$RHADS_CONFIG_CONTENT"
 
               # get the tssc image and tssc-test image from the snapshot
-              tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="rhtap-cli").containerImage')
+              tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-cli").containerImage')
               tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
 
               # Extract OCP versions from RHADS config
@@ -150,7 +150,7 @@ spec:
               GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
               KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"
 
-              if [[ "${GIT_REPO}" = "rhtap-cli" ]]; then
+              if [[ "${GIT_REPO}" = "tssc-cli" ]]; then
                 REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
                 BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
               else
@@ -164,7 +164,7 @@ spec:
               for OCP_VERSION in "${OCP_VERSIONS[@]}"; do
                 echo "Starting sub-pipeline for OCP version: $OCP_VERSION"
 
-                PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/rhtap-cli/refs/heads/$BRANCH/integration-tests/pipelines/rhtap-cli-e2e.yaml \
+                PIPELINE_RUN=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/tssc-cli/refs/heads/$BRANCH/integration-tests/pipelines/tssc-cli-e2e.yaml \
                   --param ocp-version="$OCP_VERSION"\
                   --param job-spec="$JOB_SPEC"\
                   --param konflux-test-infra-secret="$(params.konflux-test-infra-secret)" \

--- a/integration-tests/pipelines/static-code-analysis.yaml
+++ b/integration-tests/pipelines/static-code-analysis.yaml
@@ -5,7 +5,7 @@ metadata:
   name: static-code-analysis
 spec:
   description: |-
-    This pipeline automates the process of running a few static code analysis for rhtap-cli repository.
+    This pipeline automates the process of running a few static code analysis for tssc-cli repository.
   params:
     - name: SNAPSHOT
       description: 'The JSON string representing the snapshot of the application under test.'

--- a/integration-tests/pipelines/tssc-cli-e2e.yaml
+++ b/integration-tests/pipelines/tssc-cli-e2e.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: rhtap-install-e2e
+  name: tssc-install-e2e
 spec:
   description: |-
     This pipeline automates the process of running end-to-end tests for TSSC
@@ -45,7 +45,7 @@ spec:
     - name: tssc-image
       type: string
       description: "Image from where the `tssc` binary will be extracted (from path /usr/local/bin)."
-      default: "quay.io/rhtap/rhtap-cli:latest"
+      default: "quay.io/redhat-user-workloads/rhtap-shared-team-tenant/tssc-cli:latest"
     - name: tssc-test-image
       type: string
       description: "Image from where the `tssc-test` binary will be extracted (from path /usr/local/bin)."
@@ -104,18 +104,18 @@ spec:
           value: "$(params.konflux-test-infra-secret)"
         - name: cloud-credential-key
           value: "$(params.cloud-credential-key)"
-    - name: rhtap-install
+    - name: tssc-install
       runAfter:
         - provision-rosa
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/rhtap-cli.git
+            value: https://github.com/xinredhat/tssc-cli.git
           - name: revision
-            value: main
+            value: rename_its
           - name: pathInRepo
-            value: integration-tests/tasks/rhtap-install.yaml
+            value: integration-tests/tasks/tssc-install.yaml
       params:
         - name: ocp-login-command
           value: "$(tasks.provision-rosa.results.ocp-login-command)"
@@ -127,7 +127,7 @@ spec:
           value: $(params.tssc-image)
     - name: sprayproxy-provision
       runAfter:
-        - rhtap-install
+        - tssc-install
       taskRef:
         resolver: git
         params:
@@ -140,7 +140,7 @@ spec:
       params:
         - name: ocp-login-command
           value: "$(tasks.provision-rosa.results.ocp-login-command)"
-    - name: rhtap-e2e-tests
+    - name: tssc-e2e-tests
       runAfter:
         - sprayproxy-provision
       taskRef:
@@ -163,7 +163,7 @@ spec:
           value: $(params.tssc-test-image)
     - name: rhtap-ui-tests
       runAfter:
-        - rhtap-e2e-tests
+        - tssc-e2e-tests
       onError: continue
       taskRef:
         resolver: git

--- a/integration-tests/tasks/tssc-install.yaml
+++ b/integration-tests/tasks/tssc-install.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: rhtap-install
+  name: tssc-install
 spec:
   params:
     - name: ocp-login-command
@@ -18,7 +18,7 @@ spec:
       type: string
       description: "The tssc image containing the tssc binary."
   volumes:
-    - name: rhtap-cli-volume
+    - name: tssc-cli-volume
       secret:
         secretName: rhtap-cli-install
     - name: tssc-bin
@@ -32,14 +32,14 @@ spec:
         - name: tssc-bin
           mountPath: /tssc-bin
     - name: install
-      image: quay.io/redhat-user-workloads/rhtap-shared-team-tenant/rhtap-e2e/rhtap-e2e:56a53cd5d68adf7e7b0dccdc6c483a866d457cef
+      image: quay.io/konflux-qe-incubator/konflux-qe-tools:latest
       env:
         - name: JOB_SPEC
           value: "$(params.job-spec)"
         - name: OCP_LOGIN_COMMAND
           value: "$(params.ocp-login-command)"
       volumeMounts:
-        - name: rhtap-cli-volume
+        - name: tssc-cli-volume
           mountPath: /usr/local/rhtap-cli-install
         - name: tssc-bin
           mountPath: /usr/local/tssc-bin


### PR DESCRIPTION
Ticket:[RHTAP-5346]( https://issues.redhat.com/browse/RHTAP-5346)

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated all references from "rhtap-cli" to "tssc-cli" across pipeline and task configurations, including names, labels, repository URLs, and image references.
  * Renamed pipeline and task metadata, as well as related volume names, to reflect the new "tssc-cli" naming.
  * Adjusted downstream dependencies and descriptions to maintain consistency with the new naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->