### PR TITLE
Adding az and gh clients to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,12 @@ COPY cmd/ ./cmd/
 COPY pkg/ ./pkg/
 COPY scripts/ ./scripts/
 COPY test/ ./test/
+COPY image/ ./image/
 COPY vendor/ ./vendor/
 
 COPY go.mod go.sum Makefile ./
 
+RUN tar -xvf ./image/gh_2.81.0_linux_amd64.tar.gz -C ./image
 RUN make test
 RUN make GOFLAGS='-buildvcs=false'
 
@@ -57,6 +59,7 @@ COPY --from=ose-tools /usr/libexec/vi /usr/libexec/
 COPY --from=builder /workdir/tssc/installer/charts ./charts
 COPY --from=builder /workdir/tssc/installer/config.yaml ./
 COPY --from=builder /workdir/tssc/bin/tssc /usr/local/bin/tssc
+COPY --from=builder /workdir/tssc/image/gh_2.81.0_linux_amd64/bin/gh /usr/local/bin/gh
 COPY --from=builder /workdir/tssc/scripts/ ./scripts/
 
 RUN groupadd --gid 999 -r tssc && \


### PR DESCRIPTION
Partially Implements [RHTAP-5709](https://issues.redhat.com//browse/RHTAP-5709)

This is needed my ci-set-org-vars.sh when using azure or github backend 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Container image now includes the GitHub CLI for streamlined automation.

- **Chores**
  - CI now exposes the GitHub token to downstream steps at runtime.
  - Azure variable-group operations moved from CLI to REST API for more reliable create/update flows.
  - Variable sets are assembled and persisted in a single update, with improved secret masking, added debug traces, and clearer failure feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->