### PR TITLE
Enable Keycloak when either TPA or TAS are enabled

### DIFF
--- a/installer/charts/tssc-backing-services/Chart.yaml
+++ b/installer/charts/tssc-backing-services/Chart.yaml
@@ -5,5 +5,4 @@ description: TSSC Backing Services
 type: application
 version: "1.6.0"
 annotations:
-  tssc.redhat-appstudio.github.com/product-name: Keycloak
   tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-infrastructure

--- a/installer/charts/tssc-backing-services/templates/service-account.yaml
+++ b/installer/charts/tssc-backing-services/templates/service-account.yaml
@@ -1,4 +1,6 @@
+{{- if .Values.backingServices.keycloak.enabled }}
 ---
 {{- include "common.serviceAccount" . }}
 ---
 {{- include "common.clusterRoleBinding" . }}
+{{- end }}

--- a/installer/charts/tssc-backing-services/templates/tests/test.yaml
+++ b/installer/charts/tssc-backing-services/templates/tests/test.yaml
@@ -1,8 +1,7 @@
-{{- if .Values.backingServices.keycloak -}}
+{{- if .Values.backingServices.keycloak.enabled -}}
 ---
 {{- include "common.test" . }}
   containers:
-{{- if .Values.backingServices.keycloak.enabled }}
     #
     # Tests the Keycloak rollout status.
     #
@@ -27,7 +26,4 @@
           mountPath: /scripts
       securityContext:
         allowPrivilegeEscalation: false
-{{- else }}
-{{- include "common.noOp" . | nindent 4 }}
-{{- end }}
 {{- end }}

--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -11,16 +11,6 @@ tssc:
       # Enables installer verbose logging messages for troubleshooting issues.
       debug: false
   products:
-    # Keycloak is an open-source identity and access management solution that
-    # simplifies adding authentication and securing services for applications,
-    # offering features like Single Sign-On (SSO), user federation with external
-    # identity providers (IdPs) like GitHub and more. Trusted Profile Analyzer
-    # (TPA) depends on Keycloak for authentication and authorization.
-    - name: Keycloak
-      enabled: &tpaEnabled true
-      namespace: tssc-keycloak
-      properties:
-        manageSubscription: true
     # Red Hat Advanced Cluster Security (ACS) for OpenShift is a comprehensive
     # security platform that protects cloud-native applications across the entire
     # container lifecycle -- from build and deployment to runtime -- by providing
@@ -65,7 +55,7 @@ tssc:
     # Vulnerability Exploitability eXchange (VEX), and Common Vulnerabilities and
     # Exposures (CVE) to assess their risk profile.
     - name: Trusted Profile Analyzer
-      enabled: *tpaEnabled
+      enabled: true
       namespace: tssc-tpa
       properties:
         manageSubscription: true

--- a/integration-tests/scripts/install.sh
+++ b/integration-tests/scripts/install.sh
@@ -182,12 +182,12 @@ bitbucket_integration() {
 # Currently, the tssc `config` subcommand lacks the ability to modify property values stored in cluster
 disable_tpa() {
   # if "remote" is in tpa_config array, then disable TPA installation
-  # Update the YAML anchor &tpaEnabled from true to false (line 7 in config.yaml)
+  # Update the enabled flag from true to false (line 7 in config.yaml)
   if [[ " ${tpa_config[*]} " =~ " remote " ]]; then
     echo "[INFO] Disable TPA installation in TSSC configuration"
     yq -i '.tssc.products[] |= select(.name == "Trusted Profile Analyzer").enabled = false' "${config_file}"
   else
-    echo "[INFO] TPA is set to local, keeping &tpaEnabled anchor as true"
+    echo "[INFO] TPA is set to local, keeping enabled flag as true"
   fi
 }
 


### PR DESCRIPTION
Fixes [RHTAP-5223](https://issues.redhat.com//browse/RHTAP-5223)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Centralized Keycloak handling behind a computed enable flag and standardized namespace to "tssc-keycloak".
  - ArgoCD configuration reorganized under appNamespaces with consistent argoCD naming.

- Chores
  - Removed Keycloak as a standalone product from installer config.
  - Removed obsolete Keycloak annotation from chart metadata.

- Tests
  - Test resources gated by Keycloak enabled flag; removed no-op fallback.
  - Service account and related bindings render only when Keycloak is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->