### PR TITLE
feat: Upgrade GitOps to 1.17

### DIFF
--- a/installer/charts/tssc-gitops/Chart.yaml
+++ b/installer/charts/tssc-gitops/Chart.yaml
@@ -4,7 +4,7 @@ name: tssc-gitops
 description: TSSC OpenShift GitOps
 type: application
 version: "1.6.0"
-appVersion: "1.16"
+appVersion: "1.17"
 annotations:
   tssc.redhat-appstudio.github.com/product-name: OpenShift GitOps
   tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions

--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -15,7 +15,7 @@ subscriptions:
     apiResource: gitopsservices.pipelines.openshift.io
     namespace: openshift-operators
     name: openshift-gitops-operator
-    channel: gitops-1.16
+    channel: gitops-1.17
     source: redhat-operators
     sourceNamespace: openshift-marketplace
     config:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Upgraded application version in the Helm chart to 1.17.
  - Updated the default OpenShift GitOps subscription channel to gitops-1.17.
  - No functional changes expected; version values updated for consistency across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->