### PR TITLE
feat: Add the integration command for TAS

### DIFF
--- a/installer/charts/tssc-dh/Chart.yaml
+++ b/installer/charts/tssc-dh/Chart.yaml
@@ -6,5 +6,5 @@ version: "1.7.0"
 appVersion: "1.7"
 annotations:
   tssc.redhat-appstudio.github.com/product-name: Developer Hub
-  tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-infrastructure, tssc-gitops, tssc-tas, tssc-pipelines, tssc-tpa, tssc-app-namespaces
+  tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-infrastructure, tssc-gitops, tssc-pipelines, tssc-app-namespaces
   tssc.redhat-appstudio.github.com/integrations-required: "(bitbucket || github || gitlab) && (artifactory || nexus || quay)"

--- a/installer/charts/tssc-pipelines/Chart.yaml
+++ b/installer/charts/tssc-pipelines/Chart.yaml
@@ -7,4 +7,5 @@ version: "1.7.0"
 appVersion: "1.19"
 annotations:
   tssc.redhat-appstudio.github.com/product-name: OpenShift Pipelines
-  tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-tas
+  tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions
+  tssc.redhat-appstudio.github.com/integrations-required: tas

--- a/installer/charts/tssc-tas/Chart.yaml
+++ b/installer/charts/tssc-tas/Chart.yaml
@@ -8,3 +8,4 @@ appVersion: "1.2"
 annotations:
   tssc.redhat-appstudio.github.com/product-name: Trusted Artifact Signer
   tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-infrastructure, tssc-iam
+  tssc.redhat-appstudio.github.com/integrations-provided: tas

--- a/pkg/integration/tas.go
+++ b/pkg/integration/tas.go
@@ -1,0 +1,94 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/redhat-appstudio/tssc-cli/pkg/config"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TrustedArtifactSigner represents the coordinates to connect to
+// the TrustedArtifactSigner services.
+type TrustedArtifactSigner struct {
+	rekorURL string // URL of the rekor server
+	tufURL   string // URL of the TUF server
+}
+
+var _ Interface = &TrustedArtifactSigner{}
+
+// PersistentFlags adds the persistent flags to the informed Cobra command.
+func (t *TrustedArtifactSigner) PersistentFlags(c *cobra.Command) {
+	p := c.PersistentFlags()
+
+	p.StringVar(&t.rekorURL, "rekor-url", t.rekorURL,
+		"URL of the rekor server "+
+			"(e.g. https://rekor.sigstore.dev)")
+	p.StringVar(&t.tufURL, "tuf-url", t.tufURL,
+		"URL of the TUF server "+
+			"(e.g. https://tuf.trustification.dev)")
+
+	for _, f := range []string{
+		"rekor-url",
+		"tuf-url",
+	} {
+		if err := c.MarkPersistentFlagRequired(f); err != nil {
+			panic(err)
+		}
+	}
+}
+
+// SetArgument sets additional arguments to the integration.
+func (t *TrustedArtifactSigner) SetArgument(string, string) error {
+	return nil
+}
+
+// LoggerWith decorates the logger with the integration flags.
+func (t *TrustedArtifactSigner) LoggerWith(logger *slog.Logger) *slog.Logger {
+	return logger.With(
+		"rekor-url", t.rekorURL,
+		"tuf-url", t.tufURL,
+	)
+}
+
+// Type shares the Kubernetes secret type for this integration.
+func (t *TrustedArtifactSigner) Type() corev1.SecretType {
+	return corev1.SecretTypeOpaque
+}
+
+// Validate checks the informed URLs ensure valid inputs.
+func (t *TrustedArtifactSigner) Validate() error {
+	if t.rekorURL == "" {
+		return fmt.Errorf("rekor-url is required")
+	}
+	var err error
+	if err = ValidateURL(t.rekorURL); err != nil {
+		return fmt.Errorf("%s: %q", err, t.rekorURL)
+	}
+	if t.tufURL == "" {
+		return fmt.Errorf("tuf-url is required")
+	}
+	if err = ValidateURL(t.tufURL); err != nil {
+		return fmt.Errorf("%s: %q", err, t.tufURL)
+	}
+	return nil
+}
+
+// Data returns the Kubernetes secret data for this integration.
+func (t *TrustedArtifactSigner) Data(
+	_ context.Context,
+	_ *config.Config,
+) (map[string][]byte, error) {
+	return map[string][]byte{
+		"rekor_url": []byte(t.rekorURL),
+		"tuf_url":   []byte(t.tufURL),
+	}, nil
+}
+
+// NewTrustedArtifactSigner creates a new instance of the TrustedArtifactSigner integration.
+func NewTrustedArtifactSigner() *TrustedArtifactSigner {
+	return &TrustedArtifactSigner{}
+}

