### PR TITLE
fix: Use gitlab port in integration validation

### DIFF
--- a/pkg/integration/gitlab.go
+++ b/pkg/integration/gitlab.go
@@ -99,6 +99,9 @@ func (g *GitLab) Validate() error {
 // informed access token.
 func (g *GitLab) getCurrentGitLabUser() (string, error) {
 	gitLabURL := fmt.Sprintf("https://%s", g.host)
+	if g.port != 443 {
+		gitLabURL += fmt.Sprintf(":%d", g.port)
+	}
 
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{


### PR DESCRIPTION
cf [RHTAP-5995](https://issues.redhat.com//browse/RHTAP-5995)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GitLab integration URL handling so the port is included for non-default HTTPS ports, ensuring API requests use the intended host and port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->