### PR TITLE
Remove dependencies in tssc-tpa/Chart.yaml

### DIFF
--- a/installer/charts/tssc-tpa/Chart.yaml
+++ b/installer/charts/tssc-tpa/Chart.yaml
@@ -9,7 +9,3 @@ annotations:
   tssc.redhat-appstudio.github.com/product-name: Trusted Profile Analyzer
   tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-infrastructure, tssc-iam, tssc-tpa-realm
   tssc.redhat-appstudio.github.com/integrations-provided: trustification
-dependencies:
-  - name: redhat-trusted-profile-analyzer
-    version: 1.1.0
-    condition: trustedProfileAnalyzer.enabled


### PR DESCRIPTION
Dependencies are not required here as TPA is using operator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the optional dependency on Red Hat Trusted Profile Analyzer from the Helm chart. Installs will no longer resolve or deploy this component, simplifying setup and reducing install time and resource usage. If your environment requires the analyzer, manage it separately and adjust your deployment configuration accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->