### PR TITLE
Enable update of namespace and settings

### DIFF
--- a/pkg/config/extract.go
+++ b/pkg/config/extract.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"fmt"
+	"maps"
+	"strings"
+)
+
+var ProdNames = map[string]string{
+	"ACS":       "Advanced Cluster Security",
+	"TAS":       "Trusted Artifact Signer",
+	"GITOPS":    "OpenShift GitOps",
+	"DH":        "Developer Hub",
+	"TPA":       "Trusted Profile Analyzer",
+	"PIPELINES": "OpenShift Pipelines",
+}
+
+func ValueExists(m map[string]string, searchValue string) bool {
+	for _, value := range m {
+		if value == searchValue {
+			return true
+		}
+	}
+	return false
+}
+
+func ExtractProductSettings(input any) ([]map[string]any, error) {
+	var output []map[string]any
+	// subConfig := make(map[string]any)
+	switch prodConf := input.(type) {
+	case map[string]any:
+		for key, value := range prodConf {
+			item := make(map[string]any)
+			keyUpper := strings.ToUpper(key)
+			if prodName, exists := ProdNames[keyUpper]; exists {
+				item["name"] = prodName
+				config, err := FlattenMap(value, "")
+				if err != nil {
+					return nil, fmt.Errorf("failed to flatten config for product %s: %w", prodName, err)
+				}
+				if _, ok := config["name"]; ok {
+					return nil, fmt.Errorf("invalid product config: top-level key %q is reserved", "name")
+				}
+				maps.Copy(item, config)
+			} else if ValueExists(ProdNames, key) {
+				item["name"] = key
+				config, err := FlattenMap(value, "")
+				if err != nil {
+					return nil, fmt.Errorf("failed to flatten config for product %s: %w", key, err)
+				}
+				if _, ok := config["name"]; ok {
+					return nil, fmt.Errorf("invalid product config: top-level key %q is reserved", "name")
+				}
+				maps.Copy(item, config)
+			} else {
+				return nil, fmt.Errorf("invalid config for products")
+			}
+			output = append(output, item)
+		}
+	default:
+		return nil, fmt.Errorf("product configuration must be map[string]any")
+	}
+	return output, nil
+}
+
+func ConvertStringMapToAny(m map[string]string) map[string]any {
+	result := make(map[string]any)
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+func FlattenMapRecursive(input map[string]any, prefix string, output map[string]any) {
+	for key, value := range input {
+		newKey := key
+		if prefix != "" {
+			newKey = prefix + "." + newKey
+		}
+		switch v := value.(type) {
+		case map[string]any:
+			FlattenMapRecursive(v, newKey, output)
+		case map[string]string:
+			newMap := ConvertStringMapToAny(v)
+			FlattenMapRecursive(newMap, newKey, output)
+		default:
+			output[newKey] = value
+		}
+	}
+}
+
+func FlattenMap(input any, prefix string) (map[string]interface{}, error) {
+	output := make(map[string]interface{})
+	switch config := input.(type) {
+	case string:
+		output[prefix] = config
+	case map[string]any:
+		FlattenMapRecursive(config, prefix, output)
+	default:
+		return nil, fmt.Errorf("not supported config format")
+	}
+	return output, nil
+}

--- a/pkg/mcptools/configtools.go
+++ b/pkg/mcptools/configtools.go
@@ -37,6 +37,8 @@ const (
 	NamespaceArg = "namespace"
 	// SettingsArg settings argument.
 	SettingsArg = "setting"
+	// ProductsArg products argument.
+	ProductsArg = "product"
 )
 
 // getHandler similar to "tssc config --get" subcommand it returns a existing TSSC
@@ -98,10 +100,22 @@ func (c *ConfigTools) createHandler(
 	// Setting the namespace from user input, if provided.
 	if ns, ok := ctr.GetArguments()[NamespaceArg].(string); ok {
 		cfg.Installer.Namespace = ns
+		// Set namespace to value of ns
+		if err := cfg.Set("tssc.namespace", ns); err != nil {
+			return nil, err
+		}
 	}
 
-	if settings, ok := ctr.GetArguments()[SettingsArg].(config.Settings); ok {
-		cfg.Installer.Settings = settings
+	if settings, ok := ctr.GetArguments()[SettingsArg].(map[string]interface{}); ok {
+		if err := cfg.Set("tssc.settings", settings); err != nil {
+			return nil, err
+		}
+	}
+
+	if products, ok := ctr.GetArguments()[ProductsArg].(map[string]interface{}); ok {
+		if err := cfg.Set("tssc.products", products); err != nil {
+			return nil, err
+		}
 	}
 
 	// Ensure the configuration is valid.
@@ -173,6 +187,13 @@ and other fundamental services will be deployed.`,
 				mcp.Description(`
 The global settings object for TSSC ('.tssc.settings{}'). When empty the default
 settings will be used.
+				`),
+			),
+			mcp.WithObject(
+				ProductsArg,
+				mcp.Description(`
+The settings object for TSSC ('.tssc.products{}'). When empty the default config
+will be used.
 				`),
 			),
 		),


### PR DESCRIPTION
1. Enable update of namespace, in gemini cli, input `Create new config in namespace testing`, it will create configuration in testing namespace in cluster
2. Enable update of settings, in gemini cli, input `Create new config  with settings crc and ci debug to true`, it will create configuration with crc and ci.debug to true
3. Input `Create new config in namespace testing and settings ci debug to true`, it will create configuration in namespace testing and ci.debug is set to true
4. To update products, input `create new config in namespace test and product ACS disabled and product TPA properties manageSubscription to false`, it will create configuration in cluster with ACS disabled, and `properties.manageSubscription` set to false

Jira: https://issues.redhat.com/browse/RHTAP-5316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - In-place YAML config updates via dot-delimited paths and product-targeted updates; new public Set API plus utilities to extract and flatten product settings.

- Refactor
  - CLI now persists namespace, settings, and product inputs through the unified config update mechanism; new product CLI argument exposed.

- Tests
  - Added tests validating namespace, nested settings, product injection, and flattening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->