### PR TITLE
fix: source_repo_branch contains ref instead of branch name on push e…

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -66,7 +66,12 @@ spec:
               echo "Downloading rhads-config file:"
               GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
               REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
+              # Determine the branch name for the curl command.
+              # If source_repo_branch starts with "refs/heads/", strip that prefix; otherwise, use as is.
               BRANCH=$(jq -r '.git.source_repo_branch' <<< $JOB_SPEC)
+              if [[ "$BRANCH" == refs/heads/* ]]; then
+                BRANCH="${BRANCH#refs/heads/}"
+              fi
 
               rhads_config_file_location="integration-tests/config/rhads-config"
               curl -o rhads-config https://raw.githubusercontent.com/$REPO_ORG/$GIT_REPO/refs/heads/$BRANCH/$rhads_config_file_location


### PR DESCRIPTION
…vent.

This should prevent "empty runs" like this one: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-shared-team-tenant/applications/tssc-test/pipelineruns/tssc-e2e-rhddr/logs?task=start-nested-pipelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end pipeline reliability by normalizing branch names when fetching configuration from GitHub, preventing URL mismatches and reducing flaky runs on branches with refs prefixes.

* **Chores**
  * Added clarifying comments around branch handling in the pipeline to aid maintainability and future troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->