### PR TITLE
fix: deploy and ci-set-org-vars.sh scripts

### DIFF
--- a/hack/ci-set-org-vars.sh
+++ b/hack/ci-set-org-vars.sh
@@ -90,9 +90,9 @@ parse_args() {
 
 getValues() {
     COSIGN_SECRET_JSON=$(oc get secrets -n openshift-pipelines signing-secrets -o json)
-    COSIGN_SECRET_KEY="$(echo "$COSIGN_SECRET_JSON" | jq -r '.data.["cosign.key"]')"
-    COSIGN_SECRET_PASSWORD="$(echo "$COSIGN_SECRET_JSON" | jq -r '.data.["cosign.password"]')"
-    COSIGN_PUBLIC_KEY="$(echo "$COSIGN_SECRET_JSON" | jq -r '.data.["cosign.pub"]')"
+    COSIGN_SECRET_KEY="$(echo "$COSIGN_SECRET_JSON" | jq -r '.data."cosign.key"')"
+    COSIGN_SECRET_PASSWORD="$(echo "$COSIGN_SECRET_JSON" | jq -r '.data."cosign.password"')"
+    COSIGN_PUBLIC_KEY="$(echo "$COSIGN_SECRET_JSON" | jq -r '.data."cosign.pub"')"
 
     for REGISTRY in "artifactory" "nexus" "quay"; do
         REGISTRY_SECRET="tssc-$REGISTRY-integration" # notsecret

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -265,7 +265,12 @@ deploy() {
 }
 
 configure_ci() {
-    "$SCRIPT_DIR/ci-set-org-vars.sh" --env-file "$ENVFILE"
+    if [[ -n "${GITHUB:-}" ]]; then
+        "$SCRIPT_DIR/ci-set-org-vars.sh" --backend github
+    fi
+    if [[ -n "${GITLAB:-}" ]]; then
+        "$SCRIPT_DIR/ci-set-org-vars.sh" --backend gitlab
+    fi
 }
 
 action() {


### PR DESCRIPTION
Change needed by a recent update to 'ci-set-org-vars.sh'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI configuration to conditionally set organization variables per backend (GitHub/GitLab) when applicable.
  * Adjusted secret parsing in CI scripts for clearer, more robust handling of signing keys and passwords.

* **Refactor**
  * Simplified backend invocation flow in deployment scripts for clearer intent without changing default behavior.

* **Notes**
  * No user-facing features changed.
  * No public interfaces affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->