--- a/pkg/integrations/manager.go
+++ b/pkg/integrations/manager.go
@@ -22,16 +22,17 @@ type Manager struct {
 }
 
 const (
-	ACS            IntegrationName = "acs"
-	Artifactory    IntegrationName = "artifactory"
-	Azure          IntegrationName = "azure"
-	BitBucket      IntegrationName = "bitbucket"
-	GitHub         IntegrationName = "github"
-	GitLab         IntegrationName = "gitlab"
-	Jenkins        IntegrationName = "jenkins"
-	Nexus          IntegrationName = "nexus"
-	Quay           IntegrationName = "quay"
-	Trustification IntegrationName = "trustification"
+	ACS                   IntegrationName = "acs"
+	Artifactory           IntegrationName = "artifactory"
+	Azure                 IntegrationName = "azure"
+	BitBucket             IntegrationName = "bitbucket"
+	GitHub                IntegrationName = "github"
+	GitLab                IntegrationName = "gitlab"
+	Jenkins               IntegrationName = "jenkins"
+	Nexus                 IntegrationName = "nexus"
+	Quay                  IntegrationName = "quay"
+	TrustedArtifactSigner IntegrationName = "tas"
+	Trustification        IntegrationName = "trustification"
 )
 
 // Integration returns the integration instance by name.
