### PR TITLE
RHTAP-5984 Remove ACS installation from CI(use remote instance)

### DIFF
--- a/integration-tests/config/rhads-config
+++ b/integration-tests/config/rhads-config
@@ -1,5 +1,5 @@
 OCP="4.17,4.18,4.19"
-ACS="local"
+ACS="remote"
 REGISTRY="quay,artifactory,nexus"
 TPA="local"
 SCM="github,gitlab,bitbucket"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test configuration for remote environment access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->