### PR TITLE
fix konflux ci

### DIFF
--- a/.tekton/tssc-cli-pull-request.yaml
+++ b/.tekton/tssc-cli-pull-request.yaml
@@ -566,9 +566,6 @@ spec:
   taskRunTemplate:
     serviceAccountName: build-pipeline-tssc-cli
   workspaces:
-  - name: rhtap-quay-credentials
-    secret:
-      secretName: rhtap-builder
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'

--- a/.tekton/tssc-cli-push.yaml
+++ b/.tekton/tssc-cli-push.yaml
@@ -568,9 +568,6 @@ spec:
   taskRunTemplate:
     serviceAccountName: build-pipeline-tssc-cli
   workspaces:
-  - name: rhtap-quay-credentials
-    secret:
-      secretName: rhtap-builder
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline configuration by removing an unused credentials workspace. No impact to existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->