### PR TITLE
[RHTAP-4843] Remove `tssc-acs-test` Dependency from `tssc-integrations`

### DIFF
--- a/installer/charts/tssc-acs-test/Chart.yaml
+++ b/installer/charts/tssc-acs-test/Chart.yaml
@@ -7,4 +7,4 @@ version: "1.6.0"
 appVersion: "4.8"
 annotations:
   tssc.redhat-appstudio.github.com/use-product-namespace: Advanced Cluster Security
-  tssc.redhat-appstudio.github.com/depends-on: tssc-acs, tssc-gitops, tssc-tas, tssc-tpa, tssc-dh
+  tssc.redhat-appstudio.github.com/depends-on: tssc-acs

--- a/installer/charts/tssc-integrations/Chart.yaml
+++ b/installer/charts/tssc-integrations/Chart.yaml
@@ -5,4 +5,4 @@ description: TSSC Integrations
 type: application
 version: "1.6.0"
 annotations:
-  tssc.redhat-appstudio.github.com/depends-on: tssc-acs, tssc-gitops, tssc-dh, tssc-acs-test
+  tssc.redhat-appstudio.github.com/depends-on: tssc-acs, tssc-gitops, tssc-dh

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -71,6 +71,7 @@ func TestNewResolver(t *testing.T) {
 			"tssc-infrastructure",
 			"tssc-backing-services",
 			"tssc-acs",
+			"tssc-acs-test",
 			"tssc-gitops",
 			"tssc-tas",
 			"tssc-pipelines",
@@ -78,7 +79,6 @@ func TestNewResolver(t *testing.T) {
 			"tssc-tpa",
 			"tssc-app-namespaces",
 			"tssc-dh",
-			"tssc-acs-test",
 			"tssc-integrations",
 		}))
 	})


### PR DESCRIPTION
By linking `tssc-integrations` to `tssc-acs-test` it triggered including this chart to the topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Streamlined Helm chart dependency annotations by narrowing a test chart’s dependency to a single component.
  * Removed the test chart from the integrations chart’s dependency list to reduce required components and clarify install sequencing.
* Tests
  * Updated resolver test expectations to align with the new dependency order; no functional behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->