### PR TITLE
RHTAP-5695 switch SA for nested pipelines

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -64,9 +64,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/tssc-cli.git
+            value: https://github.com/rhopp/tssc-cli.git
           - name: revision
-            value: main
+            value: RHTAP-5695
           - name: pathInRepo
             value: integration-tests/tasks/start-pipelines.yaml
       params:

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -156,6 +156,7 @@ spec:
             "--labels" "custom.appstudio.openshift.io/main-pipeline-run=${CONTEXT_PIPELINE_RUN_NAME}"
             "--prefix-name" "e2e-$ocp_version$config_suffix"
             "-o" "name"
+            "--serviceaccount" "konflux-integration-runner"
           )
           echo "Starting pipeline with testplan (${#testplan_b64} chars): ${testplan_b64:0:50}..."
           pipeline_run=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/tssc-cli/refs/heads/$BRANCH/integration-tests/pipelines/tssc-cli-e2e.yaml "${tkn_params[@]}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Pipeline start invocations now include a service account parameter, running under "konflux-integration-runner".
  - Execution behavior and control flow are unchanged aside from the authenticated identity used during runs.
  - Two test tasks have been updated to use revised upstream task sources and revisions for integration runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->