### PR TITLE
fix: update reset.sh

### DIFF
--- a/hack/reset.sh
+++ b/hack/reset.sh
@@ -166,7 +166,7 @@ action() {
     fi
     if [ -n "${GITLAB:-}" ]; then
         echo '# GitLab'
-        for REPO in $(glab repo list -g "$GITLAB__GROUP" --output json | yq '.[].path_with_namespace' | grep -v -E "deleted-[0-9]*$"); do
+        for REPO in $(glab repo list -g "$GITLAB__GROUP" --output json | yq '.[].path_with_namespace' | grep -v -E "deletion_scheduled-[0-9]*$"); do
             glab repo delete --yes "$REPO"
             echo "✓ Deleted repository $REPO"
         done 2>/dev/null


### PR DESCRIPTION
GitLab changed the name of deleted repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted repository cleanup logic to properly skip items scheduled for deletion, reducing risk of accidental removal and improving reset reliability.

* **Chores**
  * Updated internal reset tooling to align with current naming conventions used during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->