### PR TITLE
Fix RBAC when authProvider is gitlab and host is gitlab.com

### DIFF
--- a/installer/charts/tssc-dh/templates/app-config-content.yaml
+++ b/installer/charts/tssc-dh/templates/app-config-content.yaml
@@ -122,11 +122,15 @@ catalog:
         timeout: { minutes: 5 }
   {{- end }}
   {{- if eq .Values.developerHub.authProvider "gitlab" }}
+    {{- $gitlabSecretData := ($gitlabSecretObj.data | default dict) }}
     gitlab:
       default:
         host: ${GITLAB__HOST}
         orgEnabled: true
         group: ${GITLAB__GROUP}
+        {{- if eq ($gitlabSecretData.host | b64dec) "gitlab.com" }}
+        includeUsersWithoutSeat: true
+        {{- end }}
         schedule:
           initialDelay: { seconds: 30 }
           frequency: { minutes: 15 }
@@ -181,9 +185,12 @@ integrations:
           privateKey: ${GITHUB__APP__PRIVATE_KEY}
 {{- end }}
 {{- if $gitlabSecretObj }}
+  {{- $gitlabSecretData := ($gitlabSecretObj.data | default dict) }}
   gitlab:
     - host: ${GITLAB__HOST}
+      {{- if ne ($gitlabSecretData.host | b64dec) "gitlab.com" }}
       apiBaseUrl: https://${GITLAB__HOST}/api/v4
+      {{- end }}
       token: ${GITLAB__TOKEN}
 {{- end }}
 {{- if $jenkinsSecretObj }}


### PR DESCRIPTION
When working with self managed gitlab instance running under OpenShift the gitlab auth provider worked well. However when using gitlab.com it was not working. It turns out there are config difference depending on wether you use SaaS gitlab or self-managed gitlab. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic GitLab host detection to tailor configuration for gitlab.com vs self-managed instances.
  * For gitlab.com: automatically includes users without seat and streamlines setup by omitting the API base URL.
  * For self-managed GitLab: automatically sets the API base URL for proper integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->