### PR TITLE
chore: update ADDITIONAL_TAGS from latest to RELEASE_BRANCH

### DIFF
--- a/hack/code-freeze.sh
+++ b/hack/code-freeze.sh
@@ -80,7 +80,7 @@ get_version() {
 update_charts() {
     # Bump "version" in all charts
     get_version "developerHub"
-    RELEASE_BRANCH="release-$VERSION_XY"
+    export RELEASE_BRANCH="release-$VERSION_XY"
     find installer/charts/ -name Chart.yaml | while read -r CHART; do
         yq -i '.version = strenv(VERSION_XYZ)' "$CHART"
     done
@@ -120,6 +120,7 @@ update_ci() {
         sed -i --regexp-extended "s|  *appstudio\.openshift\.io/component: tssc-cli|\0-${VERSION_XY//./-}|" "$PLR"
     done
     yq -i '.spec.params |= map(select(.name != "image-expires-after"))' ".tekton/tssc-cli-push.yaml"
+    yq -i '(.spec.pipelineSpec.tasks[] | select(.name == "apply-tags") | .params[] | select(.name == "ADDITIONAL_TAGS") | .value[0]) = strenv(RELEASE_BRANCH)' ".tekton/tssc-cli-push.yaml"
 }
 
 commit_release() {


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release pipeline now exposes the release branch value so it is added as an additional image tag for built images.
  * The new tag insertion is integrated into the existing release CI steps alongside prior branch substitutions and temporary image expiration removals.
  * Applies only to release builds.
  * No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->