### PR TITLE
chore: add latest as additional tag to image on push

### DIFF
--- a/.tekton/tssc-cli-push.yaml
+++ b/.tekton/tssc-cli-push.yaml
@@ -531,6 +531,9 @@ spec:
         - "false"
     - name: apply-tags
       params:
+      - name: ADDITIONAL_TAGS
+        value:
+        - latest
       - name: IMAGE_URL
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a new parameter to the pipeline configuration, allowing for additional image tags with a default value of "latest".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->