### PR TITLE
Remove GitLabCI from testplan.json to unblock CI

### DIFF
--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -16,13 +16,6 @@
         "registry": "artifactory",
         "tpa": "local",
         "acs": "local"
-      },
-      {
-        "git": "gitlab",
-        "ci": "gitlabci",
-        "registry": "nexus",
-        "tpa": "local",
-        "acs": "local"
       }
     ],
     "tests": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified integration test configuration by consolidating to a single CI path, reducing redundancy.
  * No changes to test templates or individual test cases.
  * Expect more consistent and predictable integration test runs.

* **Chores**
  * Cleaned up test configuration to reduce maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->