### PR TITLE
Take care of warning while deploying integrations

### DIFF
--- a/installer/charts/tssc-integrations/templates/acs/pod.yaml
+++ b/installer/charts/tssc-integrations/templates/acs/pod.yaml
@@ -129,10 +129,6 @@ spec:
         - bash
         - -c
         - "echo 'No op: Success'"
-      requests:
-        cpu: 125m
-        memory: 128Mi
-        ephemeral-storage: "100Mi"
       securityContext:
         allowPrivilegeEscalation: false
   {{- end }}


### PR DESCRIPTION
Since the resources is not being used, removing to avoid noice with the warning. The requests section should be under resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced installation resource footprint by removing resource requests from a no-op container in the ACS post-install process. This lowers reserved CPU, memory, and ephemeral storage during install/upgrade.
  * Eases scheduling on resource-constrained clusters by avoiding unnecessary reservation for the post-install step.
  * No functional changes to ACS behavior; only installation overhead is reduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->