### PR TITLE
RHTAP-4826: MCP Tool `tssc_status`

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -32,7 +32,7 @@ func (r *RootCmd) Cmd() *cobra.Command {
 		subcmd.NewConfig(logger, r.flags, r.cfs, r.kube),
 		subcmd.NewDeploy(logger, r.flags, r.cfs, r.kube),
 		subcmd.NewInstaller(r.flags),
-		subcmd.NewMCPServer(r.flags, r.kube),
+		subcmd.NewMCPServer(r.flags, r.cfs, r.kube),
 		subcmd.NewTemplate(logger, r.flags, r.cfs, r.kube),
 		subcmd.NewTopology(logger, r.cfs, r.kube),
 	} {

--- a/pkg/mcpserver/instructions.md
+++ b/pkg/mcpserver/instructions.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Welcome! I am the `tssc` Installer Assistant, an AI agent designed to guide you through the installation and configuration of Red Hat Advanced Developer Suite (RHADS). My purpose is to simplify the deployment process by managing the workflow, validating configurations, and orchestrating the deployment on your OpenShift cluster.
+Welcome! I am the `tssc` (Trusted Software Supply Chain) installer assistant, an AI agent designed to guide you through the installation and configuration of Red Hat Advanced Developer Suite (RHADS). My purpose is to simplify the deployment process by managing the workflow, validating configuration, guiding the configuration of TSSC integrations, and orchestrating the deployment on your OpenShift cluster.
 
 This is achieved through a stateful, guided process. I will help you progress through distinct phases, and I will reject tool calls that are out of sequence to ensure a valid installation.
 
@@ -16,24 +16,28 @@ My primary objective is to help you successfully install RHADS. I will guide you
 
 ## Workflow
 
-The installation process is divided into three main phases.
+The installation process is divided into four main phases.
 
 ### Phase 1: Configuration (`AWAITING_CONFIGURATION`)
 
-This is the starting point. You must define the installation configuration.  
+This is the starting point. You must define the installation configuration.
 
-- Use `tssc_config_get` to view the current configuration. Take note of each `.tscc.products[]` top comment to understand what each product does, so you can control whether to install it or not.  
-- Use `tssc_config_create` or `tssc_config_update` to set your desired cluster configuration, which determines which `.tssc.products[]` to install, along with global settings.  
+1. Use `tssc_status` to view the overall installer status.
+2. Use `tssc_config_get` to view the current configuration. Take note of each `.tssc.products[]` top comment to understand what each product does, so you can decide whether to install it or not.
+3. Use `tssc_config_get` to view the current configuration. For each entry in `.tssc.products[]`, read its leading comment/description to understand what the product does so you can decide whether to install it
 
 Once the configuration is successfully applied, we will proceed to the next phase.
 
 ### Phase 2: Integrations (`AWAITING_INTEGRATIONS`)
 
-In this phase, you will configure the necessary integrations.
+In this phase, you will help configure the necessary integrations by scaffolding the integration commands. All `tssc integration` subcommands handle sensitive information and must be executed in a secure environment, such as a dedicated shell session outside of the MCP/LLM context.
 
-- Use `tssc_integration_list` to see all available integration types.
-- Use `tssc_integration_scaffold` to generate the command for configuring a specific integration. You will need to run this command manually in your terminal for security reasons.
-- Use `tssc_integration_status` to check if an integration has been configured correctly.
+If integrations are missing, inspect the result to identify which integration names are missing.
+
+1. Use `tssc_status` to view the overall installer status.
+2. Use `tssc_integration_list` to see all available integration types.
+3. Use `tssc_integration_scaffold` to generate the command for configuring a specific integration. You will need to run this command manually in your terminal for security reasons.
+4. Use `tssc_integration_status` to check if an integration has been configured correctly.
 
 Completing this step is a prerequisite for deployment.
 
@@ -41,7 +45,14 @@ Completing this step is a prerequisite for deployment.
 
 Once configuration and integrations are complete, you can deploy RHADS.
 
-- Use `tssc_deploy` to start the deployment. This will create a Kubernetes Job to run the installation.
-- Use `tssc_deploy_status` to monitor the progress of the deployment.
+1. Use `tssc_status` to view the overall installer status.
+2. Use `tssc_deploy` to start the deployment. This will create a Kubernetes Job to run the installation.
+3. Use `tssc_status` to monitor the progress of the deployment.
 
 I will guide you with suggestions for the next logical action in my responses. Let's get started!
+
+### Phase 4: Completed (`DEPLOYING` to `COMPLETED`)
+
+The installer has finished successfully and all components are running as expected.
+
+- Use `tssc_status` to view the overall installer status.

--- a/pkg/mcptools/configtools.go
+++ b/pkg/mcptools/configtools.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/redhat-appstudio/tssc-cli/pkg/config"
+	"github.com/redhat-appstudio/tssc-cli/pkg/constants"
 	"github.com/redhat-appstudio/tssc-cli/pkg/k8s"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -27,6 +28,11 @@ type ConfigTools struct {
 }
 
 const (
+	// ConfigGetTool MCP config get tool name.
+	ConfigGetTool = constants.AppName + "_config_get"
+	// ConfigCreateTool MCP config create tool name.
+	ConfigCreateTool = constants.AppName + "_config_create"
+
 	// NamespaceArg namespace argument.
 	NamespaceArg = "namespace"
 	// SettingsArg settings argument.
@@ -139,7 +145,7 @@ TSSC has been successfully configured in namespace %s with settings:
 func (c *ConfigTools) Init(s *server.MCPServer) {
 	s.AddTools([]server.ServerTool{{
 		Tool: mcp.NewTool(
-			"tssc_config_get",
+			ConfigGetTool,
 			mcp.WithDescription(`
 Get the existing TSSC configuration in the cluster, or return the default if none
 exists yet. Use the default configuration as the reference to create a new TSSC
@@ -149,7 +155,7 @@ configuration for the cluster.`,
 		Handler: c.getHandler,
 	}, {
 		Tool: mcp.NewTool(
-			"tssc_config_create",
+			ConfigCreateTool,
 			mcp.WithDescription(`
 Create a new TSSC configuration in the cluster, in case none exists yet. Use the
 defaults as the reference to create a new TSSC cluster configuration.`,

--- a/pkg/mcptools/interface.go
+++ b/pkg/mcptools/interface.go
@@ -7,5 +7,5 @@ import (
 // Interface represents the MCP tools in the project.
 type Interface interface {
 	// Init decorates the MCP server with the tool declaration.
-	Init(s *server.MCPServer)
+	Init(*server.MCPServer)
 }

--- a/pkg/mcptools/statustool.go
+++ b/pkg/mcptools/statustool.go
@@ -1,0 +1,212 @@
+package mcptools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/redhat-appstudio/tssc-cli/pkg/config"
+	"github.com/redhat-appstudio/tssc-cli/pkg/constants"
+	"github.com/redhat-appstudio/tssc-cli/pkg/installer"
+	"github.com/redhat-appstudio/tssc-cli/pkg/resolver"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// StatusTool represents the MCP tool that's responsible to report the current
+// installer status in the cluster.
+type StatusTool struct {
+	cm              *config.ConfigMapManager  // cluster configuration
+	topologyBuilder *resolver.TopologyBuilder // topology builder
+	job             *installer.Job            // cluster deployment job
+
+	phase string // current deployment phase
+}
+
+var _ Interface = &StatusTool{}
+
+const (
+	// StatusToolName MCP status tool name.
+	StatusToolName = constants.AppName + "_status"
+
+	// AwaitingConfigurationPhase first step, the cluster is not configured yet.
+	AwaitingConfigurationPhase = "AWAITING_CONFIGURATION"
+	// AwaitingIntegrationsPhase second step, the cluster doesn't have the
+	// required integrations configured yet.
+	AwaitingIntegrationsPhase = "AWAITING_INTEGRATIONS"
+	// ReadyToDeployPhase third step, the cluster is ready to deploy. It's
+	// configured and has all required integrations in place.
+	ReadyToDeployPhase = "READY_TO_DEPLOY"
+	// DeployingPhase fourth step, the installer is currently deploying the
+	// dependencies, Helm charts.
+	DeployingPhase = "DEPLOYING"
+	// CompletedPhase final step, the installation process is complete, and the
+	// cluster is ready.
+	CompletedPhase = "COMPLETED"
+)
+
+// resultWithPhaseF uses the global phase, the informed message format and
+// arguments to compose the tool result. The installer status name is place before
+// the informed message.
+func (s *StatusTool) resultWithPhaseF(
+	format string,
+	a ...any,
+) *mcp.CallToolResult {
+	return mcp.NewToolResultText(
+		fmt.Sprintf("# Current Status: %q\n", s.phase) +
+			fmt.Sprintf(format, a...),
+	)
+}
+
+// statusHandler shows the installer overall status by inspecting the cluster to
+// determine the current state of the installation.
+func (s *StatusTool) statusHandler(
+	ctx context.Context,
+	_ mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	// Ensure the cluster is configured, if the ConfigMap is not found, creates a
+	// message to inform the user about MCP configuration tools.
+	s.phase = AwaitingConfigurationPhase
+	cfg, err := s.cm.GetConfig(ctx)
+	if err != nil {
+		return s.resultWithPhaseF(`
+The cluster is not configured yet, use the tool %q to configure it. That's the
+first step to deploy TSSC components.
+
+Inspecting the configuration in the cluster returned the following error:
+
+> %s`,
+			ConfigCreateTool, err.Error(),
+		), nil
+	}
+
+	// Given the cluster is configured, let's inspect the topology to ensure all
+	// dependencies and integrations are resolved.
+	s.phase = AwaitingIntegrationsPhase
+	if _, err = s.topologyBuilder.Build(ctx, cfg); err != nil {
+		switch {
+		case errors.Is(err, resolver.ErrCircularDependency) ||
+			errors.Is(err, resolver.ErrDependencyNotFound) ||
+			errors.Is(err, resolver.ErrInvalidCollection):
+			return s.resultWithPhaseF(`
+ATTENTION: The installer set of dependencies, Helm charts, are not properly
+resolved. Please check the dependencies given to the installer. Preferably use the
+embedded dependency collection.
+
+> %s`,
+				err.Error(),
+			), nil
+		case errors.Is(err, resolver.ErrInvalidExpression) ||
+			errors.Is(err, resolver.ErrUnknownIntegration):
+			return s.resultWithPhaseF(`
+ATTENTION: The installer set of dependencies, Helm charts, are referencing invalid
+required integrations expressions and/or using invalid integration names. Please
+check the dependencies given to the installer. Preferably use the embedded
+dependency collection.
+
+> %s`,
+				err.Error(),
+			), nil
+		case errors.Is(err, resolver.ErrConfiguredIntegration):
+			// TODO: when the configuration update is ready (RHTAP-5316) the tool
+			// result will instruct the user to rely on the configuration tool to
+			// update the cluster configuration, or remove the integration from
+			// from the cluster.
+			return s.resultWithPhaseF(`
+The integration is already configured in the cluster, 
+
+> %s`,
+				err.Error(),
+			), nil
+		case errors.Is(err, resolver.ErrMissingIntegrations):
+			return s.resultWithPhaseF(`
+ATTENTION: One or more required integrations are missing. Use the tool %q to
+describe the existing integrations, and examples of how to use the CLI to
+configure them. 
+
+> %s`,
+				IntegrationListTool, err.Error(),
+			), nil
+		default:
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+	}
+
+	// Given integrations are in place, let's inspect the current state of the
+	// cluster deployment job.
+	jobState, err := s.job.GetState(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Shell command to get the logs of the deployment job.
+	logsCmdEx := s.job.GetJobLogFollowCmd(cfg.Installer.Namespace)
+
+	// Handle different states of the deployment job.
+	switch jobState {
+	case installer.NotFound:
+		s.phase = ReadyToDeployPhase
+		return s.resultWithPhaseF(`
+The cluster is ready to deploy the TSSC components. Use the tool %q to deploy the
+TSSC components.`,
+			DeployToolName,
+		), nil
+	case installer.Deploying:
+		s.phase = DeployingPhase
+		return s.resultWithPhaseF(`
+The cluster is deploying the TSSC components. Please wait for the deployment to
+complete. You can use the following command to follow the deployment job logs:
+
+> %s`,
+			logsCmdEx,
+		), nil
+	case installer.Failed:
+		s.phase = DeployingPhase
+		return s.resultWithPhaseF(`
+The deployment job has failed. You can use the following command to view the
+related POD logs:
+
+> %s`,
+			logsCmdEx,
+		), nil
+	case installer.Done:
+		s.phase = CompletedPhase
+		return s.resultWithPhaseF(`
+The TSSC components have been deployed successfully. You can use the following
+command to inspect the installation logs and get initial information for each
+product deployed:
+
+> %s`,
+			logsCmdEx,
+		), nil
+	}
+
+	return mcp.NewToolResultError("unknown installer state"), nil
+}
+
+// Init registers the status tool.
+func (s *StatusTool) Init(mcpServer *server.MCPServer) {
+	mcpServer.AddTools([]server.ServerTool{{
+		Tool: mcp.NewTool(
+			StatusToolName,
+			mcp.WithDescription(`
+Reports the overall installer status, the first tool to be called to identify the
+installer status in the cluster and define the next tool to call.
+			`),
+		),
+		Handler: s.statusHandler,
+	}}...)
+}
+
+// NewStatusTool creates a new StatusTool instance.
+func NewStatusTool(
+	cm *config.ConfigMapManager,
+	tb *resolver.TopologyBuilder,
+	job *installer.Job,
+) *StatusTool {
+	return &StatusTool{
+		cm:              cm,
+		topologyBuilder: tb,
+		job:             job,
+	}
+}

--- a/pkg/resolver/topologybuilder.go
+++ b/pkg/resolver/topologybuilder.go
@@ -47,8 +47,8 @@ func (t *TopologyBuilder) Build(
 	return topology, nil
 }
 
-// NewTopologyManager creates a new TopologyBuilder instance.
-func NewTopologyManager(
+// NewTopologyBuilder creates a new TopologyBuilder instance.
+func NewTopologyBuilder(
 	logger *slog.Logger,
 	cfs *chartfs.ChartFS,
 	integrationsManager *integrations.Manager,

--- a/pkg/subcmd/deploy.go
+++ b/pkg/subcmd/deploy.go
@@ -73,7 +73,7 @@ func (d *Deploy) log() *slog.Logger {
 // Complete verifies the object is complete.
 func (d *Deploy) Complete(args []string) error {
 	var err error
-	d.topologyBuilder, err = resolver.NewTopologyManager(
+	d.topologyBuilder, err = resolver.NewTopologyBuilder(
 		d.logger, d.cfs, integrations.NewManager(d.logger, d.kube))
 	if err != nil {
 		return err

--- a/pkg/subcmd/mcpserver.go
+++ b/pkg/subcmd/mcpserver.go
@@ -4,22 +4,26 @@ import (
 	"io"
 	"log/slog"
 
+	"github.com/redhat-appstudio/tssc-cli/pkg/chartfs"
 	"github.com/redhat-appstudio/tssc-cli/pkg/config"
 	"github.com/redhat-appstudio/tssc-cli/pkg/flags"
 	"github.com/redhat-appstudio/tssc-cli/pkg/installer"
+	"github.com/redhat-appstudio/tssc-cli/pkg/integrations"
 	"github.com/redhat-appstudio/tssc-cli/pkg/k8s"
 	"github.com/redhat-appstudio/tssc-cli/pkg/mcpserver"
 	"github.com/redhat-appstudio/tssc-cli/pkg/mcptools"
+	"github.com/redhat-appstudio/tssc-cli/pkg/resolver"
 
 	"github.com/spf13/cobra"
 )
 
 // MCPServer is a subcommand for starting the MCP server.
 type MCPServer struct {
-	cmd    *cobra.Command // cobra command
-	logger *slog.Logger   // application logger
-	flags  *flags.Flags   // global flags
-	kube   *k8s.Kube      // kubernetes client
+	cmd    *cobra.Command   // cobra command
+	logger *slog.Logger     // application logger
+	flags  *flags.Flags     // global flags
+	cfs    *chartfs.ChartFS // embedded filesystem
+	kube   *k8s.Kube        // kubernetes client
 
 	image string // installer's container image
 }
@@ -58,22 +62,35 @@ func (m *MCPServer) Validate() error {
 // Run starts the MCP server.
 func (m *MCPServer) Run() error {
 	cm := config.NewConfigMapManager(m.kube)
-	cfgTools, err := mcptools.NewConfigTools(m.logger, m.kube, cm)
+	configTools, err := mcptools.NewConfigTools(m.logger, m.kube, cm)
 	if err != nil {
 		return err
 	}
 
+	tb, err := resolver.NewTopologyBuilder(
+		m.logger, m.cfs, integrations.NewManager(m.logger, m.kube))
+	if err != nil {
+		return err
+	}
+	jm := installer.NewJob(m.kube)
+	statusTool := mcptools.NewStatusTool(cm, tb, jm)
+
 	integrationCmd := NewIntegration(m.logger, m.kube)
 	integrationTools := mcptools.NewIntegrationTools(integrationCmd)
-	deployTools := mcptools.NewDeployTools(cm, installer.NewJob(m.kube), m.image)
+
+	deployTools := mcptools.NewDeployTools(cm, jm, m.image)
 
 	s := mcpserver.NewMCPServer()
-	s.AddTools(cfgTools, integrationTools, deployTools)
+	s.AddTools(configTools, statusTool, integrationTools, deployTools)
 	return s.Start()
 }
 
 // NewMCPServer creates a new MCPServer instance.
-func NewMCPServer(f *flags.Flags, kube *k8s.Kube) *MCPServer {
+func NewMCPServer(
+	f *flags.Flags,
+	cfs *chartfs.ChartFS,
+	kube *k8s.Kube,
+) *MCPServer {
 	m := &MCPServer{
 		cmd: &cobra.Command{
 			Use:   "mcp-server",
@@ -84,6 +101,7 @@ func NewMCPServer(f *flags.Flags, kube *k8s.Kube) *MCPServer {
 		// to the console, for the time being it will be discarded.
 		logger: f.GetLogger(io.Discard),
 		flags:  f,
+		cfs:    cfs,
 		kube:   kube,
 	}
 	m.PersistentFlags(m.cmd)


### PR DESCRIPTION
Introducing a central MCP tool to report the current deployment phase in the cluster, as well the instructions for the LLM to understand each phase, and how to proceed to the next step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Multi-phase status command reporting installer progress (awaiting config/integrations, ready to deploy, deploying, completed) with actionable guidance and log-follow instructions.
  - Streamlined deploy command that initiates deployment and directs users to follow logs.
  - Standardized config tool names for get/create operations.
  - Server now wires topology, integration, status, and deploy tooling for clearer guidance.

- **Documentation**
  - Installer guide expanded to a four-phase workflow with status checks, integration scaffolding, and secure handling guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->