### PR TITLE
fix: wrong PaC URL in the GH App

### DIFF
--- a/pkg/integrations/github.go
+++ b/pkg/integrations/github.go
@@ -116,13 +116,9 @@ func (g *GithubIntegration) setOpenShiftURLs(
 		g.log().Debug("Using OpenShift cluster for GitHub App callback URL")
 	}
 	if g.webhookURL == "" {
-		product, err := cfg.GetProduct(config.OpenShiftPipelines)
-		if err != nil {
-			return err
-		}
 		g.webhookURL = fmt.Sprintf(
 			"https://pipelines-as-code-controller-%s.%s",
-			product.GetNamespace(),
+			"openshift-pipelines", // Static namespace
 			ingressDomain,
 		)
 		g.log().Debug("Using OpenShift cluster for GitHub App webhook URL")


### PR DESCRIPTION
Broken by the changes done to config.yaml. The namespace for the relevant route being static, it is now hardcoded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of GitHub App webhook URL generation in OpenShift Pipelines environments by using a stable namespace, reducing intermittent setup failures. No user-facing API changes.
* **Chores**
  * Simplified configuration to remove a runtime dependency, lowering operational overhead and potential error paths. Callback and homepage URL behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->