### PR TITLE
RHTAP-5316: Granular set of MCP Configuration Tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
+	dario.cat/mergo v1.0.2
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/google/cel-go v0.26.1
 	github.com/google/go-github/scrape v0.0.0-20251008171934-06b8b3a37d13
@@ -29,7 +30,6 @@ require (
 
 require (
 	cel.dev/expr v0.24.0 // indirect
-	dario.cat/mergo v1.0.2 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
@@ -170,4 +170,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.13.0
+replace (
+	github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.13.0
+	github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
+)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,9 +31,10 @@ type Spec struct {
 
 // Config root configuration structure.
 type Config struct {
-	cfs       *chartfs.ChartFS // embedded filesystem
-	Installer Spec             `yaml:"tssc"` // root configuration for the installer
-	root      yaml.Node        // yaml data representation
+	cfs  *chartfs.ChartFS // embedded filesystem
+	root yaml.Node        // yaml data representation
+
+	Installer Spec `yaml:"tssc"` // root configuration for the installer
 }
 
 var (
@@ -116,6 +117,83 @@ func (c *Config) DecodeNode() error {
 	return nil
 }
 
+// Set returns new configuration with updates
+func (c *Config) Set(key string, configData any) error {
+	keyPaths, err := FlattenMap(configData, key)
+	if err != nil {
+		return err
+	}
+
+	for keyPath, value := range keyPaths {
+		keys := strings.Split(keyPath, ".")
+		if err = UpdateNestedValue(&c.root, keys, value); err != nil {
+			return err
+		}
+	}
+
+	return c.DecodeNode()
+}
+
+// SetProduct updates an existing product specification in the configuration. It
+// searches for a product by its name and, if found, replaces its specification
+// with the provided `spec`. The configuration is then re-decoded to reflect the
+// changes.
+func (c *Config) SetProduct(name string, spec Product) error {
+	if len(c.root.Content) == 0 {
+		return fmt.Errorf("invalid configuration: content is empty")
+	}
+	doc := c.root.Content[0]
+
+	var tsscNode *yaml.Node
+	for i := 0; i+1 < len(doc.Content); i += 2 {
+		if doc.Content[i].Value == "tssc" {
+			tsscNode = doc.Content[i+1]
+			break
+		}
+	}
+	if tsscNode == nil {
+		return fmt.Errorf("invalid configuration: missing 'tssc' key")
+	}
+
+	var productsNode *yaml.Node
+	for i := 0; i+1 < len(tsscNode.Content); i += 2 {
+		if tsscNode.Content[i].Value == "products" {
+			productsNode = tsscNode.Content[i+1]
+			break
+		}
+	}
+	if productsNode == nil {
+		return fmt.Errorf("invalid configuration: missing 'products' key")
+	}
+
+	if productsNode.Kind != yaml.SequenceNode {
+		return fmt.Errorf("'products' is not a sequence")
+	}
+
+	for i, productNode := range productsNode.Content {
+		// Each productNode is a MappingNode
+		var productName string
+		for j := 0; j+1 < len(productNode.Content); j += 2 {
+			if productNode.Content[j].Value == "name" {
+				productName = productNode.Content[j+1].Value
+				break
+			}
+		}
+
+		// Found it. Replace the node.
+		if productName == name {
+			var newNode yaml.Node
+			if err := newNode.Encode(&spec); err != nil {
+				return fmt.Errorf("failed to encode product spec: %w", err)
+			}
+			productsNode.Content[i] = &newNode
+			return c.DecodeNode()
+		}
+	}
+
+	return fmt.Errorf("product %q not found", name)
+}
+
 // MarshalYAML marshals the Config into a YAML byte array.
 func (c *Config) MarshalYAML() ([]byte, error) {
 	var buf bytes.Buffer
@@ -154,178 +232,6 @@ func (c *Config) String() string {
 		panic(err)
 	}
 	return string(data)
-}
-
-// UpdateMappingValue updates configuration with new value
-func (c *Config) UpdateMappingValue(node *yaml.Node, key string, newValue any) error {
-	switch node.Kind {
-	case yaml.DocumentNode:
-		if len(node.Content) > 0 {
-			return c.UpdateMappingValue(node.Content[0], key, newValue)
-		}
-		// Create root mapping
-		mappingNode := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{}}
-		node.Content = []*yaml.Node{mappingNode}
-		return c.UpdateMappingValue(mappingNode, key, newValue)
-
-	case yaml.MappingNode:
-		// Find existing key
-		for i := 0; i < len(node.Content); i += 2 {
-			if node.Content[i].Value == key {
-				// Rebuild value node to preserve types.
-				var doc yaml.Node
-				bs, err := yaml.Marshal(newValue)
-				if err != nil {
-					return err
-				}
-				if err := yaml.Unmarshal(bs, &doc); err != nil {
-					return err
-				}
-				if len(doc.Content) == 0 {
-					return fmt.Errorf("invalid new value for key %q", key)
-				}
-				node.Content[i+1] = doc.Content[0]
-				return nil
-			}
-		}
-		return nil
-	default:
-		return fmt.Errorf("cannot set value on node kind: %v", node.Kind)
-	}
-}
-
-// UpdateNestedValue loops in node contents to get the node that needs update
-func (c *Config) UpdateNestedValue(node *yaml.Node, path []string, newValue any) error {
-	if len(path) == 0 {
-		return fmt.Errorf("config path is missing")
-	}
-	if len(path) == 1 {
-		return c.UpdateMappingValue(node, path[0], newValue)
-	}
-	key := path[0]
-	remainingKeys := path[1:]
-
-	switch node.Kind {
-	case yaml.DocumentNode:
-		if len(node.Content) > 0 {
-			return c.UpdateNestedValue(node.Content[0], path, newValue)
-		}
-		return fmt.Errorf("invalid config content")
-
-	case yaml.MappingNode:
-		for i := 0; i < len(node.Content); i += 2 {
-			if strings.EqualFold(node.Content[i].Value, key) {
-				return c.UpdateNestedValue(node.Content[i+1], remainingKeys, newValue)
-			}
-		}
-		return fmt.Errorf("key not found: %s", key)
-
-	default:
-		return fmt.Errorf("cannot navigate through node kind: %v", node.Kind)
-	}
-}
-
-// UpdateNestedValues gets the config content and call UpdateNestedValue to update
-func (c *Config) UpdateNestedValues(path string, newValue any) error {
-	keys := strings.Split(path, ".")
-	return c.UpdateNestedValue(&c.root, keys, newValue)
-}
-
-func (c *Config) FindNode(node *yaml.Node, key string) (*yaml.Node, error) {
-	if key != "products" {
-		return nil, fmt.Errorf("key must be 'products'")
-	}
-	current := node
-
-	switch current.Kind {
-	case yaml.DocumentNode:
-		if len(current.Content) == 0 {
-			return nil, fmt.Errorf("empty document")
-		}
-		current = current.Content[0]
-		return c.FindNode(current, key)
-	case yaml.MappingNode:
-		for i := 0; i < len(current.Content); i += 2 {
-			keyNode := current.Content[i]
-			valueNode := current.Content[i+1]
-			if keyNode.Value == key {
-				return valueNode, nil
-			}
-		}
-		for i := 1; i < len(current.Content); i += 2 {
-			result, err := c.FindNode(current.Content[i], key)
-			if err == nil && result != nil {
-				return result, nil
-			}
-		}
-		return nil, fmt.Errorf("key %q not found", key)
-	default:
-		return nil, fmt.Errorf("cannot find config: %v", key)
-	}
-}
-
-// Update product by name (example of custom update logic)
-func (c *Config) UpdateProductByName(productName any, keyPath string, value interface{}) error {
-	if strings.TrimSpace(keyPath) == "" {
-		return fmt.Errorf("config path is missing")
-	}
-	keys := strings.Split(keyPath, ".")
-	pn, ok := productName.(string)
-	if !ok {
-		return fmt.Errorf("product name must be a string, got %T", productName)
-	}
-	productsNode, err := c.FindNode(&c.root, "products")
-	if err != nil {
-		return err
-	}
-	if productsNode.Kind != yaml.SequenceNode {
-		return fmt.Errorf("config of products is not an array")
-	}
-	for _, productNode := range productsNode.Content {
-		if productNode.Kind == yaml.MappingNode {
-			for i := 0; i < len(productNode.Content); i += 2 {
-				if productNode.Content[i].Value == "name" && strings.EqualFold(productNode.Content[i+1].Value, pn) {
-					return c.UpdateNestedValue(productNode, keys, value)
-				}
-			}
-		}
-	}
-	return fmt.Errorf("product not found: %q", pn)
-}
-
-// Set returns new configuration with updates
-func (c *Config) Set(key string, configData any) error {
-	var keyPaths map[string]any
-	var err error
-	if strings.Contains(key, "products") {
-		prodKeyPaths, err := ExtractProductSettings(configData)
-		if err != nil {
-			return err
-		}
-		for _, prodKeyPath := range prodKeyPaths {
-			if name, exists := prodKeyPath["name"]; exists {
-				delete(prodKeyPath, "name")
-				for keyPath, value := range prodKeyPath {
-					if err = c.UpdateProductByName(name, keyPath, value); err != nil {
-						return err
-					}
-				}
-			} else {
-				return fmt.Errorf("product config without name is not supported")
-			}
-		}
-	} else {
-		keyPaths, err = FlattenMap(configData, key)
-		if err != nil {
-			return err
-		}
-		for keyPath, value := range keyPaths {
-			if err = c.UpdateNestedValues(keyPath, value); err != nil {
-				return err
-			}
-		}
-	}
-	return c.DecodeNode()
 }
 
 // NewConfigFromFile returns a new Config instance based on the informed file.

--- a/pkg/config/extract.go
+++ b/pkg/config/extract.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"fmt"
+	"maps"
+	"strings"
+)
+
+var ProdNames = map[string]string{
+	"ACS":       "Advanced Cluster Security",
+	"TAS":       "Trusted Artifact Signer",
+	"GITOPS":    "OpenShift GitOps",
+	"DH":        "Developer Hub",
+	"TPA":       "Trusted Profile Analyzer",
+	"PIPELINES": "OpenShift Pipelines",
+}
+
+func ValueExists(m map[string]string, searchValue string) bool {
+	for _, value := range m {
+		if value == searchValue {
+			return true
+		}
+	}
+	return false
+}
+
+func ExtractProductSettings(input any) ([]map[string]any, error) {
+	var output []map[string]any
+	// subConfig := make(map[string]any)
+	switch prodConf := input.(type) {
+	case map[string]any:
+		for key, value := range prodConf {
+			item := make(map[string]any)
+			keyUpper := strings.ToUpper(key)
+			if prodName, exists := ProdNames[keyUpper]; exists {
+				item["name"] = prodName
+				config, err := FlattenMap(value, "")
+				if err != nil {
+					return nil, fmt.Errorf("failed to flatten config for product %s: %w", prodName, err)
+				}
+				if _, ok := config["name"]; ok {
+					return nil, fmt.Errorf("invalid product config: top-level key %q is reserved", "name")
+				}
+				maps.Copy(item, config)
+			} else if ValueExists(ProdNames, key) {
+				item["name"] = key
+				config, err := FlattenMap(value, "")
+				if err != nil {
+					return nil, fmt.Errorf("failed to flatten config for product %s: %w", key, err)
+				}
+				if _, ok := config["name"]; ok {
+					return nil, fmt.Errorf("invalid product config: top-level key %q is reserved", "name")
+				}
+				maps.Copy(item, config)
+			} else {
+				return nil, fmt.Errorf("invalid config for products")
+			}
+			output = append(output, item)
+		}
+	default:
+		return nil, fmt.Errorf("product configuration must be map[string]any")
+	}
+	return output, nil
+}
+
+func ConvertStringMapToAny(m map[string]string) map[string]any {
+	result := make(map[string]any)
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+func FlattenMapRecursive(input map[string]any, prefix string, output map[string]any) {
+	for key, value := range input {
+		newKey := key
+		if prefix != "" {
+			newKey = prefix + "." + newKey
+		}
+		switch v := value.(type) {
+		case map[string]any:
+			FlattenMapRecursive(v, newKey, output)
+		case map[string]string:
+			newMap := ConvertStringMapToAny(v)
+			FlattenMapRecursive(newMap, newKey, output)
+		default:
+			output[newKey] = value
+		}
+	}
+}
+
+func FlattenMap(input any, prefix string) (map[string]interface{}, error) {
+	output := make(map[string]interface{})
+	switch config := input.(type) {
+	case string:
+		output[prefix] = config
+	case map[string]any:
+		FlattenMapRecursive(config, prefix, output)
+	default:
+		return nil, fmt.Errorf("not supported config format")
+	}
+	return output, nil
+}

--- a/pkg/config/extract.go
+++ b/pkg/config/extract.go
@@ -1,68 +1,6 @@
 package config
 
-import (
-	"fmt"
-	"maps"
-	"strings"
-)
-
-var ProdNames = map[string]string{
-	"ACS":       "Advanced Cluster Security",
-	"TAS":       "Trusted Artifact Signer",
-	"GITOPS":    "OpenShift GitOps",
-	"DH":        "Developer Hub",
-	"TPA":       "Trusted Profile Analyzer",
-	"PIPELINES": "OpenShift Pipelines",
-}
-
-func ValueExists(m map[string]string, searchValue string) bool {
-	for _, value := range m {
-		if value == searchValue {
-			return true
-		}
-	}
-	return false
-}
-
-func ExtractProductSettings(input any) ([]map[string]any, error) {
-	var output []map[string]any
-	// subConfig := make(map[string]any)
-	switch prodConf := input.(type) {
-	case map[string]any:
-		for key, value := range prodConf {
-			item := make(map[string]any)
-			keyUpper := strings.ToUpper(key)
-			if prodName, exists := ProdNames[keyUpper]; exists {
-				item["name"] = prodName
-				config, err := FlattenMap(value, "")
-				if err != nil {
-					return nil, fmt.Errorf("failed to flatten config for product %s: %w", prodName, err)
-				}
-				if _, ok := config["name"]; ok {
-					return nil, fmt.Errorf("invalid product config: top-level key %q is reserved", "name")
-				}
-				maps.Copy(item, config)
-			} else if ValueExists(ProdNames, key) {
-				item["name"] = key
-				config, err := FlattenMap(value, "")
-				if err != nil {
-					return nil, fmt.Errorf("failed to flatten config for product %s: %w", key, err)
-				}
-				if _, ok := config["name"]; ok {
-					return nil, fmt.Errorf("invalid product config: top-level key %q is reserved", "name")
-				}
-				maps.Copy(item, config)
-			} else {
-				return nil, fmt.Errorf("invalid config for products")
-			}
-			output = append(output, item)
-		}
-	default:
-		return nil, fmt.Errorf("product configuration must be map[string]any")
-	}
-	return output, nil
-}
-
+// ConvertStringMapToAny converts a map[string]string to a map[string]any.
 func ConvertStringMapToAny(m map[string]string) map[string]any {
 	result := make(map[string]any)
 	for k, v := range m {
@@ -71,7 +9,14 @@ func ConvertStringMapToAny(m map[string]string) map[string]any {
 	return result
 }
 
-func FlattenMapRecursive(input map[string]any, prefix string, output map[string]any) {
+// FlattenMapRecursive recursively flattens a nested map[string]any into a
+// single-level map. Keys are concatenated with dots to represent their original
+// hierarchy ("key path").
+func FlattenMapRecursive(
+	input map[string]any,
+	prefix string,
+	output map[string]any,
+) {
 	for key, value := range input {
 		newKey := key
 		if prefix != "" {
@@ -89,15 +34,17 @@ func FlattenMapRecursive(input map[string]any, prefix string, output map[string]
 	}
 }
 
+// FlattenMap flattens a given input into a single-level map.  If the input is a
+// map[string]any, it calls FlattenMapRecursive to flatten it, using the provided
+// prefix for keys. If the input is not a map, it treats the entire input as a
+// single value and assigns it to the given prefix.
 func FlattenMap(input any, prefix string) (map[string]interface{}, error) {
 	output := make(map[string]interface{})
 	switch config := input.(type) {
-	case string:
-		output[prefix] = config
 	case map[string]any:
 		FlattenMapRecursive(config, prefix, output)
 	default:
-		return nil, fmt.Errorf("not supported config format")
+		output[prefix] = input
 	}
 	return output, nil
 }

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -76,6 +76,10 @@ func UpdateMappingValue(node *yaml.Node, key string, newValue any) error {
 			if node.Content[i].Value != key {
 				continue
 			}
+
+			// Preserve anchor on the old value.
+			oldValue := node.Content[i+1]
+
 			// Rebuild value node to preserve types.
 			var doc yaml.Node
 			bs, err := yaml.Marshal(newValue)
@@ -88,7 +92,12 @@ func UpdateMappingValue(node *yaml.Node, key string, newValue any) error {
 			if len(doc.Content) == 0 {
 				return fmt.Errorf("invalid new value for key %q", key)
 			}
-			node.Content[i+1] = doc.Content[0]
+
+			// Replace node and preserve anchor.
+			newValueNode := doc.Content[0]
+			newValueNode.Anchor = oldValue.Anchor
+			node.Content[i+1] = newValueNode
+
 			return nil
 		}
 		return nil

--- a/pkg/config/node.go
+++ b/pkg/config/node.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FindNode searches for a specific key within a YAML node structure.
+//
+// It traverses the YAML node structure:
+//   - If the node is a DocumentNode, it unwraps to its first content node and
+//     recurses.
+//   - If the node is a MappingNode, it first checks if the key exists directly
+//     within the current mapping. If not found, it recursively searches
+//     within the values of the current mapping.
+//   - For any other node kind, it returns an error.
+//
+// Returns the yaml.Node corresponding to the found key's value, or an error
+// if the key is not found, or the node kind is unsupported.
+func FindNode(node *yaml.Node, key string) (*yaml.Node, error) {
+	current := node
+
+	switch current.Kind {
+	case yaml.DocumentNode:
+		if len(current.Content) == 0 {
+			return nil, fmt.Errorf("empty document")
+		}
+		current = current.Content[0]
+		return FindNode(current, key)
+	case yaml.MappingNode:
+		for i := 0; i < len(current.Content); i += 2 {
+			keyNode := current.Content[i]
+			valueNode := current.Content[i+1]
+			if keyNode.Value == key {
+				return valueNode, nil
+			}
+		}
+		for i := 1; i < len(current.Content); i += 2 {
+			result, err := FindNode(current.Content[i], key)
+			if err == nil && result != nil {
+				return result, nil
+			}
+		}
+		return nil, fmt.Errorf("key %q not found", key)
+	default:
+		return nil, fmt.Errorf("cannot find config: %v", key)
+	}
+}
+
+// UpdateMappingValue updates a key's value within a YAML mapping node.
+//
+// It traverses the YAML node structure:
+//   - If the node is a DocumentNode, it delegates to its first content node.
+//     If the DocumentNode is empty, it creates a root mapping node.
+//   - If the node is a MappingNode, it searches for the specified key.
+//     If found, it marshals the newValue to YAML and unmarshals it back
+//     into a new yaml.Node to preserve type fidelity, then replaces the
+//     existing value node. If the key is not found, it returns nil.
+//   - For any other node kind, it returns an error.
+func UpdateMappingValue(node *yaml.Node, key string, newValue any) error {
+	switch node.Kind {
+	case yaml.DocumentNode:
+		if len(node.Content) > 0 {
+			return UpdateMappingValue(node.Content[0], key, newValue)
+		}
+		// Create root mapping.
+		mappingNode := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{}}
+		node.Content = []*yaml.Node{mappingNode}
+		return UpdateMappingValue(mappingNode, key, newValue)
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			// Find existing key.
+			if node.Content[i].Value != key {
+				continue
+			}
+			// Rebuild value node to preserve types.
+			var doc yaml.Node
+			bs, err := yaml.Marshal(newValue)
+			if err != nil {
+				return err
+			}
+			if err := yaml.Unmarshal(bs, &doc); err != nil {
+				return err
+			}
+			if len(doc.Content) == 0 {
+				return fmt.Errorf("invalid new value for key %q", key)
+			}
+			node.Content[i+1] = doc.Content[0]
+			return nil
+		}
+		return nil
+	default:
+		return fmt.Errorf("cannot set value on node kind: %v", node.Kind)
+	}
+}
+
+// UpdateNestedValue updates a value deep within a YAML node structure by
+// traversing a given path of keys. The path of keys represents the hierarchy of
+// the yaml.Node structure.
+//
+// It handles different node kinds and path lengths:
+//   - If the path is empty, it returns an error.
+//   - If the path contains only one key, it delegates to UpdateMappingValue.
+//   - If the node is a DocumentNode, it unwraps to its first content node and
+//     recurses.
+//   - If the node is a MappingNode, it iterates through its content to find the
+//     first key in the path. If found, it recursively calls itself on the
+//     corresponding value node with the rest of the path. If the key is not
+//     found, it returns an error.
+//   - For any other node kind, it returns an error, as navigation is not
+//     possible.
+func UpdateNestedValue(node *yaml.Node, keyPath []string, newValue any) error {
+	if len(keyPath) == 0 {
+		return fmt.Errorf("config path is missing")
+	}
+	if len(keyPath) == 1 {
+		return UpdateMappingValue(node, keyPath[0], newValue)
+	}
+	key := keyPath[0]
+	remainingKeys := keyPath[1:]
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		if len(node.Content) > 0 {
+			return UpdateNestedValue(node.Content[0], keyPath, newValue)
+		}
+		return fmt.Errorf("invalid config content")
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			if strings.EqualFold(node.Content[i].Value, key) {
+				return UpdateNestedValue(
+					node.Content[i+1], remainingKeys, newValue)
+			}
+		}
+		return fmt.Errorf("key not found: %s", key)
+	case yaml.SequenceNode:
+		index, err := strconv.Atoi(key)
+		if err != nil {
+			return fmt.Errorf("invalid array index: %q", key)
+		}
+		if index < 0 || index >= len(node.Content) {
+			return fmt.Errorf("array index out of bounds: %d", index)
+		}
+		return UpdateNestedValue(node.Content[index], remainingKeys, newValue)
+	default:
+		return fmt.Errorf("cannot navigate through node kind: %v", node.Kind)
+	}
+}

--- a/pkg/mcpserver/instructions.md
+++ b/pkg/mcpserver/instructions.md
@@ -28,6 +28,17 @@ This is the starting point. You must define the installation configuration.
 
 Once the configuration is successfully applied, we will proceed to the next phase.
 
+#### Configuration Tools
+
+The following tools are available to manage the installer configuration. You must **always** run `tssc_config_get` first to understand the current state before making any changes.
+
+- `tssc_config_get`: Retrieves the current TSSC configuration from the cluster. If no configuration exists, it returns the default configuration, which you can use as a template.
+- `tssc_config_init`: Initializes the cluster with the default TSSC configuration. You can provide a namespace where the installer and its components will be deployed.
+- `tssc_config_settings`: Updates a global setting by specifying a `key` and `value` under the `.tssc.settings` path.
+- `tssc_config_product_enabled`: Enables or disables a specific product (e.g., "Trusted Artifact Signer" or "TAS").
+- `tssc_config_product_namespace`: Assigns a dedicated namespace to a product.
+- `tssc_config_product_properties`: Updates a product's specific properties under its `.properties` key.
+
 ### Phase 2: Integrations (`AWAITING_INTEGRATIONS`)
 
 In this phase, you will help configure the necessary integrations by scaffolding the integration commands. All `tssc integration` subcommands handle sensitive information and must be executed in a secure environment, such as a dedicated shell session outside of the MCP/LLM context.

--- a/pkg/mcptools/configtools.go
+++ b/pkg/mcptools/configtools.go
@@ -37,6 +37,8 @@ const (
 	NamespaceArg = "namespace"
 	// SettingsArg settings argument.
 	SettingsArg = "setting"
+	// ProductsArg products argument.
+	ProductsArg = "product"
 )
 
 // getHandler similar to "tssc config --get" subcommand it returns a existing TSSC
@@ -98,10 +100,22 @@ func (c *ConfigTools) createHandler(
 	// Setting the namespace from user input, if provided.
 	if ns, ok := ctr.GetArguments()[NamespaceArg].(string); ok {
 		cfg.Installer.Namespace = ns
+		// Set namespace to value of ns
+		if err := cfg.Set("tssc.namespace", ns); err != nil {
+			return nil, err
+		}
 	}
 
-	if settings, ok := ctr.GetArguments()[SettingsArg].(config.Settings); ok {
-		cfg.Installer.Settings = settings
+	if settings, ok := ctr.GetArguments()[SettingsArg].(map[string]interface{}); ok {
+		if err := cfg.Set("tssc.settings", settings); err != nil {
+			return nil, err
+		}
+	}
+
+	if products, ok := ctr.GetArguments()[ProductsArg].(map[string]interface{}); ok {
+		if err := cfg.Set("tssc.products", products); err != nil {
+			return nil, err
+		}
 	}
 
 	// Ensure the configuration is valid.
@@ -173,6 +187,13 @@ and other fundamental services will be deployed.`,
 				mcp.Description(`
 The global settings object for TSSC ('.tssc.settings{}'). When empty the default
 settings will be used.
+				`),
+			),
+			mcp.WithObject(
+				ProductsArg,
+				mcp.Description(`
+The settings object for TSSC ('.tssc.products{}'). When empty the default config
+will be used.
 				`),
 			),
 		),

--- a/pkg/mcptools/configtools.go
+++ b/pkg/mcptools/configtools.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redhat-appstudio/tssc-cli/pkg/constants"
 	"github.com/redhat-appstudio/tssc-cli/pkg/k8s"
 
+	"dario.cat/mergo"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -32,21 +33,24 @@ const (
 	ConfigGetTool = constants.AppName + "_config_get"
 	// ConfigInitTool initializes the cluster configuration.
 	ConfigInitTool = constants.AppName + "_config_init"
-	// ConfigSetSettings manipulates global settings.
-	ConfigSetSettings = constants.AppName + "_set_settings"
-	// ConfigSetProductEnabled manipulates the status of a product.
-	ConfigSetProductEnabled = constants.AppName + "_set_product_enabled"
-	// ConfigSetProductNamespace manipulates the namespace of a product.
-	ConfigSetProductNamespace = constants.AppName + "_set_product_namespace"
-	// ConfigSetProductProperties manipulates the properties of a product.
-	ConfigSetProductProperties = constants.AppName + "_set_product_properties"
+	// ConfigSettings manipulates global settings.
+	ConfigSettings = constants.AppName + "_config_settings"
+	// ConfigProductEnabled manipulates the status of a product.
+	ConfigProductEnabled = constants.AppName + "_config_product_enabled"
+	// ConfigProductNamespace manipulates the namespace of a product.
+	ConfigProductNamespace = constants.AppName + "_config_product_namespace"
+	// ConfigProductProperties manipulates the properties of a product.
+	ConfigProductProperties = constants.AppName + "_config_product_properties"
+)
 
-	// NamespaceArg namespace argument.
-	NamespaceArg = "namespace"
-	// SettingsArg settings argument.
-	SettingsArg = "setting"
-	// ProductsArg products argument.
-	ProductsArg = "product"
+// Arguments for the config tools.
+const (
+	NamespaceArg  = "namespace"
+	KeyArg        = "key"
+	ValueArg      = "value"
+	NameArg       = "name"
+	EnabledArg    = "enabled"
+	PropertiesArg = "properties"
 )
 
 // getHandler similar to "tssc config --get" subcommand it returns a existing TSSC
@@ -83,17 +87,14 @@ func (c *ConfigTools) getHandler(
 		return nil, err
 	}
 
-	// TODO: include the name of the other config functions as a reference here.
-	return mcp.NewToolResultText(
-		fmt.Sprintf(`
+	return mcp.NewToolResultText(fmt.Sprintf(`
 There's no TSSC configuration in the cluster yet. As the platform engineer,
 carefully consider the default YAML configuration below.
 
 ---
 %s`,
-			payload,
-		),
-	), nil
+		payload,
+	)), nil
 }
 
 // initHandler initializes the cluster configuration using defaults.
@@ -140,9 +141,284 @@ func (c *ConfigTools) initHandler(
 		return nil, err
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf(
-		`TSSC default configuration is successfully applied in %q namespace`,
+	return mcp.NewToolResultText(fmt.Sprintf(`
+TSSC default configuration is successfully applied in %q namespace`,
 		cfg.Installer.Namespace,
+	)), nil
+}
+
+// getConfig Retrieving the existing configuration from the cluster.
+func (c *ConfigTools) getConfig(
+	ctx context.Context,
+) (*config.Config, *mcp.CallToolResult) {
+	cfg, err := c.cm.GetConfig(ctx)
+	if err != nil {
+		return nil, mcp.NewToolResultErrorFromErr(`
+Unable to retrieve the configuration from the cluster!`,
+			err,
+		)
+	}
+	return cfg, nil
+}
+
+// configSettingsHandler handles the configuration settings update request. It
+// retrieves the current configuration, merges the provided settings (from the
+// 'settings' argument) into the existing installer settings, and updates the
+// cluster configuration.
+func (c *ConfigTools) configSettingsHandler(
+	ctx context.Context,
+	ctr mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	key, ok := ctr.GetArguments()[KeyArg].(string)
+	if !ok || key == "" {
+		return mcp.NewToolResultErrorf(`
+You must inform the %q argument with the name of the attribute to update!`,
+			KeyArg,
+		), nil
+	}
+	value, ok := ctr.GetArguments()[ValueArg].(bool)
+	if !ok {
+		return mcp.NewToolResultErrorf(`
+You must inform the %q argument with the value for the informed key %q!`,
+			ValueArg,
+			key,
+		), nil
+	}
+
+	cfg, res := c.getConfig(ctx)
+	if res != nil {
+		return res, nil
+	}
+
+	// Updating the configuration instance and the cluster.
+	err := cfg.Set(fmt.Sprintf("tssc.settings.%s", key), value)
+	if err != nil {
+		return mcp.NewToolResultErrorf(`
+Unable to update the existing configuration with informed settings:
+
+    Key: %q
+  Value: %v
+  Error: %s`,
+			key,
+			value,
+			err,
+		), nil
+	}
+	if err = c.cm.Update(ctx, cfg); err != nil {
+		return mcp.NewToolResultErrorFromErr(`
+Unable to update the cluster configuration!
+`,
+			err,
+		), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf(`
+The cluster is now using the following '.tssc.settings':
+
+%v`,
+		cfg.Installer.Settings,
+	)), nil
+}
+
+// getProduct get the product from the configuration, or returns the MCP error.
+func (c *ConfigTools) getProduct(
+	cfg *config.Config,
+	name string,
+) (*config.Product, *mcp.CallToolResult) {
+	spec, err := cfg.GetProduct(name)
+	if err != nil {
+		return nil, mcp.NewToolResultErrorf(`
+Unable to find the product name %q: %q`,
+			name,
+			err,
+		)
+	}
+	return spec, nil
+}
+
+// setProduct updates the product configuration by name,using the provided spec
+// and persists the changes to the cluster configuration.
+func (c *ConfigTools) setProduct(
+	ctx context.Context,
+	cfg *config.Config,
+	name string,
+	spec config.Product,
+) *mcp.CallToolResult {
+	err := cfg.SetProduct(name, spec)
+	if err != nil {
+		return mcp.NewToolResultErrorf(`
+Unable to update product %q: %q`,
+			name,
+			err,
+		)
+	}
+	if err = c.cm.Update(ctx, cfg); err != nil {
+		return mcp.NewToolResultErrorFromErr(`
+Unable to update the cluster configuration!
+`,
+			err,
+		)
+	}
+	return nil
+}
+
+// configProductEnableHandler handles requests to enable or disable a specific
+// product within the cluster configuration. It requires the 'name' (product name)
+// and 'enabled' (boolean status) arguments.
+func (c *ConfigTools) configProductEnableHandler(
+	ctx context.Context,
+	ctr mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	name, ok := ctr.GetArguments()[NameArg].(string)
+	if !ok {
+		return mcp.NewToolResultErrorf(`
+You must inform the product name %q argument, in order to toggle its status.`,
+			NameArg,
+		), nil
+	}
+	enabled, ok := ctr.GetArguments()[EnabledArg].(bool)
+	if !ok {
+		return mcp.NewToolResultErrorf(`
+You must inform the %q argument, with the status of the product %q`,
+			EnabledArg,
+			name,
+		), nil
+	}
+
+	cfg, res := c.getConfig(ctx)
+	if res != nil {
+		return res, nil
+	}
+
+	// Select the product by name.
+	spec, res := c.getProduct(cfg, name)
+	if res != nil {
+		return res, nil
+	}
+	// Toggle the product status.
+	spec.Enabled = enabled
+
+	if res = c.setProduct(ctx, cfg, name, config.Product{Enabled: enabled}); res != nil {
+		return res, nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf(`
+The product %q is toggled to %v, the configuration is applied in the cluster.`,
+		name,
+		enabled,
+	)), nil
+}
+
+// configProductNamespaceHandler handles the configuration of a product's
+// namespace.  It expects 'name' and 'namespace' arguments.
+func (c *ConfigTools) configProductNamespaceHandler(
+	ctx context.Context,
+	ctr mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	name, ok := ctr.GetArguments()[NameArg].(string)
+	if !ok {
+		return mcp.NewToolResultErrorf(`
+You must inform the product name %q argument, in order to change its namespace.`,
+			NameArg,
+		), nil
+	}
+	namespace, ok := ctr.GetArguments()[NamespaceArg].(string)
+	if !ok {
+		return mcp.NewToolResultErrorf(`
+You must inform the %q argument for the %q product.`,
+			NamespaceArg,
+			name,
+		), nil
+	}
+
+	cfg, res := c.getConfig(ctx)
+	if res != nil {
+		return res, nil
+	}
+
+	// Select the product by name.
+	spec, res := c.getProduct(cfg, name)
+	if res != nil {
+		return res, nil
+	}
+	// Toggle the namespace on the product spec.
+	spec.Namespace = &namespace
+
+	if res = c.setProduct(ctx, cfg, name, *spec); res != nil {
+		return res, nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf(`
+The product %q is using the namespace %q, the configuration is applied in the
+cluster.`,
+		name,
+		namespace,
+	)), nil
+}
+
+// configProductPropertiesHandler updates the properties of a product
+// configuration. It receives the product name and a map of properties to update.
+// The properties are merged into the existing configuration, overriding existing
+// values if present.
+func (c *ConfigTools) configProductPropertiesHandler(
+	ctx context.Context,
+	ctr mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	name, ok := ctr.GetArguments()[NameArg].(string)
+	if !ok {
+		return mcp.NewToolResultErrorf(`
+You must inform the product name %q argument to update its properties.`,
+			NameArg,
+		), nil
+	}
+	properties, ok := ctr.GetArguments()[PropertiesArg].(map[string]interface{})
+	if !ok {
+		return mcp.NewToolResultErrorf(`
+You must inform the properties %q argument for the %q product.`,
+			PropertiesArg,
+			name,
+		), nil
+	}
+
+	cfg, res := c.getConfig(ctx)
+	if res != nil {
+		return res, nil
+	}
+
+	// Select the product by name.
+	spec, res := c.getProduct(cfg, name)
+	if res != nil {
+		return res, nil
+	}
+	// Initialize properties when nil.
+	if spec.Properties == nil {
+		spec.Properties = map[string]interface{}{}
+	}
+
+	// Merging current properties with informed.
+	err := mergo.Merge(&spec.Properties, properties, mergo.WithOverride)
+	if err != nil {
+		return mcp.NewToolResultErrorf(`
+Unable to merge informed properties with existing configuration!
+
+  Properties: %#v
+       Error: %s`,
+			properties,
+			err,
+		), nil
+	}
+
+	if res = c.setProduct(ctx, cfg, name, *spec); res != nil {
+		return res, nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf(`
+The product %q has updated properties, and the configuration is applied in the
+cluster.
+
+  Properties: %#v`,
+		name,
+		properties,
 	)), nil
 }
 
@@ -175,6 +451,97 @@ and other fundamental services will be deployed.`,
 			),
 		),
 		Handler: c.initHandler,
+	}, {
+		Tool: mcp.NewTool(
+			ConfigSettings,
+			mcp.WithDescription(fmt.Sprintf(`
+Modifies the top level settings, '.tssc.settings' in the configuration. It defines
+the global settings for the installer applied to all products. Use the tool %q to
+inspect the configuration's '.tssc.settings' attributes and their current values,
+pay attention to the data type of the values, and make sure they are compatible
+with the expected types.`,
+				ConfigGetTool,
+			)),
+			mcp.WithString(
+				KeyArg,
+				mcp.Description(`
+The key in '.tssc.settings' object to update, for instance "crc".`,
+				),
+			),
+			mcp.WithBoolean(
+				ValueArg,
+				mcp.Description(`
+The value for the informed key in '.tssc.settings' object.`,
+				),
+			),
+		),
+		Handler: c.configSettingsHandler,
+	}, {
+		Tool: mcp.NewTool(
+			ConfigProductEnabled,
+			mcp.WithDescription(`
+Toggles a product status, enable or disable it a product for the TSSC installer
+scope. The installer will adequate the deployment topology to the enabled
+products.`,
+			),
+			mcp.WithString(
+				NameArg,
+				mcp.Description(`
+The product name to update the '.enabled' attribute.`,
+				),
+			),
+			mcp.WithBoolean(
+				EnabledArg,
+				mcp.Description(`
+Boolean value indicating whether the product should be enabled or not.`,
+				),
+				mcp.DefaultBool(true),
+			),
+		),
+		Handler: c.configProductEnableHandler,
+	}, {
+		Tool: mcp.NewTool(
+			ConfigProductNamespace,
+			mcp.WithDescription(`
+Updates the namespace for a given product, which means the primary product
+components will take place on the specified Kubernetes namespace.`,
+			),
+			mcp.WithString(
+				NameArg,
+				mcp.Description(`
+The product name to update the '.namespace' attribute.`,
+				),
+			),
+			mcp.WithString(
+				NamespaceArg,
+				mcp.Description(`
+The namespace where the product components will take place.`,
+				),
+				mcp.DefaultString(""),
+			),
+		),
+		Handler: c.configProductNamespaceHandler,
+	}, {
+		Tool: mcp.NewTool(
+			ConfigProductProperties,
+			mcp.WithDescription(`
+Updates the properties of a given product, the product '.properties' attributes
+will be updated using the informed object.`,
+			),
+			mcp.WithString(
+				NameArg,
+				mcp.Description(`
+The product name to update its '.properties' attribute.`,
+				),
+			),
+			mcp.WithObject(
+				PropertiesArg,
+				mcp.Description(`
+The properties object with the attributes for the informed product name.`,
+				),
+			),
+		),
+		Handler: c.configProductPropertiesHandler,
 	}}...)
 }
 

--- a/pkg/mcptools/deploytools.go
+++ b/pkg/mcptools/deploytools.go
@@ -161,8 +161,9 @@ additional platform deployment information.`,
 // NewDeployTools creates a new DeployTools instance.
 func NewDeployTools(
 	cm *config.ConfigMapManager,
+	topologyBuilder *resolver.TopologyBuilder,
 	job *installer.Job,
 	image string,
 ) *DeployTools {
-	return &DeployTools{cm: cm, job: job, image: image}
+	return &DeployTools{cm: cm, topologyBuilder: topologyBuilder, job: job, image: image}
 }

--- a/pkg/mcptools/statustool.go
+++ b/pkg/mcptools/statustool.go
@@ -77,7 +77,7 @@ first step to deploy TSSC components.
 Inspecting the configuration in the cluster returned the following error:
 
 > %s`,
-			ConfigCreateTool, err.Error(),
+			ConfigInitTool, err.Error(),
 		), nil
 	}
 

--- a/pkg/subcmd/mcpserver.go
+++ b/pkg/subcmd/mcpserver.go
@@ -78,7 +78,7 @@ func (m *MCPServer) Run() error {
 	integrationCmd := NewIntegration(m.logger, m.kube)
 	integrationTools := mcptools.NewIntegrationTools(integrationCmd)
 
-	deployTools := mcptools.NewDeployTools(cm, jm, m.image)
+	deployTools := mcptools.NewDeployTools(cm, tb, jm, m.image)
 
 	s := mcpserver.NewMCPServer()
 	s.AddTools(configTools, statusTool, integrationTools, deployTools)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1214,3 +1214,4 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
 # github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.13.0
+# github.com/imdario/mergo => github.com/imdario/mergo v0.3.16


### PR DESCRIPTION
Incorporating the changes from #1276 and continue on the MCP configuration tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Interactive configuration tools: init, global settings, and per-product enable/namespace/properties updates; supports nested key updates and in-place product edits.
  - New utilities for flattening and manipulating configuration values.

- **Bug Fixes / Improvements**
  - Improved YAML read/update behavior preserving structure and anchors.
  - Deploy tooling now uses topology information during setup.

- **Documentation**
  - Added a “Configuration Tools” guide and clarified Phase 2 inspection notes.

- **Chore**
  - Updated dependency declarations and replacements.

- **Tests**
  - Expanded tests for namespace, settings, products, and map-flattening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->