### PR TITLE
fix: Add unittests to pipelines

### DIFF
--- a/.tekton/tssc-cli-pull-request.yaml
+++ b/.tekton/tssc-cli-pull-request.yaml
@@ -200,6 +200,26 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: run-unittests
+      params:
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: integration-tests/tasks/tssc-unittest.yaml
+        resolver: git
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
     - name: build-container
       params:
       - name: IMAGE
@@ -228,7 +248,7 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
-      - prefetch-dependencies
+      - run-unittests
       taskRef:
         params:
         - name: name

--- a/.tekton/tssc-cli-push.yaml
+++ b/.tekton/tssc-cli-push.yaml
@@ -197,6 +197,26 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: run-unittests
+      params:
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: pathInRepo
+            value: integration-tests/tasks/tssc-unittest.yaml
+        resolver: git
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
     - name: build-container
       params:
       - name: IMAGE
@@ -225,7 +245,7 @@ spec:
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
-      - prefetch-dependencies
+      - run-unittests
       taskRef:
         params:
         - name: name

--- a/integration-tests/tasks/tssc-unittest.yaml
+++ b/integration-tests/tasks/tssc-unittest.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: tssc-unittest
+spec:
+  params:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+  steps:
+    - name: run-unittests
+      image: registry.access.redhat.com/ubi9/go-toolset:1.24.6-1755755147
+      workingDir: /var/workdir
+      env:
+        - name: SOURCE_ARTIFACT
+          value: "$(params.SOURCE_ARTIFACT)"
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        echo "[$(date --utc -Ins)] Run unit tests"
+
+        echo "SOURCE_ARTIFACT=$SOURCE_ARTIFACT"
+        echo "PWD=$PWD"
+        echo "ls -la"
+        ls
+        echo "find"
+        find . -name Makefile
+        echo "make test"
+        make test
+        echo "[$(date --utc -Ins)] End unit tests"
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  volumes:
+    - name: workdir
+      emptyDir: {}


### PR DESCRIPTION
This is the issues with this PR:

1. The source code is packaged in an OCI making it difficult to access.
2. The go image needs to be kept in sync with the original Dockerfile.
3. It modifies the default Konflux pipeline, which means update to the pipeline definition from Konflux might need to be managed manually.