### PR TITLE
Upgrade GitOps to 1.18 and Pipelines to 1.20

### DIFF
--- a/installer/charts/tssc-gitops/Chart.yaml
+++ b/installer/charts/tssc-gitops/Chart.yaml
@@ -4,7 +4,7 @@ name: tssc-gitops
 description: TSSC OpenShift GitOps
 type: application
 version: "1.7.0"
-appVersion: "1.17"
+appVersion: "1.18"
 annotations:
   tssc.redhat-appstudio.github.com/product-name: OpenShift GitOps
   tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions

--- a/installer/charts/tssc-pipelines/Chart.yaml
+++ b/installer/charts/tssc-pipelines/Chart.yaml
@@ -4,7 +4,7 @@ name: tssc-pipelines
 description: TSSC OpenShift Pipelines
 type: application
 version: "1.7.0"
-appVersion: "1.19"
+appVersion: "1.20"
 annotations:
   tssc.redhat-appstudio.github.com/product-name: OpenShift Pipelines
   tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions

--- a/installer/charts/tssc-pipelines/templates/NOTES.txt
+++ b/installer/charts/tssc-pipelines/templates/NOTES.txt
@@ -5,13 +5,6 @@ Tekton Pipelines as Code:
 {{- else }}
   - URL: unset
 {{- end }}
-{{- $secretObj := (lookup "v1" "Secret" "openshift-pipelines" "pipelines-as-code-secret") | default dict -}}
-{{- $secretData := (get $secretObj "data") | default dict -}}
-{{- if $secretData }}
-  - Webhook secret: {{ get $secretData "webhook.secret" | b64dec }}
-{{- else }}
-  - Webhook secret: unset
-{{- end }}
 
 Tekton Chains:
 {{- $secretObj := (lookup "v1" "Secret" "openshift-pipelines" "signing-secrets") | default dict -}}

--- a/installer/charts/tssc-subscriptions/templates/tests/test.yaml
+++ b/installer/charts/tssc-subscriptions/templates/tests/test.yaml
@@ -18,6 +18,7 @@
         - name: scripts
           mountPath: /scripts
       securityContext:
+        runAsNonRoot: false
         allowPrivilegeEscalation: false
 {{- range $sub := include "subscriptions.enabled" . | fromYaml }}
     #

--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -28,7 +28,7 @@ subscriptions:
     description: OpenShift Pipelines Operator
     namespace: openshift-operators
     name: openshift-pipelines-operator-rh
-    channel: pipelines-1.19
+    channel: pipelines-1.20
     source: redhat-operators
     sourceNamespace: openshift-marketplace
   openshiftTrustedArtifactSigner:

--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -6,7 +6,7 @@ subscriptions:
     apiResource: gitopsservices.pipelines.openshift.io
     namespace: openshift-operators
     name: openshift-gitops-operator
-    channel: gitops-1.17
+    channel: gitops-1.18
     source: redhat-operators
     sourceNamespace: openshift-marketplace
     config:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated GitOps app version to 1.18.
  - Updated Pipelines app version to 1.20.
  - Updated subscription channels: OpenShift GitOps to gitops-1.18 and OpenShift Pipelines to pipelines-1.20.
  - Adjusted test security context to allow non-root execution in internal test configs.

- Documentation
  - Removed display of the webhook secret from installation notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->