### PR TITLE
Renaming the required chart variable

### DIFF
--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -132,7 +132,7 @@ func (r *Resolver) resolveDependencies() error {
 		}
 		// Collecting the last dependency name that is required by the current
 		// chart (dependency), if any.
-		requiredBy := ""
+		requiredDependency := ""
 		for _, dependsOn := range d.DependsOn() {
 			// Ensure the required dependency is in the topology, when not in the
 			// topology it is skipped.
@@ -148,10 +148,10 @@ func (r *Resolver) resolveDependencies() error {
 					name,
 				)
 			}
-			requiredBy = dependsOn
+			requiredDependency = dependsOn
 		}
-		// If it's not required by any other dependency, skip it.
-		if requiredBy == "" {
+		// If there is no required dependency, skip it.
+		if requiredDependency == "" {
 			return nil
 		}
 		// Setting the desired namespace in the dependency.
@@ -160,7 +160,7 @@ func (r *Resolver) resolveDependencies() error {
 		}
 		// Append the current dependency after the last one in the collection that
 		// requires it.
-		r.topology.AppendAfter(requiredBy, d)
+		r.topology.AppendAfter(requiredDependency, d)
 		// Recursively resolve dependencies.
 		return r.dependsOn(name, &d, map[string]bool{})
 	})


### PR DESCRIPTION
RequiredBy variable implies that current chart is required by the dependency but it is the other way around, changing to avoid confusion in the future. Logic does not need to change as they are correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal code readability improved through non-functional renaming and cleanup.
  * Dependency resolution behavior, ordering, and public interfaces remain unchanged.
  * Backward compatibility preserved; no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->