### PR TITLE
fix: make scm backend plugins conditional

### DIFF
--- a/installer/charts/tssc-dh/templates/plugins-content.yaml
+++ b/installer/charts/tssc-dh/templates/plugins-content.yaml
@@ -119,13 +119,18 @@ plugins:
   #
   # Git
   #
-  # The all the git plugins are always enabled as they are referenced by the default templates
+{{- if (lookup "v1" "Secret" $integrationNamespace "tssc-bitbucket-integration") }}
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic
+{{- end }}
+{{- if (lookup "v1" "Secret" $integrationNamespace "tssc-github-integration") }}
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+{{- end }}
+{{- if (lookup "v1" "Secret" $integrationNamespace "tssc-gitlab-integration") }}
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic
+{{- end }}
   #
   # Image Registry
   #


### PR DESCRIPTION
The SCM backend plugins are not needed if the SCM is not configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved plugin configuration management for Git integrations (Bitbucket, GitHub, GitLab). Git-related plugins now only become available when properly configured through their corresponding integration credentials, ensuring a cleaner experience with only active integrations displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->