### PR TITLE
RHTAP-5387 Change authProvider when using GitLab

### DIFF
--- a/integration-tests/scripts/.ci-env
+++ b/integration-tests/scripts/.ci-env
@@ -14,7 +14,7 @@ export GITHUB__APP__WEBHOOK__SECRET=
 #### Gitlab
 # https://docs.redhat.com/en/documentation/red_hat_trusted_application_pipeline/1.2/html-single/installing_red_hat_trusted_application_pipeline/index#optional_integrating_gitlab
 export GITLAB__TOKEN=
-# When using gitlab as auth provider(auth_config="github"), you also need to set the following values
+# When using gitlab as auth provider(auth_config="gitlab"), you also need to set the following values
 export GITLAB__APP__ID=
 export GITLAB__APP_SECRET=
 export GITLAB__GROUP=

--- a/integration-tests/scripts/.env.template
+++ b/integration-tests/scripts/.env.template
@@ -20,7 +20,7 @@ export GITHUB__APP__WEBHOOK__SECRET=
 #### Gitlab
 # https://docs.redhat.com/en/documentation/red_hat_trusted_application_pipeline/1.2/html-single/installing_red_hat_trusted_application_pipeline/index#optional_integrating_gitlab
 export GITLAB__TOKEN=
-# When using gitlab as auth provider(auth_config="github"), you also need to set the following values
+# When using gitlab as auth provider(auth_config="gitlab"), you also need to set the following values
 export GITLAB__APP__ID=
 export GITLAB__APP_SECRET=
 export GITLAB__GROUP=

--- a/integration-tests/scripts/install.sh
+++ b/integration-tests/scripts/install.sh
@@ -78,6 +78,14 @@ update_dh_catalog_url() {
   fi
 }
 
+update_dh_auth_config() {
+  # if SCM is set to Gielab, update auth config, otherwise keep it to default - github
+  if [[ " ${scm_config[*]} " =~ " gitlab " ]]; then
+    echo "[INFO] Change Developer Hub auth to gitlab"
+    yq -i '.tssc.products[] |= select(.name == "Developer Hub").properties.authProvider = "gitlab"' "${config_file}"
+    fi
+}
+
 # Workaround: This function has to be called before tssc import "installer/config.yaml" into cluster.
 # Currently, the tssc `config` subcommand lacks the ability to modify property values stored in config.yaml.
 github_integration() {
@@ -240,6 +248,7 @@ nexus_integration() {
 create_cluster_config() {
   echo "[INFO] Creating the installer's cluster configuration"
   update_dh_catalog_url
+  update_dh_auth_config
   disable_acs
   disable_tpa
   


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now auto-configures the Developer Hub auth provider to GitLab when a GitLab SCM is detected, reducing manual setup.

* **Documentation**
  * Updated CI and environment template guidance to correctly reference the GitLab auth provider, improving configuration clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->