@@ -76,16 +77,17 @@ func NewManager(logger *slog.Logger, kube *k8s.Kube) *Manager {
 	// Instantiating all integrations making sure the set of integrations is
 	// complete and unique. The application must panic on duplicated integrations.
 	for name, data := range map[IntegrationName]integration.Interface{
-		ACS:            integration.NewACS(),
-		Artifactory:    integration.NewContainerRegistry(""),
-		Azure:          integration.NewAzure(),
-		BitBucket:      integration.NewBitBucket(),
-		GitHub:         integration.NewGitHub(logger, kube),
-		GitLab:         integration.NewGitLab(logger),
-		Jenkins:        integration.NewJenkins(),
-		Nexus:          integration.NewContainerRegistry(""),
-		Quay:           integration.NewContainerRegistry(integration.QuayURL),
-		Trustification: integration.NewTrustification(),
+		ACS:                   integration.NewACS(),
+		Artifactory:           integration.NewContainerRegistry(""),
+		Azure:                 integration.NewAzure(),
+		BitBucket:             integration.NewBitBucket(),
+		GitHub:                integration.NewGitHub(logger, kube),
+		GitLab:                integration.NewGitLab(logger),
+		Jenkins:               integration.NewJenkins(),
+		Nexus:                 integration.NewContainerRegistry(""),
+		Quay:                  integration.NewContainerRegistry(integration.QuayURL),
+		TrustedArtifactSigner: integration.NewTrustedArtifactSigner(),
+		Trustification:        integration.NewTrustification(),
 	} {
 		// Ensure unique integration names.
 		if _, exists := m.integrations[name]; exists {

--- a/pkg/subcmd/integration.go
+++ b/pkg/subcmd/integration.go
@@ -36,6 +36,8 @@ func NewIntegration(logger *slog.Logger, kube *k8s.Kube) *cobra.Command {
 			logger, kube, manager.Integration(integrations.Nexus)),
 		NewIntegrationQuay(
 			logger, kube, manager.Integration(integrations.Quay)),
+		NewIntegrationTrustedArtifactSigner(
+			logger, kube, manager.Integration(integrations.TrustedArtifactSigner)),
 		NewIntegrationTrustification(
 			logger, kube, manager.Integration(integrations.Trustification)),
 	} {

--- a/pkg/subcmd/integration_trustedartifactsigner.go
+++ b/pkg/subcmd/integration_trustedartifactsigner.go
@@ -1,0 +1,75 @@
+package subcmd
+
+import (
+	"log/slog"
+
+	"github.com/redhat-appstudio/tssc-cli/pkg/config"
+	"github.com/redhat-appstudio/tssc-cli/pkg/integration"
+	"github.com/redhat-appstudio/tssc-cli/pkg/k8s"
+
+	"github.com/spf13/cobra"
+)
+
+// IntegrationTrustedArtifactSigner is the sub-command for the "integration trusted-artifact-signer",
+// responsible for creating and updating the TrustedArtifactSigner integration secret.
+type IntegrationTrustedArtifactSigner struct {
+	cmd         *cobra.Command           // cobra command
+	logger      *slog.Logger             // application logger
+	cfg         *config.Config           // installer configuration
+	kube        *k8s.Kube                // kubernetes client
+	integration *integration.Integration // integration instance
+}
+
+var _ Interface = &IntegrationTrustedArtifactSigner{}
+
+const trustedArtifactSignerIntegrationLongDesc = `
+Manages the TrustedArtifactSigner integration with TSSC, by storing the required
+URL required to interact with Trusted Artifact Signer.
+
+The credentials are stored in a Kubernetes Secret in the configured namespace for TSSC.`
+
+// Cmd exposes the cobra instance.
+func (t *IntegrationTrustedArtifactSigner) Cmd() *cobra.Command {
+	return t.cmd
+}
+
+// Complete is a no-op in this case.
+func (t *IntegrationTrustedArtifactSigner) Complete(args []string) error {
+	var err error
+	t.cfg, err = bootstrapConfig(t.cmd.Context(), t.kube)
+	return err
+}
+
+// Validate checks if the required configuration is set.
+func (t *IntegrationTrustedArtifactSigner) Validate() error {
+	return t.integration.Validate()
+}
+
+// Run creates or updates the TrustedArtifactSigner integration secret.
+func (t *IntegrationTrustedArtifactSigner) Run() error {
+	return t.integration.Create(t.cmd.Context(), t.cfg)
+}
+
+// NewIntegrationTrustedArtifactSigner creates the sub-command for the "integration
+// trusted-artifact-signer" responsible to manage the TSSC integrations with the
+// Trusted Artifact Signer services.
+func NewIntegrationTrustedArtifactSigner(
+	logger *slog.Logger,
+	kube *k8s.Kube,
+	i *integration.Integration,
+) *IntegrationTrustedArtifactSigner {
+	t := &IntegrationTrustedArtifactSigner{
+		cmd: &cobra.Command{
+			Use:          "trusted-artifact-signer [flags]",
+			Short:        "Integrates a Trusted Artifact Signer instance into TSSC",
+			Long:         trustedArtifactSignerIntegrationLongDesc,
+			SilenceUsage: true,
+		},
+
+		logger:      logger,
+		kube:        kube,
+		integration: i,
+	}
+	i.PersistentFlags(t.cmd)
+	return t
+}


### PR DESCRIPTION
- Add the integration command
- Update the Chart.yaml for the templates to reference the new integration

cf [RHTAP-5658](https://issues.redhat.com//browse/RHTAP-5658)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Trusted Artifact Signer (TAS) integration, including a new CLI command to configure and manage it.
- Chores
  - Updated installer charts to reflect integration relationships: pipelines now declares TAS as required; TAS declares what it provides.
  - Simplified dependency annotations by removing unused components from relevant charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->