### PR TITLE
fix: disable microsoft auth in DH

### DIFF
--- a/installer/charts/tssc-dh/templates/app-config-content.yaml
+++ b/installer/charts/tssc-dh/templates/app-config-content.yaml
@@ -23,10 +23,6 @@ app:
   {{- fail (printf "Github Integration required for github auth provider") }}
 {{- else if and (not $gitlabSecretObj) (eq .Values.developerHub.authProvider "gitlab") }}
   {{- fail (printf "Gitlab Integration required for gitlab auth provider") }}
-{{- else if and (not $azureSecretObj) (eq .Values.developerHub.authProvider "microsoft") }}
-  {{- fail (printf "Azure Integration required for microsoft auth provider") }}
-{{- else if not (has .Values.developerHub.authProvider (list "github" "gitlab" "microsoft")) }}
-  {{- fail (printf "Auth provider %s is not supported, set it to github, gitlab, or microsoft" .Values.developerHub.authProvider) }}
 {{- end }}
 
 {{- if $argocdSecretData }}
@@ -54,16 +50,6 @@ auth:
   environment: production
   providers:
   {{- $signInPage := "" }}
-  {{- if eq .Values.developerHub.authProvider "microsoft" }}
-    {{- if and $azureSecretData.clientId $azureSecretData.clientSecret $azureSecretData.tenantId }}
-    {{- $signInPage = "microsoft" }}
-    microsoft:
-      production:
-        clientId: ${AZURE__CLIENT__ID}
-        clientSecret: ${AZURE__CLIENT__SECRET}
-        tenantId: ${AZURE__TENANT__ID}
-    {{- end }}
-  {{- end }}
   {{- if eq .Values.developerHub.authProvider "github" }}
     {{- $signInPage = "github" }}
     github:

--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -72,7 +72,7 @@ tssc:
         # namespacePrefixes:
         #   - tssc-app
         authProvider: github
-        # Possible values: github, gitlab, microsoft
+        # Possible values: github, gitlab
         # RBAC:
         #   adminUsers:
         #     - myUsername


### PR DESCRIPTION
The feature was not complete and is low priority, so it is disabled.

cf [RHTAP-5660](https://issues.redhat.com//browse/RHTAP-5660)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GitLab as a supported authentication provider alongside GitHub.

- Chores
  - Removed Microsoft OAuth provider configuration and related validation. Microsoft is no longer available as a sign-in option; Azure integrations remain available but not for authentication.

- Documentation
  - Updated configuration comments to list supported auth providers as “github, gitlab” (removed “microsoft”).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->