### PR TITLE
Revert branches for periodic job

### DIFF
--- a/integration-tests/pipelines/e2e-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-periodic-pipeline.yaml
@@ -70,9 +70,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/jkopriva/tssc-cli.git
+            value: https://github.com/redhat-appstudio/tssc-cli.git
           - name: revision
-            value: fix-periodic-branch
+            value: main
           - name: pathInRepo
             value: integration-tests/tasks/start-pipelines.yaml
       params:

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -108,8 +108,8 @@ spec:
         fi
         if [[ "$MODE" == "periodic" ]]; then
           # use always main from redhat-appstudio for periodic jobs
-          REPO_ORG="jkopriva"
-          BRANCH="fix-periodic-branch"
+          REPO_ORG="redhat-appstudio"
+          BRANCH="main"
         fi
         echo "REPO_ORG:"
         echo "$REPO_ORG"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated periodic pipeline configuration to pull the TSSC CLI from the official repository and main branch when running in periodic mode, without altering task flow or behavior.
* **Chores**
  * Standardized repository origin and branch references used by periodic runs to reflect the canonical upstream source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->