### PR TITLE
chore: revert install task url back

### DIFF
--- a/integration-tests/pipelines/rhtap-cli-e2e.yaml
+++ b/integration-tests/pipelines/rhtap-cli-e2e.yaml
@@ -115,9 +115,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/xinredhat/tssc-cli.git
+            value: https://github.com/redhat-appstudio/rhtap-cli.git
           - name: revision
-            value: update_ci_release1.6
+            value: release-1.6
           - name: pathInRepo
             value: integration-tests/tasks/rhtap-install.yaml
       params:


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED