### PR TITLE
Run TSSC on supported ocp version

### DIFF
--- a/integration-tests/config/rhads-config
+++ b/integration-tests/config/rhads-config
@@ -1,4 +1,4 @@
-OCP="4.16,4.17,4.18"
+OCP="4.17,4.18,4.19"
 ACS="local"
 REGISTRY="quay,artifactory,nexus"
 TPA="local"


### PR DESCRIPTION
RHADS-SSC support OCP 4.17-4.19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test configuration to target OCP versions 4.17–4.19.
  * Removed testing for OCP 4.16 and added coverage for OCP 4.19 to reflect current support.
  * Ensures automated validation runs against the latest supported platform versions.
* **Chores**
  * Refreshed version matrix to align with current platform compatibility; no functional changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->