### PR TITLE
Integration Overwrite Error

### DIFF
--- a/pkg/resolver/integrations.go
+++ b/pkg/resolver/integrations.go
@@ -50,15 +50,10 @@ func (i *Integrations) Inspect(t *Topology) error {
 				return fmt.Errorf("%w: %q in %q dependency (%q product)",
 					ErrUnknownIntegration, provided, chartName, d.ProductName())
 			}
-			// Asserting the integration is not configured yet.
 			if configured {
-				return fmt.Errorf(
-					"%w: %q can't be overwritten by the %q (%q product)",
-					ErrConfiguredIntegration,
-					provided,
-					chartName,
-					d.ProductName(),
-				)
+				// If the integration is already configured (either by user or
+				// previous run) we skip marking it again to ensure idempotency.
+				continue
 			}
 			// Marking the integration as configured, this dependency is
 			// responsible for creating the integration secret accordingly.


### PR DESCRIPTION
Avoid error out when the interation is already configured, removing the overwrite error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Integration setup is idempotent: already-configured integrations are now skipped instead of causing an error.
  * Re-running inspection or configuration completes gracefully without failing on previously set integrations.
  * Prevents duplicate processing of integrations that were already present, avoiding redundant configuration attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->