### PR TITLE
fix: use the argocd image corresponding to the app version

### DIFF
--- a/installer/charts/tssc-gitops/templates/_argocd.tpl
+++ b/installer/charts/tssc-gitops/templates/_argocd.tpl
@@ -16,35 +16,3 @@
 {{- define "argoCD.secretClusterName" -}}
   {{ printf "%s-cluster" .Values.argoCD.name }}
 {{- end -}}
-
-{{/* 
-
-  Creates a POD container spec for the ArgoCD login test.
-
-*/}}
-{{- define "argoCD.testArgoCDLogin" -}}
-  {{- $argoCD := .Values.argoCD -}}
-- name: {{ printf "argocd-login-%s" $argoCD.name }}
-  image: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:5bfc4686983f9c62107772d99d900efbcc38175afe621c40958035aa49bfa9ed
-  env:
-    - name: ARGOCD_HOSTNAME
-      value: {{ include "argoCD.serverHostname" . }}
-    - name: ARGOCD_USER
-      value: admin
-    - name: ARGOCD_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: {{ include "argoCD.secretClusterName" . }} 
-          key: admin.password
-  workingDir: /home/argocd
-  command:
-    - /scripts/argocd-helper.sh
-  args:
-    - login
-  volumeMounts:
-    - name: scripts
-      mountPath: /scripts
-  securityContext:
-    runAsNonRoot: false
-    allowPrivilegeEscalation: false
-{{- end -}}

--- a/installer/charts/tssc-gitops/templates/job-post-deploy.yaml
+++ b/installer/charts/tssc-gitops/templates/job-post-deploy.yaml
@@ -45,7 +45,7 @@ spec:
             - name: ARGOCD_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "argoCD.secretClusterName" . }} 
+                  name: {{ include "argoCD.secretClusterName" . }}
                   key: admin.password
             - name: ARGOCD_ENV_FILE
               value: {{ $argoCDEnvFile }}

--- a/installer/charts/tssc-gitops/templates/job-post-deploy.yaml
+++ b/installer/charts/tssc-gitops/templates/job-post-deploy.yaml
@@ -36,7 +36,7 @@ spec:
         # file which is later stored as a Kubernetes secret.
         #
         - name: argocd-generate-token
-          image: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:5bfc4686983f9c62107772d99d900efbcc38175afe621c40958035aa49bfa9ed
+          image: registry.redhat.io/openshift-gitops-1/argocd-rhel8:{{ .Chart.AppVersion }}
           env:
             - name: ARGOCD_HOSTNAME
               value: {{ include "argoCD.serverHostname" . }}

--- a/installer/charts/tssc-gitops/templates/tests/test.yaml
+++ b/installer/charts/tssc-gitops/templates/tests/test.yaml
@@ -2,7 +2,7 @@
 {{- include "common.test" . }}
   containers:
 {{- if .Values.argoCD.enabled }}
-  {{- $argoCD := .Values.argoCD }}
+{{- $argoCD := .Values.argoCD }}
     #
     # Test the ArgoCD rollout status.
     #
@@ -25,5 +25,27 @@
     #
     # Tests the ArgoCD instance login.
     #
-  {{- include "argoCD.testArgoCDLogin" . | nindent 4 }}
+    - name: {{ printf "argocd-login-%s" $argoCD.name }}
+      image: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:5bfc4686983f9c62107772d99d900efbcc38175afe621c40958035aa49bfa9ed
+      env:
+        - name: ARGOCD_HOSTNAME
+          value: {{ include "argoCD.serverHostname" . }}
+        - name: ARGOCD_USER
+          value: admin
+        - name: ARGOCD_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "argoCD.secretClusterName" . }}
+              key: admin.password
+      workingDir: /home/argocd
+      command:
+        - /scripts/argocd-helper.sh
+      args:
+        - login
+      volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+      securityContext:
+        runAsNonRoot: false
+        allowPrivilegeEscalation: false
 {{- end }}

--- a/installer/charts/tssc-gitops/templates/tests/test.yaml
+++ b/installer/charts/tssc-gitops/templates/tests/test.yaml
@@ -26,7 +26,7 @@
     # Tests the ArgoCD instance login.
     #
     - name: {{ printf "argocd-login-%s" $argoCD.name }}
-      image: registry.redhat.io/openshift-gitops-1/argocd-rhel8@sha256:5bfc4686983f9c62107772d99d900efbcc38175afe621c40958035aa49bfa9ed
+      image: registry.redhat.io/openshift-gitops-1/argocd-rhel8:{{ .Chart.AppVersion }}
       env:
         - name: ARGOCD_HOSTNAME
           value: {{ include "argoCD.serverHostname" . }}

--- a/installer/scripts/argocd-helper.sh
+++ b/installer/scripts/argocd-helper.sh
@@ -55,6 +55,7 @@ argocd_login() {
     argocd login "${ARGOCD_HOSTNAME}" \
         --grpc-web \
         --insecure \
+        --skip-test-tls \
         --http-retry-max="5" \
         --username="${ARGOCD_USER}" \
         --password="${ARGOCD_PASSWORD}"


### PR DESCRIPTION
- Use the image that match the operator version.
- Fix login command to add new required flag.
- Remove an include that was used only once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Inlined the ArgoCD login test into deployment tests so the login test is now always included.

* **Chores**
  * Token generator image now uses the chart/app version tag instead of a fixed digest.
  * Added an option to skip TLS checks during ArgoCD login.
  * Minor manifest cleanup and whitespace fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->