### PR TITLE
Umarshal config.yaml to yaml.Node

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,12 +45,25 @@ func TestNewConfigFromFile(t *testing.T) {
 		g.Expect(err).To(o.Succeed())
 		g.Expect(string(payload)).To(o.ContainSubstring("tssc:"))
 
-		err = cfg.UnmarshalYAML()
+		err = cfg.UnmarshalYAML(payload)
 		g.Expect(err).To(o.Succeed())
 	})
 
+	t.Run("DecodeNode", func(t *testing.T) {
+		err := cfg.DecodeNode()
+		g.Expect(err).To(o.Succeed())
+		g.Expect(cfg.Installer).NotTo(o.BeNil())
+	})
+
 	t.Run("String", func(t *testing.T) {
-		payload := cfg.String()
-		g.Expect(string(payload)).To(o.ContainSubstring("tssc:"))
+		original, err := cfs.ReadFile("config.yaml")
+		g.Expect(err).To(o.Succeed())
+
+		configString := cfg.String()
+		g.Expect(err).To(o.Succeed())
+		g.Expect(string(configString)).To(o.ContainSubstring("tssc:"))
+
+		// Asserting the original configuration looks like the marshaled one.
+		g.Expect(string(original)).To(o.Equal(configString))
 	})
 }

--- a/pkg/subcmd/config.go
+++ b/pkg/subcmd/config.go
@@ -179,6 +179,9 @@ func (c *Config) runCreate() error {
 			config.Name,
 			fmt.Sprintf("%s=true", config.Label),
 		)
+		if err != nil {
+			return err
+		}
 		fmt.Print(cfg.String())
 		return nil
 	}


### PR DESCRIPTION
Remove `payload` in type config.Config add `root yaml.Node instead,` . Unmarshal config into *yaml.Node, decode it to Installer, marshal it to payload, then update the configuration in cluster.

Jira: [RHTAP-5316](https://issues.redhat.com/browse/RHTAP-5316)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved YAML config handling: load from file/bytes and decode in-memory YAML for reliable processing and round-trips.

- Bug Fixes
  - Better validation and clearer errors for empty/invalid configs.
  - Dry-run no longer prints configuration when an error occurs.

- Refactor
  - Encoding/decoding path revamped to preserve YAML structure and emit consistent document headers.

- Tests
  - Added/updated tests for decode/encode round-trips and string output equality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->