### PR TITLE
RHTAP-5653: Topology Weights

### DIFF
--- a/docs/topology.md
+++ b/docs/topology.md
@@ -47,6 +47,17 @@ annotations:
   tssc.redhat-appstudio.github.com/depends-on: "tssc-openshift, tssc-subscriptions"
 ```
 
+### `tssc.redhat-appstudio.github.com/weight`
+
+- **Purpose**: This **optional** annotation defines the weight of a chart in the topology. It allows for fine-tuning the order of chart deployments, especially when charts have indirect dependencies or no direct dependencies. The annotation `depends-on`, described before, takes precedence over the weight. 
+- **Usage**: The value is an integer that defines the weight of the chart. Charts with lower weights are deployed earlier.
+- **Example**: If the OpenShift GitOps Helm chart has a weight of 10:
+
+```yaml
+annotations:
+  tssc.redhat-appstudio.github.com/weight: "10"
+```
+
 ### `tssc.redhat-appstudio.github.com/integrations-provided`
 
 - **Purpose**: This **optional** annotation lists the names of integrations that the Helm chart provides.  The chart is responsible for creating the necessary secrets or configurations for these integrations.

--- a/installer/charts/tssc-acs-test/Chart.yaml
+++ b/installer/charts/tssc-acs-test/Chart.yaml
@@ -8,3 +8,4 @@ appVersion: "4.8"
 annotations:
   tssc.redhat-appstudio.github.com/use-product-namespace: Advanced Cluster Security
   tssc.redhat-appstudio.github.com/depends-on: tssc-acs
+  tssc.redhat-appstudio.github.com/weight: "99"

--- a/pkg/resolver/annotations.go
+++ b/pkg/resolver/annotations.go
@@ -14,6 +14,11 @@ var (
 	// to be installed before it can be installed.
 	DependsOnAnnotation = fmt.Sprintf("%s/depends-on", constants.RepoURI)
 
+	// WeightAnnotation defines the weight a chart has in the topology, which
+	// allows moving a dependency down or up in the topology. The annotation
+	// "depends-on" takes preference over the weight annotation.
+	WeightAnnotation = fmt.Sprintf("%s/weight", constants.RepoURI)
+
 	// UseProductNamespaceAnnotation defines the Helm chart should use the same
 	// namespace than the referred product name.
 	UseProductNamespaceAnnotation = fmt.Sprintf(

--- a/pkg/resolver/collection.go
+++ b/pkg/resolver/collection.go
@@ -82,6 +82,10 @@ func NewCollection(charts []chart.Chart) (*Collection, error) {
 	// Populating the collection with dependencies.
 	for _, hc := range charts {
 		d := NewDependency(&hc)
+		// Asserting the weight annotation is a valid integer.
+		if _, err := d.Weight(); err != nil {
+			return nil, fmt.Errorf("%w:  %s", ErrInvalidCollection, err)
+		}
 		// Dependencies in the collection must have unique names.
 		if _, err := c.Get(d.Name()); err == nil {
 			return nil, fmt.Errorf("%w: duplicate chart: %s",

--- a/pkg/resolver/dependency.go
+++ b/pkg/resolver/dependency.go
@@ -1,7 +1,9 @@
 package resolver
 
 import (
+	"fmt"
 	"log/slog"
+	"strconv"
 
 	"helm.sh/helm/v3/pkg/chart"
 )
@@ -61,6 +63,20 @@ func (d *Dependency) DependsOn() []string {
 		return nil
 	}
 	return commaSeparatedToSlice(dependsOn)
+}
+
+// Weight returns the weight of this dependency. If no weight is specified, zero
+// is returned. The weight must be specified as an integer value.
+func (d *Dependency) Weight() (int, error) {
+	if v, exists := d.chart.Metadata.Annotations[WeightAnnotation]; exists {
+		w, err := strconv.Atoi(v)
+		if err != nil {
+			return -1, fmt.Errorf(
+				"invalid value %q for annotation %q", v, WeightAnnotation)
+		}
+		return w, nil
+	}
+	return 0, nil
 }
 
 // ProductName returns the product name from the chart annotations.

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -178,17 +178,19 @@ func (r *Resolver) Resolve() error {
 func (r *Resolver) Print(w io.Writer) {
 	table := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	row := func(a ...any) {
-		fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", a...)
+		fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", a...)
 	}
-	row("Index", "Dependency", "Namespace", "Product", "Depends-On",
+	row("Index", "Dependency", "Namespace", "Product", "Depends-On", "Weight",
 		"Provided-Integrations", "Required-Integrations")
 	for i, d := range r.topology.Dependencies() {
+		weight, _ := d.Weight()
 		row(
 			fmt.Sprintf("%2d", i+1),
 			d.Name(),
 			d.Namespace(),
 			d.ProductName(),
 			strings.Join(d.DependsOn(), ", "),
+			fmt.Sprintf("%d", weight),
 			strings.Join(d.IntegrationsProvided(), ", "),
 			d.IntegrationsRequired(),
 		)

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -69,7 +69,6 @@ func TestNewResolver(t *testing.T) {
 			"tssc-openshift",
 			"tssc-subscriptions",
 			"tssc-acs",
-			"tssc-acs-test",
 			"tssc-gitops",
 			"tssc-infrastructure",
 			"tssc-iam",
@@ -80,6 +79,7 @@ func TestNewResolver(t *testing.T) {
 			"tssc-app-namespaces",
 			"tssc-dh",
 			"tssc-integrations",
+			"tssc-acs-test",
 		}))
 	})
 }


### PR DESCRIPTION
This pull request introduces the ability to specify and utilize dependency weights within the `Topology` struct, allowing for more granular control over the order in which dependencies are processed.

Also, the `tssc-acs-test` is moved to the last chart in the topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support for an optional “weight” annotation to influence deployment order (lower values deploy earlier); topology insertions now respect weights and resolver output shows a Weight column.

- Documentation
  - Topology docs updated with the “weight” annotation description, usage (integer), example, and precedence (depends-on still wins).

- Bug Fixes
  - Invalid/non-integer weight values are now detected and reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->