### PR TITLE
feat: upgrade redhat-tssc/backstage-plugins to 1.7

### DIFF
--- a/installer/charts/tssc-dh/templates/plugins-content.yaml
+++ b/installer/charts/tssc-dh/templates/plugins-content.yaml
@@ -97,11 +97,11 @@ plugins:
     package: ./dynamic-plugins/dist/backstage-community-plugin-jenkins-backend-dynamic
 {{- end }}
   - disabled: false
-    package: oci://registry.redhat.io/rhtap-backstage-plugins/rhtap-backstage-plugins-artifacts:1.5.0!rhtap-plugins-backstage-community-plugin-multi-source-security-viewer-dynamic
+    package: oci://quay.io/redhat-tssc/backstage-plugins:1.7.0!tssc-plugins-backstage-community-plugin-multi-source-security-viewer-dynamic
     pluginConfig:
       dynamicPlugins:
         frontend:
-          rhtap-plugins.backstage-community-plugin-multi-source-security-viewer:
+          tssc-plugins.backstage-community-plugin-multi-source-security-viewer:
             mountPoints:
               - config:
                   layout:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Multi-Source Security Viewer plugin to version 1.7.0 from a new registry for continued support.
  * Aligned the plugin identifier with the new distribution naming.
  * Preserved existing layout and configuration behavior; no user action required.
  * Improves consistency of plugin sourcing without altering visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->