### PR TITLE
fix: set DH container resources

### DIFF
--- a/installer/charts/tssc-dh/templates/backstage.yaml
+++ b/installer/charts/tssc-dh/templates/backstage.yaml
@@ -23,6 +23,13 @@ spec:
       spec:
         template:
           spec:
+            containers:
+              - name: backstage-backend
+                resources:
+                  requests:
+                    cpu: 250m
+                  limits:
+                    cpu: '4'
             volumes:
               - $patch: replace
                 name: dynamic-plugins-root


### PR DESCRIPTION
A user on a slower system reported that the default values were preventing DH to come up. Those new values fixed the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured CPU request (250m) and CPU limit (4 cores) for the backstage-backend container in Kubernetes deployments.
  * Improves workload predictability and reduces CPU contention for backend services.
  * No direct user-facing changes; operators will see more consistent performance and clearer capacity planning after deploying the updated chart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->