### PR TITLE
Migrate TPA DB from Crunchy PGSQL cluster to a local PGSQL Service

### DIFF
--- a/installer/charts/tssc-infrastructure/templates/NOTES.txt
+++ b/installer/charts/tssc-infrastructure/templates/NOTES.txt
@@ -4,3 +4,14 @@ PostgreSQL Clusters:
     Name: {{ $k }}
     Version: {{ $v.postgresVersion }}
 {{- end }}
+
+PostgreSQL Services:
+{{- with $pgsql := .Values.infrastructure.pgsqlService }}
+{{- range $inst := $pgsql.instances }}
+{{- if $inst.enabled }}
+  - Namespace: {{ $inst.namespace }}
+    Name: {{$inst.name }}
+    Image: {{ $pgsql.image.name }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/installer/charts/tssc-infrastructure/templates/postgres/pgsql-service.yaml
+++ b/installer/charts/tssc-infrastructure/templates/postgres/pgsql-service.yaml
@@ -1,0 +1,128 @@
+{{- $currentNamespace := .Release.Namespace }}
+{{- with $pgsql := .Values.infrastructure.pgsqlService }}
+{{- range $inst := $pgsql.instances }}
+{{- if $inst.enabled }}
+{{- $secretName := printf "%s-%s" $inst.name $pgsql.secretName }}
+{{- $serviceName := printf "%s-%s" $inst.name $pgsql.service.name }}
+{{- $podName := printf "%s-%s" $inst.name $pgsql.podName }}
+{{- $pvcName := printf "%s-pgsql-data" $inst.name }}
+{{- $secret := lookup "v1" "Secret" $inst.namespace $secretName }}
+{{- $password := randAlphaNum 16 }}
+{{- if $secret }}
+  {{- $password = index $secret.data "password" | b64dec }}
+{{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $pvcName }}
+  namespace: {{ $inst.namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ $pgsql.storageSize }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $inst.namespace }}
+stringData:
+  dbname: {{ $inst.name }}
+  host: {{ printf "%s.%s.svc" $serviceName $inst.namespace }}
+  user: {{ $inst.name }}
+  port: "{{ $pgsql.service.port | toString }}"
+  password: {{ $password | quote }}
+{{- if ne $currentNamespace $inst.namespace }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $currentNamespace }}
+stringData:
+  password: {{ $password | quote }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $serviceName }}
+  namespace: {{ $inst.namespace }}
+spec:
+  type: {{ $pgsql.service.type }}
+  ports:
+    - name: data
+      port: {{ $pgsql.service.port }}
+      targetPort: {{ $pgsql.service.port }}
+  selector:
+    app: {{ $podName }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $podName }}
+  namespace: {{ $inst.namespace }}
+  annotations:
+    app.kubernetes.io/part-of: tssc
+spec:
+  selector:
+    matchLabels: 
+      app: {{ $podName }}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ $podName }}
+        phase: reference
+    spec:
+      volumes:
+        - name: pgsql-storage
+          persistentVolumeClaim:
+            claimName: {{ $pvcName }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - name: {{ $pgsql.podName }}
+        image: '{{ $pgsql.image.repository }}{{ $pgsql.image.name }}:{{ $pgsql.image.tag }}'
+        imagePullPolicy: {{ $pgsql.image.pullPolicy }}
+        env:
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ $secretName }}
+              key: user
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ $secretName }}
+              key: password
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: {{ $secretName }}
+              key: dbname
+        volumeMounts:
+          - name: pgsql-storage
+            mountPath: "/var/lib/pgsql/data"
+        ports:
+          - containerPort: {{ $pgsql.service.port }}
+        resources:
+          limits:
+            cpu: {{ $pgsql.resources.limits.cpu }}
+            memory: {{ $pgsql.resources.limits.memory }}
+          requests:
+            cpu: {{ $pgsql.resources.requests.cpu }}
+            memory: {{ $pgsql.resources.requests.memory }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ $pgsql.service.port }}
+          initialDelaySeconds: 15
+          periodSeconds: 20
+{{- end }}
+{{- end }}
+{{- end }}

--- a/installer/charts/tssc-infrastructure/templates/tests/test.yaml
+++ b/installer/charts/tssc-infrastructure/templates/tests/test.yaml
@@ -1,6 +1,36 @@
 ---
 {{- include "common.test" . }}
   containers:
