### PR TITLE
RHTAP-2537: update install.sh to support customize DH namespace prefixes

### DIFF
--- a/integration-tests/scripts/.ci-env
+++ b/integration-tests/scripts/.ci-env
@@ -2,6 +2,11 @@
 # For testing your changes, replace with your fork and branch of tssc-sample-templates
 export DEVELOPER_HUB__CATALOG__URL=https://github.com/redhat-appstudio/tssc-sample-templates/blob/main/all.yaml
 
+#### Customize App Deployment Namespaces
+# For setting different tssc app deployment namespaces
+# For example "argo-app,deploy-app"
+export TSSC_APP_DEPLOYMENT_NAMESPACES=""
+
 #### Github
 # https://docs.redhat.com/en/documentation/red_hat_trusted_application_pipeline/1.2/html-single/installing_red_hat_trusted_application_pipeline/index#creating_a_github_personal_access_token
 export GITHUB__APP__ID=

--- a/integration-tests/scripts/.env.template
+++ b/integration-tests/scripts/.env.template
@@ -8,6 +8,11 @@ export pipeline_config="tekton,jenkins,actions,gitlabci" # tekton, jenkins, acti
 # For testing your changes, replace with your fork and branch of tssc-sample-templates
 export DEVELOPER_HUB__CATALOG__URL=
 
+#### Customize App Deployment Namespaces
+# For setting different tssc app deployment namespaces
+# For example "argo-app,deploy-app"
+export TSSC_APP_DEPLOYMENT_NAMESPACES=""
+
 #### Github
 # https://docs.redhat.com/en/documentation/red_hat_trusted_application_pipeline/1.2/html-single/installing_red_hat_trusted_application_pipeline/index#creating_a_github_personal_access_token
 export GITHUB__APP__ID=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable environment setting to customize app deployment namespaces.
  * Installation now applies provided namespace prefixes to Developer Hub configuration during cluster setup; defaults are preserved if unset.

* **Documentation**
  * Environment templates updated with a new configuration block and explanatory comments for namespace customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->