### PR TITLE
[RHTAP-5689] Reverts default auth provider for CI back to Github

### DIFF
--- a/integration-tests/scripts/install.sh
+++ b/integration-tests/scripts/install.sh
@@ -248,7 +248,8 @@ nexus_integration() {
 create_cluster_config() {
   echo "[INFO] Creating the installer's cluster configuration"
   update_dh_catalog_url
-  update_dh_auth_config
+  # TODO: Uncomment this when settig auth provider is implemented in rhads-config
+  # update_dh_auth_config
   disable_acs
   disable_tpa
   


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/RHTAP-5689

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted integration test installation flow to temporarily skip authentication provider updates during cluster configuration, reducing flakiness and improving test reliability.

* **Chores**
  * Added a reminder to reinstate authentication updates once supported.
  * No user-facing changes; production behavior remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->