### PR TITLE
fix: remove safeguard preventing OIDC configuration in DH

### DIFF
--- a/installer/charts/tssc-dh/templates/app-config-content.yaml
+++ b/installer/charts/tssc-dh/templates/app-config-content.yaml
@@ -25,8 +25,6 @@ app:
   {{- fail (printf "Gitlab Integration required for gitlab auth provider") }}
 {{- else if and (not $azureSecretObj) (eq .Values.developerHub.authProvider "microsoft") }}
   {{- fail (printf "Azure Integration required for microsoft auth provider") }}
-{{- else if not (has .Values.developerHub.authProvider (list "github" "gitlab" "microsoft")) }}
-  {{- fail (printf "Auth provider %s is not supported, set it to github, gitlab, or microsoft" .Values.developerHub.authProvider) }}
 {{- end }}
 
 {{- if $argocdSecretData }}


### PR DESCRIPTION
The safeguard is breaking the RHDP usecase. This should be fixed in 1.8 with the official support of SSO.