### PR TITLE
Add tssc_integration_scaffold tool

### DIFF
--- a/pkg/mcpserver/instructions.md
+++ b/pkg/mcpserver/instructions.md
@@ -34,9 +34,9 @@ In this phase, you will help configure the necessary integrations by scaffolding
 
 If integrations are missing, inspect the result to identify which integration names are missing.
 
-1. Use `tssc_status` to view the overall installer status.
-2. Use `tssc_integration_list` to see all available integration types.
-3. Use `tssc_integration_scaffold` to generate the command for configuring a specific integration. You will need to run this command manually in your terminal for security reasons.
+1. Use `tssc_status` to view the overall installer status. If integrations are missing, the result will contain CEL (Common Expression Language) expressions. Inspect the expression result to determine which integrations are missing. For example, an expression like `(github || gitlab) && acs && trustification` means the integrations acs and `trustification` are mandatory, while the user can choose between `github` or `gitlab`. Use `tssc_integration_list` to inspect the valid integration names and LLM should list the mandantory integrations, as well as the ones users should choose from.
+2. Use `tssc_integration_list` to see all available integration types. If itegrations are missing, informations about what integrations are missing should be provided, e.g. what integrations are mandatory, at lease one of what integrations should be chosen. LLM client should ask users to input the integration name that they want to configure, and use `tssc_integration_scaffold` to generate the example command.
+3. Use `tssc_integration_scaffold` to generate the command for configuring a specific integration. Before call this tool,  and the integration name will be the input parameter for tool `tssc_integration_scaffold`. And LLM client is not allowed to run the command, so you will need to copy-and-paste this command and run it manually in your terminal for security reasons.
 4. Use `tssc_integration_status` to check if an integration has been configured correctly.
 
 Completing this step is a prerequisite for deployment.
@@ -46,7 +46,7 @@ Completing this step is a prerequisite for deployment.
 Once configuration and integrations are complete, you can deploy RHADS.
 
 1. Use `tssc_status` to view the overall installer status.
-2. Use `tssc_deploy` to start the deployment. This will create a Kubernetes Job to run the installation.
+2. Use `tssc_deploy` to start the deployment. This will create a Kubernetes Job to run the installation. Before deployment starts, integration status will be checked. If integrations are missing, the result will contain CEL (Common Expression Language) expressions. Inspect the expression result to determine which integrations are missing. For example, an expression like `(github || gitlab) && acs && trustification` means the integrations `acs` and `trustification` are mandatory, while the user can choose between `github` or `gitlab`. Use `tssc_integration_list` to inspect the valid integration names.
 3. Use `tssc_status` to monitor the progress of the deployment.
 
 I will guide you with suggestions for the next logical action in my responses. Let's get started!

--- a/pkg/mcptools/integrationtools.go
+++ b/pkg/mcptools/integrationtools.go
@@ -17,8 +17,15 @@ type IntegrationTools struct {
 	integrationCmd *cobra.Command // integration subcommand
 }
 
-// IntegrationListTool list integrations tool.
-const IntegrationListTool = "tssc_integration_list"
+const (
+	// IntegrationListTool list integrations tool.
+	IntegrationListTool = constants.AppName + "_integration_list"
+	// IntegrationScaffoldTool generates the `tssc integration` command
+	// required to configure the integration type
+	IntegrationScaffoldTool = constants.AppName + "_integration_scaffold"
+	// MandatoryIntegrations missing integrations that are mandatory
+	MissingIntegration = "integration"
+)
 
 func (i *IntegrationTools) listHandler(
 	ctx context.Context,
@@ -72,6 +79,64 @@ The detailed description of each '%s integration' command is found below.
 	return mcp.NewToolResultText(output.String()), nil
 }
 
+// generateIntegrationCmd creates a command string for configuring an integration
+func generateIntegrationCmd(subCmd *cobra.Command) string {
+	var exampleCmd strings.Builder
+	exampleCmd.WriteString(fmt.Sprintf("\n $ tssc integration %s \\\n", subCmd.Name()))
+
+	var flags []string
+	subCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		if annotations, ok := f.Annotations[cobra.BashCompOneRequiredFlag]; ok &&
+			len(annotations) > 0 && annotations[0] == "true" {
+			flags = append(flags, f.Name)
+		}
+	})
+
+	for idx, flagName := range flags {
+		if idx == len(flags)-1 {
+			exampleCmd.WriteString(fmt.Sprintf(" --%s=\"REDACTED\"\n", flagName))
+		} else {
+			exampleCmd.WriteString(fmt.Sprintf(" --%s=\"REDACTED\" \\\n", flagName))
+		}
+	}
+
+	return fmt.Sprintf(`
+### Command to configure integration %s
+%s:
+
+%s
+`, subCmd.Name(), subCmd.Short, exampleCmd.String())
+}
+
+func (i *IntegrationTools) scaffoldHandler(
+	ctx context.Context,
+	ctr mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	var output strings.Builder
+	var integration string
+
+	output.WriteString(`
+# Some integrations are missing, example commands will be provided.
+  1. Copy and paste the commands in the terminal
+  2. Replace "REDACTED" with your actual credentials
+  3. Run the commands to configure the integrations
+  4. Configure all the MANDATORY integrations
+  5. Configure one of the OPTIONAL integrations
+`)
+
+	if i, ok := ctr.GetArguments()[MissingIntegration].(string); ok {
+		integration = i
+	}
+
+	for _, subCmd := range i.integrationCmd.Commands() {
+		if subCmd.Name() == integration {
+			output.WriteString(generateIntegrationCmd(subCmd))
+		}
+	}
+
+	return mcp.NewToolResultText(output.String()), nil
+}
+
 func (i *IntegrationTools) Init(s *server.MCPServer) {
 	s.AddTools([]server.ServerTool{{
 		Tool: mcp.NewTool(
@@ -82,7 +147,23 @@ required for certain features, make sure to configure the integrations
 accordingly.`),
 		),
 		Handler: i.listHandler,
-	}}...)
+	},
+		{
+			Tool: mcp.NewTool(
+				IntegrationScaffoldTool,
+				mcp.WithDescription(`
+Scaffold the configuration required for a specific TSSC integration. The
+scaffolded configuration can be used as a reference to create the integration
+using the 'tssc integration <name> ...' command.`),
+				mcp.WithString(
+					MissingIntegration,
+					mcp.Description(`
+The missing integrations that are mandatory for deployment.`,
+					),
+				),
+			),
+			Handler: i.scaffoldHandler,
+		}}...)
 }
 
 func NewIntegrationTools(integrationCmd *cobra.Command) *IntegrationTools {


### PR DESCRIPTION
Add tssc_integration_scaffold to list and give example commands of the missing integrations.
Jira: https://issues.redhat.com/browse/RHTAP-5328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Integration Scaffold tool that detects missing integrations, groups mandatory vs. optional, and generates example scaffold commands and step‑by‑step guidance for users to copy and run manually.
  * Integration listing remains available with improved naming consistency.

* **Documentation**
  * Clarified how to interpret status expressions that indicate missing integrations and emphasized scaffold commands must be executed manually (the client will not run them).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->