### PR TITLE
RHTAP-4843: Fix `tssc-tpa-realm` Dependency

### DIFF
--- a/installer/charts/tssc-tpa-realm/Chart.yaml
+++ b/installer/charts/tssc-tpa-realm/Chart.yaml
@@ -6,4 +6,3 @@ type: application
 version: "1.6.0"
 annotations:
   tssc.redhat-appstudio.github.com/use-product-namespace: Trusted Profile Analyzer
-  tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-backing-services

--- a/pkg/resolver/topology.go
+++ b/pkg/resolver/topology.go
@@ -29,10 +29,10 @@ func (t *Topology) GetDependencyForChart(
 	return nil, fmt.Errorf("dependency not found for chart %s", name)
 }
 
-// exists checks if a dependency exists in the topology.
-func (t *Topology) exists(dependency config.Dependency) bool {
+// Contains checks if a dependency Contains in the topology.
+func (t *Topology) Contains(name string) bool {
 	for _, d := range t.dependencies {
-		if d.Chart.Name() == dependency.Chart.Name() {
+		if d.Chart.Name() == name {
 			return true
 		}
 	}
@@ -43,7 +43,7 @@ func (t *Topology) exists(dependency config.Dependency) bool {
 func (t *Topology) PrependBefore(name string, dependencies ...config.Dependency) {
 	prefix := config.Dependencies{}
 	for _, dependency := range dependencies {
-		if !t.exists(dependency) {
+		if !t.Contains(dependency.Chart.Name()) {
 			prefix = append(prefix, dependency)
 		}
 	}
@@ -73,11 +73,11 @@ func (t *Topology) PrependBefore(name string, dependencies ...config.Dependency)
 }
 
 // AppendAfter inserts dependencies after a given chart name. If the chart does
-// not exist, it apends to the end the slice.
+// not exist, it appends to the end the slice.
 func (t *Topology) AppendAfter(name string, dependencies ...config.Dependency) {
 	suffix := config.Dependencies{}
 	for _, dependency := range dependencies {
-		if !t.exists(dependency) {
+		if !t.Contains(dependency.Chart.Name()) {
 			suffix = append(suffix, dependency)
 		}
 	}
@@ -108,7 +108,7 @@ func (t *Topology) AppendAfter(name string, dependencies ...config.Dependency) {
 
 // Append adds a new dependency to the end of the topology.
 func (t *Topology) Append(dependency config.Dependency) {
-	if t.exists(dependency) {
+	if t.Contains(dependency.Chart.Name()) {
 		return
 	}
 	t.dependencies = append(t.dependencies, dependency)


### PR DESCRIPTION
When product TPA is disabled, the Topology must not include `tssc-tpa-realm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dependency resolution now considers only dependencies included in the selected topology, preventing unintended installs.
- Bug Fixes
  - Clearer error messaging when a required dependency is not available.
- Chores
  - Removed legacy dependency annotation from the chart to streamline installation metadata.
- Documentation
  - Minor comment typo corrections for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->