### PR TITLE
chore: bump go dependency gitlab.com/gitlab-org/api/client-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/quay/claircore v1.5.39
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
-	gitlab.com/gitlab-org/api/client-go v0.141.2
+	gitlab.com/gitlab-org/api/client-go v0.142.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.18.6
 	k8s.io/api v0.33.4

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT0
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-gitlab.com/gitlab-org/api/client-go v0.141.2 h1:Ijlg+4sYV6WQgiw7rbNHYdHqrnt+bR0CTOm7u5n243M=
-gitlab.com/gitlab-org/api/client-go v0.141.2/go.mod h1:3YuWlZCirs2TTcaAzM6qNwVHB7WvV67ATb0GGpBCdlQ=
+gitlab.com/gitlab-org/api/client-go v0.142.0 h1:cR8+RhDc7ooH0SiGNhgm3Nf5ZpW5D1R3DLshfAXJZmQ=
+gitlab.com/gitlab-org/api/client-go v0.142.0/go.mod h1:3YuWlZCirs2TTcaAzM6qNwVHB7WvV67ATb0GGpBCdlQ=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/bridges/prometheus v0.57.0 h1:UW0+QyeyBVhn+COBec3nGhfnFe5lwB0ic1JBVjzhk0w=

--- a/vendor/gitlab.com/gitlab-org/api/client-go/CHANGELOG.md
+++ b/vendor/gitlab.com/gitlab-org/api/client-go/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.142.0](https://gitlab.com/gitlab-org/api/client-go/compare/v0.141.2...v0.142.0) (2025-08-21)
+
+
+### Features
+
+* **tokens:** add expiration filters and sorting options to ListPersonalAccessTokens ([0a9f797](https://gitlab.com/gitlab-org/api/client-go/commit/0a9f79790ac87c7f7b8e32e9cdea27fbc613728b))
+
 ## [0.141.2](https://gitlab.com/gitlab-org/api/client-go/compare/v0.141.1...v0.141.2) (2025-08-20)
 
 ## [0.141.1](https://gitlab.com/gitlab-org/api/client-go/compare/v0.141.0...v0.141.1) (2025-08-18)

--- a/vendor/gitlab.com/gitlab-org/api/client-go/personal_access_tokens.go
+++ b/vendor/gitlab.com/gitlab-org/api/client-go/personal_access_tokens.go
@@ -84,10 +84,13 @@ type ListPersonalAccessTokensOptions struct {
 	ListOptions
 	CreatedAfter   *ISOTime `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore  *ISOTime `url:"created_before,omitempty" json:"created_before,omitempty"`
+	ExpiresAfter   *ISOTime `url:"expires_after,omitempty" json:"expires_after,omitempty"`
+	ExpiresBefore  *ISOTime `url:"expires_before,omitempty" json:"expires_before,omitempty"`
 	LastUsedAfter  *ISOTime `url:"last_used_after,omitempty" json:"last_used_after,omitempty"`
 	LastUsedBefore *ISOTime `url:"last_used_before,omitempty" json:"last_used_before,omitempty"`
 	Revoked        *bool    `url:"revoked,omitempty" json:"revoked,omitempty"`
 	Search         *string  `url:"search,omitempty" json:"search,omitempty"`
+	Sort           *string  `url:"sort,omitempty" json:"sort,omitempty"`
 	State          *string  `url:"state,omitempty" json:"state,omitempty"`
 	UserID         *int     `url:"user_id,omitempty" json:"user_id,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -386,7 +386,7 @@ github.com/xlzd/gotp
 # github.com/yosida95/uritemplate/v3 v3.0.2
 ## explicit; go 1.14
 github.com/yosida95/uritemplate/v3
-# gitlab.com/gitlab-org/api/client-go v0.141.2
+# gitlab.com/gitlab-org/api/client-go v0.142.0
 ## explicit; go 1.23.0
 gitlab.com/gitlab-org/api/client-go
 # go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a third-party API client dependency to the latest minor version for improved compatibility and maintenance.
  * No user-facing changes expected; functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->