### PR TITLE
fix: allow custom port for the GitLab service

### DIFF
--- a/installer/charts/tssc-dh/templates/app-config-content.yaml
+++ b/installer/charts/tssc-dh/templates/app-config-content.yaml
@@ -175,7 +175,8 @@ integrations:
   gitlab:
     - host: ${GITLAB__HOST}
       {{- if ne ($gitlabSecretData.host | b64dec) "gitlab.com" }}
-      apiBaseUrl: https://${GITLAB__HOST}/api/v4
+      baseUrl: ${GITLAB__URL}
+      apiBaseUrl: ${GITLAB__URL}/api/v4
       {{- end }}
       token: ${GITLAB__TOKEN}
 {{- end }}

--- a/installer/charts/tssc-dh/templates/extra-env.yaml
+++ b/installer/charts/tssc-dh/templates/extra-env.yaml
@@ -77,7 +77,11 @@ data:
     GITLAB__GROUP: "{{ $glSecretData.group }}"
     GITLAB__HOST: {{ $glSecretData.host }}
     GITLAB__TOKEN: "{{ $glSecretData.token }}"
+    {{- if eq ($glSecretData.port | b64dec) "443" }}
     GITLAB__URL: {{ print "https://" ($glSecretData.host | b64dec) | b64enc }}
+    {{- else }}
+    GITLAB__URL: {{ print "https://" ($glSecretData.host | b64dec) ":" ($glSecretData.port | b64dec) | b64enc }}
+    {{- end }}
     GITLAB__USERNAME: {{ $glSecretData.username }}
     {{- if and $glSecretData.clientId $glSecretData.clientSecret }}
     GITLAB__APP__CLIENT__ID: {{ $glSecretData.clientId }}

--- a/pkg/integration/gitlab.go
+++ b/pkg/integration/gitlab.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/redhat-appstudio/tssc-cli/pkg/config"
 
@@ -20,6 +21,7 @@ type GitLab struct {
 
 	insecure  bool   // skip tls verification
 	host      string // gitlab host
+	port      int    // gitlab port
 	group     string // gitlab group name
 	appID     string // gitlab application client id
 	appSecret string // gitlab application client secret
@@ -34,6 +36,8 @@ func (g *GitLab) PersistentFlags(c *cobra.Command) {
 
 	p.StringVar(&g.host, "host", g.host,
 		"GitLab hostname")
+	p.IntVar(&g.port, "port", g.port,
+		"GitLab port")
 	p.BoolVar(&g.insecure, "insecure", g.insecure,
 		"Skips TLS verification on API calls")
 	p.StringVar(&g.group, "group", g.group,
@@ -61,6 +65,7 @@ func (g *GitLab) SetArgument(string, string) error {
 func (g *GitLab) LoggerWith(logger *slog.Logger) *slog.Logger {
 	return logger.With(
 		"host", g.host,
+		"port", g.port,
 		"insecure", g.insecure,
 		"group", g.group,
 		"app-id", g.appID,
@@ -133,6 +138,7 @@ func (g *GitLab) Data(
 
 	return map[string][]byte{
 		"host":         []byte(g.host),
+		"port":         []byte(strconv.Itoa(g.port)),
 		"group":        []byte(g.group),
 		"clientId":     []byte(g.appID),
 		"clientSecret": []byte(g.appSecret),
@@ -147,5 +153,6 @@ func NewGitLab(logger *slog.Logger) *GitLab {
 	return &GitLab{
 		logger: logger,
 		host:   "gitlab.com",
+		port:   443,
 	}
 }


### PR DESCRIPTION
cf [RHTAP-5995](https://issues.redhat.com//browse/RHTAP-5995)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --port option to configure custom ports for GitLab integration.
  * Exposed a base URL for non-gitlab.com hosts and standardized the API base URL to use that value.
  * Port handling improved: when port is 443 it’s treated as standard HTTPS and omitted from generated URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->