### PR TITLE
RHTAP-5637: Deployment Tool Flags

### DIFF
--- a/pkg/mcptools/deploytools.go
+++ b/pkg/mcptools/deploytools.go
@@ -25,8 +25,17 @@ type DeployTools struct {
 
 var _ Interface = &DeployTools{}
 
-// DeployToolName deploy tool name.
-const DeployToolName = constants.AppName + "_deploy"
+const (
+	// DeployToolName deploy tool name.
+	DeployToolName = constants.AppName + "_deploy"
+
+	// DebugArg enables debug mode for the deployment job.
+	DebugArg = "debug"
+	// DryRunArg runs the deployment job on dry-run.
+	DryRunArg = "dry-run"
+	// ForceArg forces the recreation of the deployment job.
+	ForceArg = "force"
+)
 
 // deployHandler handles the deployment of TSSC components.
 func (d *DeployTools) deployHandler(
@@ -46,20 +55,65 @@ installation status, and the next actions after that.
 		)), nil
 	}
 
-	if err = d.job.Create(ctx, cfg.Installer.Namespace, d.image); err != nil {
-		return nil, fmt.Errorf("failed to create installer job: %w", err)
+	// Validating the topology as a whole, dependencies and integrations to ensure
+	// the cluster is ready to deploy.
+	if _, err = d.topologyBuilder.Build(ctx, cfg); err != nil {
+		return mcp.NewToolResultErrorFromErr(`
+Ensure the cluster is properly configured and all required integrations are in
+place. Inspect the error message below to assess the issue.`,
+			err,
+		), nil
+	}
+
+	// Deployment job flags.
+	var debug, dryRun, force bool
+
+	if v, ok := ctr.GetArguments()[DebugArg].(bool); ok {
+		debug = v
+	}
+	if v, ok := ctr.GetArguments()[DryRunArg].(bool); ok {
+		dryRun = v
+	}
+	if v, ok := ctr.GetArguments()[ForceArg].(bool); ok {
+		force = v
 	}
 
 	// Command to get the logs of the deployment job.
 	logsCmd := d.job.GetJobLogFollowCmd(cfg.Installer.Namespace)
-	return mcp.NewToolResultText(fmt.Sprintf(`
-The installer job has been created successfully. Use the tool 'tssc_deploy_status'
-to check the deployment status using the MCP server.
 
-You can follow the logs by running:
+	// Issue the deployment job using the informed flags.
+	err = d.job.Run(ctx, debug, dryRun, force, cfg.Installer.Namespace, d.image)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf(`
+Unable to issue the deployment Job, it returned the following error:
+
+> %s
+
+In case the job exists in the cluster, use the force flag to force it's
+recreation, and use the following command to inspect its current state:
 
 	%s`,
-		logsCmd,
+			err.Error(), logsCmd),
+		), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf(`
+ATTENTION: The "dry-run" flag will prevent any changes from being made to the
+cluster, set the flag to "false" in order to apply changes.
+
+The installer job has been created successfully. Use the tool %q to check the
+deployment status; this can take a few minutes depending on cluster performance.
+Use the tool periodically to verify that the deployment is proceeding as expected.
+
+Informed flags:
+	- debug: %v
+	- dry-run: %v
+	- force: %v
+
+You can follow the Kubernetes Job logs by running:
+
+	%s`,
+		StatusToolName, debug, dryRun, force, logsCmd,
 	)), nil
 }
 
@@ -69,8 +123,35 @@ func (d *DeployTools) Init(mcpServer *server.MCPServer) {
 		Tool: mcp.NewTool(
 			DeployToolName,
 			mcp.WithDescription(`
-Deploys TSSC components to the cluster, uses the cluster configuration to deploy
-the TSSC components sequentially.`,
+Deploys TSSC components to the cluster, using the cluster configuration to deploy
+the components sequentially. Note the "dry-run" flag: the deployment process will
+only be initiated when the "dry-run" flag is set to "false". By default, this flag
+is set to "true".`,
+			),
+			mcp.WithBoolean(
+				DryRunArg,
+				mcp.Description(`
+Run the installation Job in dry-run mode. This will not create any resources in
+the cluster and is useful for validating the configuration and integrations. You
+must set it to "false" in order to deploy the TSSC platform in your cluster.`,
+				),
+				mcp.DefaultBool(true),
+			),
+			mcp.WithBoolean(
+				ForceArg,
+				mcp.Description(`
+Forces the recreation of the installation Job. This will delete the existing
+Job and create a new one regardless of its state.`,
+				),
+				mcp.DefaultBool(false),
+			),
+			mcp.WithBoolean(
+				DebugArg,
+				mcp.Description(`
+Sets the debug mode for the deployment job. This will enable verbose logging and
+additional platform deployment information.`,
+				),
+				mcp.DefaultBool(false),
 			),
 		),
 		Handler: d.deployHandler,


### PR DESCRIPTION
Passing the flags, force, debug and dry-run to the MCP tool, so the installer job uses the same settings. Also, adapting the `tssc_status` tool to recognise a dry-run job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for --dry-run, --debug, and --force flags in the deployment tool.
  * Enforced single-deployment-per-cluster with an option to force-redeploy existing jobs.
  * Introduced pre-deployment topology validation with actionable guidance on failures.
* Documentation
  * Updated help text to explain new flags, dry-run behavior, defaults, and monitoring options.
  * Improved error messages with clearer next steps and a logs command for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->