### PR TITLE
fix: validate JSON parameter

### DIFF
--- a/pkg/integration/helper.go
+++ b/pkg/integration/helper.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -9,6 +10,12 @@ import (
 
 // ErrInvalidURL is an error returned when a URL is invalid, malformed.
 var ErrInvalidURL = errors.New("invalid URL")
+
+// ErrInvalidJSON is an error returned when a string is not a valid JSON.
+var ErrInvalidJSON = errors.New("invalid JSON")
+
+// ErrJSONContainsSpaces is an error returned when a JSON key or value contains spaces.
+var ErrJSONContainsSpaces = errors.New("contains unexpected spaces")
 
 // ValidateURL check if the informed URL is valid.
 func ValidateURL(location string) error {
@@ -19,6 +26,43 @@ func ValidateURL(location string) error {
 	if !strings.HasPrefix(u.Scheme, "http") {
 		return fmt.Errorf("%w: invalid scheme %q, expected http or https",
 			ErrInvalidURL, location)
+	}
+	return nil
+}
+
+// ValidateJSON checks if the given string is a valid JSON and that there
+// is no space character in any of the keys and values of a JSON object.
+func ValidateJSON(p string, s string) error {
+	var data interface{}
+
+	if err := json.Unmarshal([]byte(s), &data); err != nil {
+		return fmt.Errorf("%w in --%s: %s", ErrInvalidJSON, p, err)
+	}
+
+	return checkJSONSpaces(p, data)
+}
+
+func checkJSONSpaces(p string, data interface{}) error {
+	switch v := data.(type) {
+	case string:
+		if strings.Contains(v, " ") {
+			return fmt.Errorf("--%s %w in string %q", p, ErrJSONContainsSpaces, v)
+		}
+	case map[string]interface{}:
+		for key, val := range v {
+			if err := checkJSONSpaces(p, key); err != nil {
+				return err
+			}
+			if err := checkJSONSpaces(p, val); err != nil {
+				return err
+			}
+		}
+	case []interface{}:
+		for _, val := range v {
+			if err := checkJSONSpaces(p, val); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/integration/helper_test.go
+++ b/pkg/integration/helper_test.go
@@ -1,0 +1,114 @@
+package integration
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateURL(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name        string
+		location    string
+		expectedErr error
+	}{
+		{
+			name:        "Valid HTTP URL",
+			location:    "http://example.com",
+			expectedErr: nil,
+		},
+		{
+			name:        "Valid HTTPS URL",
+			location:    "https://example.com",
+			expectedErr: nil,
+		},
+		{
+			name:        "Invalid URL, no scheme",
+			location:    "example.com",
+			expectedErr: ErrInvalidURL,
+		},
+		{
+			name:        "Invalid URL, unparseable",
+			location:    "://example.com",
+			expectedErr: ErrInvalidURL,
+		},
+		{
+			name:        "Invalid scheme",
+			location:    "ftp://example.com",
+			expectedErr: ErrInvalidURL,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateURL(tc.location)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("expected err %v, got %v", tc.expectedErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateJSON(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name        string
+		param       string
+		json        string
+		expectedErr error
+	}{
+		{
+			name:        "Valid JSON",
+			param:       "test",
+			json:        `{"key":"value"}`,
+			expectedErr: nil,
+		},
+		{
+			name:        "Valid nested JSON",
+			param:       "test",
+			json:        `{"key":{"nested_key":"nested_value"}}`,
+			expectedErr: nil,
+		},
+		{
+			name:        "Invalid JSON syntax",
+			param:       "test",
+			json:        `{"key":"value}`,
+			expectedErr: ErrInvalidJSON,
+		},
+		{
+			name:        "JSON with space in key",
+			param:       "test",
+			json:        `{"key key":"value"}`,
+			expectedErr: ErrJSONContainsSpaces,
+		},
+		{
+			name:        "JSON with space in value",
+			param:       "test",
+			json:        `{"key":"value value"}`,
+			expectedErr: ErrJSONContainsSpaces,
+		},
+		{
+			name:        "JSON with space in nested key",
+			param:       "test",
+			json:        `{"key":{"nested key":"nested_value"}}`,
+			expectedErr: ErrJSONContainsSpaces,
+		},
+		{
+			name:        "JSON with space in nested value",
+			param:       "test",
+			json:        `{"key":{"nested_key":"nested value"}}`,
+			expectedErr: ErrJSONContainsSpaces,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateJSON(tc.param, tc.json)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("expected err %v, got %v", tc.expectedErr, err)
+			}
+		})
+	}
+}

--- a/pkg/integration/imageregistry.go
+++ b/pkg/integration/imageregistry.go
@@ -62,6 +62,18 @@ func (i *ImageRegistry) LoggerWith(logger *slog.Logger) *slog.Logger {
 
 // Validate validates the integration configuration.
 func (i *ImageRegistry) Validate() error {
+	err := ValidateJSON("dockerconfigjson", i.dockerConfig)
+	if err != nil {
+		return err
+	}
+
+	if i.dockerConfigRO != "" {
+		err = ValidateJSON("dockerconfigjsonreadonly", i.dockerConfigRO)
+		if err != nil {
+			return err
+		}
+	}
+
 	return ValidateURL(i.url)
 }
 


### PR DESCRIPTION
We do not expect any of the key/values in the dockerconfigjson to have spaces, and interpret the presence of a space as bad input.

This safeguard is added after a customer ran into a difficult to debug issue where the invalid content of the secret had an unexpected impact on the ability to pull any image in the namespace.

cf [RHTAP-5655](https://issues.redhat.com//browse/RHTAP-5655)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added JSON validation for credential inputs, enforcing no spaces in keys or string values and returning clearer errors for invalid JSON.
  - Applied this validation to image registry configurations before URL checks for more reliable setup feedback.

- Bug Fixes
  - Prevents saving misconfigured image registry settings with malformed or space-containing JSON, reducing setup errors.

- Tests
  - Added comprehensive tests covering valid/invalid URLs and multiple JSON scenarios (syntax errors, spaces in keys/values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->