+{{- with $pgsql := .Values.infrastructure.pgsqlService }}
+{{- range $inst := $pgsql.instances }}
+{{- if $inst.enabled }}
+{{- $podName := printf "test-%s-%s" $inst.name $pgsql.podName }}
+{{- $serviceName := printf "%s-%s" $inst.name $pgsql.service.name }}
+{{- $secretName := printf "%s-%s" $inst.name $pgsql.secretName }}
+{{- $hostName := printf "%s.%s.svc" $serviceName $inst.namespace }}
+    - name: {{ $podName }}
+      image: '{{ $pgsql.image.repository }}{{ $pgsql.image.name }}:{{ $pgsql.image.tag }}'
+      imagePullPolicy: {{ $pgsql.image.pullPolicy }}
+      env:
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ $secretName }}
+              key: password
+      command:
+        - /bin/bash
+        - -ec
+        - |
+          for i in {1..30}; do
+            psql -d {{ $inst.name }} -h {{ $hostName }} -p {{ $pgsql.service.port | toString }} -U {{ $inst.name }} -c "select 1" && exit 0
+            echo "pgsql service not ready yet, retrying ($i/30)..."
+            sleep 2
+          done
+          echo "ERROR: psql readiness check failed after 30 retries"
+          exit 1
+{{- end }}
+{{- end }}
+{{- end }}
 {{- range $k, $v := include "infrastructure.postgresClusters.enabled" . | fromYaml }}
     - name: {{ printf "postgrescluster-%s-test" $k }}
       image: registry.redhat.io/openshift4/ose-tools-rhel9

--- a/installer/charts/tssc-infrastructure/values.yaml
+++ b/installer/charts/tssc-infrastructure/values.yaml
@@ -1,6 +1,31 @@
 ---
 infrastructure:
   #
+  # PostgreSQL Service
+  #
+  pgsqlService:
+    podName: pgsql-bee
+    secretName: pgsql-user
+    storageSize: 50Gi
+    image:
+      name: postgresql-16
+      repository: "registry.redhat.io/rhel9/"
+      pullPolicy: IfNotPresent
+      tag: "1-1754433677"
+    service:
+      name: pgsql
+      type: ClusterIP
+      port: 5432
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 512Mi
+    instances: __OVERWRITE_ME__
+
+  #
   # PostgreSQL Clusters
   #
   postgresClusters:
@@ -30,38 +55,7 @@ infrastructure:
             resources:
               requests:
                 storage: 500Mi
-    tpa:
-      enabled: false
-      namespace: __OVERWRITE_ME__
-      postgresVersion: 14
-      image: registry.connect.redhat.com/crunchydata/crunchy-postgres@sha256:6f4db1e9707b196aaa9f98ada5c09523ec00ade573ff835bd1ca6367ac0bb9f1
-      pgbackrest:
-        global:
-          repo1-retention-full: "3"
-        image: registry.connect.redhat.com/crunchydata/crunchy-pgbackrest@sha256:7092a1036b0ff04004a45bae296262a97b96cb81eab266ce68197060f6711c6b
-      backupRepos:
-        - name: repo1
-          volume:
-            volumeClaimSpec:
-              accessModes:
-                - ReadWriteOnce
-              resources:
-                requests:
-                  storage: 50Gi
-      instances:
-        - replicas: 1
-          dataVolumeClaimSpec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 50Gi
-      patroni:
-        dynamicConfiguration:
-          postgresql:
-            pg_hba:
-              - host all all 0.0.0.0/0 scram-sha-256
-              - host all all ::1/128 scram-sha-256
+
   #
   # OpenShift Pipelines
   #

--- a/installer/charts/values.yaml.tpl
+++ b/installer/charts/values.yaml.tpl
@@ -84,13 +84,15 @@ subscriptions:
 infrastructure:
   developerHub:
     namespace: {{ $rhdh.Namespace }}
+  pgsqlService:
+    instances:
+      - name: tpa
+        enabled: {{ $tpa.Enabled }}
+        namespace: {{ $tpa.Namespace }}
   postgresClusters:
     keycloak:
       enabled: {{ $keycloak.Enabled }}
       namespace: {{ $keycloak.Namespace }}
-    tpa:
-      enabled: {{ $tpa.Enabled }}
-      namespace: {{ $tpa.Namespace }}
   openShiftPipelines:
     enabled: {{ $pipelines.Enabled }}
     namespace: {{ $pipelines.Namespace }}
@@ -289,7 +291,7 @@ trustedProfileAnalyzerRealm:
 # tssc-tpa
 #
 
-{{- $tpaDatabaseSecretName := "tpa-pguser-tpa" }}
+{{- $tpaDatabaseSecretName := "tpa-pgsql-user" }}
 
 trustedProfileAnalyzer:
   enabled: {{ $tpa.Enabled }}


### PR DESCRIPTION
Implements [RHTAP-5353](https://issues.redhat.com//browse/RHTAP-5353)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds configurable PostgreSQL service provisioning per enabled instance (PVC, secrets, Service, Deployment, storage, credentials, resources, readiness probe).
* **Refactor**
  * Moves Postgres provisioning to infrastructure.pgsqlService; removes legacy postgresClusters.tpa and updates TPA DB secret name.
* **Tests**
  * Adds per-instance connectivity readiness tests that validate DB access using configured credentials and endpoints.
* **Documentation**
  * NOTES now list enabled PostgreSQL service instances and images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->