### PR TITLE
RHTAP-5997: MCP Notes Tool

### DIFF
--- a/pkg/deployer/helm.go
+++ b/pkg/deployer/helm.go
@@ -147,6 +147,8 @@ func (h *Helm) Verify() error {
 	return nil
 }
 
+// VerifyWithRetry attempts to verify the Helm deployment multiple times with a
+// delay between retries.
 func (h *Helm) VerifyWithRetry() error {
 	var err error
 	var retries = 3
@@ -176,6 +178,19 @@ func (h *Helm) VisitReleaseResources(
 		}
 		return m.Collect(ctx, r)
 	})
+}
+
+// GetNotes retrieves the latest release (version 0) of the Helm chart, printing
+// out the notes from the info section.
+func (h *Helm) GetNotes() (string, error) {
+	c := action.NewGet(h.actionCfg)
+	c.Version = 0
+
+	res, err := c.Run(h.chart.Name())
+	if err != nil {
+		return "", err
+	}
+	return res.Info.Notes, nil
 }
 
 // NewHelm creates a new Helm instance, setting up the Helm action configuration

--- a/pkg/mcpserver/instructions.md
+++ b/pkg/mcpserver/instructions.md
@@ -67,3 +67,4 @@ I will guide you with suggestions for the next logical action in my responses. L
 The installer has finished successfully and all components are running as expected.
 
 - Use `tssc_status` to view the overall installer status.
+- Use `tssc_notes` to retrieve instructions on how to connect to a service (product) deployed by the installer. You must provide the product name.

--- a/pkg/mcptools/deploytools.go
+++ b/pkg/mcptools/deploytools.go
@@ -46,13 +46,7 @@ func (d *DeployTools) deployHandler(
 	// error to inform the user about MCP configuration tools.
 	cfg, err := d.cm.GetConfig(ctx)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf(`
-The cluster is not configured yet, use the tool %q to identify the cluster
-installation status, and the next actions after that.
-
-> %s`,
-			StatusToolName, err.Error(),
-		)), nil
+		return mcp.NewToolResultError(missingClusterConfigErrorFromErr(err)), nil
 	}
 
 	// Validating the topology as a whole, dependencies and integrations to ensure

--- a/pkg/mcptools/notestool.go
+++ b/pkg/mcptools/notestool.go
@@ -1,0 +1,150 @@
+package mcptools
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/redhat-appstudio/tssc-cli/pkg/config"
+	"github.com/redhat-appstudio/tssc-cli/pkg/constants"
+	"github.com/redhat-appstudio/tssc-cli/pkg/deployer"
+	"github.com/redhat-appstudio/tssc-cli/pkg/flags"
+	"github.com/redhat-appstudio/tssc-cli/pkg/installer"
+	"github.com/redhat-appstudio/tssc-cli/pkg/k8s"
+	"github.com/redhat-appstudio/tssc-cli/pkg/resolver"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// NotesTool a MCP tool to provide connection instructions for products. These
+// products must be completely deployed before its "NOTES.txt" is generated.
+type NotesTool struct {
+	logger *slog.Logger              // application logger
+	flags  *flags.Flags              // global flags
+	kube   *k8s.Kube                 // kubernetes client
+	cm     *config.ConfigMapManager  // cluster configuration
+	tb     *resolver.TopologyBuilder // topology builder
+	job    *installer.Job            // cluster deployment job
+}
+
+var _ Interface = &NotesTool{}
+
+const (
+	// NotesToolName retrieves the connection instruction for a product.
+	NotesToolName = constants.AppName + "_notes"
+)
+
+// notesHandler retrieves the Helm chart notes (NOTES.txt) for a specified Red Hat
+// product. It ensures the product name is provided, checks if the cluster
+// installation is in a "completed" phase, and then uses a Helm client to fetch
+// and return the notes.
+func (n *NotesTool) notesHandler(
+	ctx context.Context,
+	ctr mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	// Ensure the user has provided the product name.
+	name := ctr.GetString(NameArg, "")
+	if name == "" {
+		return mcp.NewToolResultError(`
+		You must inform the Red Hat product name`,
+		), nil
+	}
+
+	// Check if the cluster is ready. If not, provide instructions on how to
+	// proceed. The installer must be on "completed" status.
+	phase, err := getInstallerPhase(ctx, n.cm, n.tb, n.job)
+	currentStatus := fmt.Sprintf(`
+# Current Status: %q
+
+The cluster is not ready, use the tool %q to check the overall status and general
+directions on how to proceed.`,
+		phase, StatusToolName,
+	)
+	if err != nil {
+		return mcp.NewToolResultText(fmt.Sprintf(`%s
+
+Inspecting the cluster returned the following error:
+
+> %s`,
+			currentStatus, err.Error(),
+		)), nil
+	}
+	if phase != CompletedPhase {
+		return mcp.NewToolResultText(currentStatus), nil
+	}
+
+	dep, err := n.tb.GetCollection().GetProductDependency(name)
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr(
+			fmt.Sprintf(`
+Unable to find the dependency for the informed product name %q`,
+				name,
+			),
+			err,
+		), nil
+	}
+
+	hc, err := deployer.NewHelm(
+		n.logger, n.flags, n.kube, dep.Namespace(), dep.Chart())
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr(
+			fmt.Sprintf(`
+Error trying to instantiate a Helm client for the chart %q on namespace %q.`,
+				dep.Chart().Name(),
+				dep.Namespace(),
+			),
+			err,
+		), nil
+	}
+
+	notes, err := hc.GetNotes()
+	if err != nil {
+		return mcp.NewToolResultErrorFromErr(
+			fmt.Sprintf(`
+Unable to get "NOTES.txt" for the chart %q on namespace %q.`,
+				dep.Chart().Name(),
+				dep.Namespace(),
+			),
+			err,
+		), nil
+	}
+
+	return mcp.NewToolResultText(notes), nil
+}
+
+func (n *NotesTool) Init(s *server.MCPServer) {
+	s.AddTools([]server.ServerTool{{
+		Tool: mcp.NewTool(
+			NotesToolName,
+			mcp.WithDescription(`
+Retrieve the service notes, the initial coordinates to utilize services deployed
+by this installer, from the informed product name.`,
+			),
+			mcp.WithString(
+				NameArg,
+				mcp.Description(`
+The name of the Red Hat product to retrieve connection information.`,
+				),
+			),
+		),
+		Handler: n.notesHandler,
+	}}...)
+}
+
+func NewNotesTool(
+	logger *slog.Logger,
+	f *flags.Flags,
+	kube *k8s.Kube,
+	cm *config.ConfigMapManager,
+	tb *resolver.TopologyBuilder,
+) *NotesTool {
+	return &NotesTool{
+		logger: logger,
+		flags:  f,
+		kube:   kube,
+		cm:     cm,
+		tb:     tb,
+		job:    installer.NewJob(kube),
+	}
+}

--- a/pkg/mcptools/status.go
+++ b/pkg/mcptools/status.go
@@ -1,0 +1,60 @@
+package mcptools
+
+import (
+	"context"
+	"errors"
+
+	"github.com/redhat-appstudio/tssc-cli/pkg/config"
+	"github.com/redhat-appstudio/tssc-cli/pkg/installer"
+	"github.com/redhat-appstudio/tssc-cli/pkg/resolver"
+)
+
+func getInstallerPhase(
+	ctx context.Context,
+	cm *config.ConfigMapManager,
+	tb *resolver.TopologyBuilder,
+	job *installer.Job,
+) (string, error) {
+	// Ensure the cluster is configured.
+	cfg, err := cm.GetConfig(ctx)
+	if err != nil {
+		// If config is missing, we are in AwaitingConfigurationPhase.
+		// The specific error will be used by the caller for detailed messaging.
+		return AwaitingConfigurationPhase, err
+	}
+
+	// Given the cluster is configured, inspect the topology to ensure all
+	// dependencies and integrations are resolved.
+	if _, err = tb.Build(ctx, cfg); err != nil {
+		// If topology build fails, we are in AwaitingIntegrationsPhase.
+		// The specific resolver error will be used by the caller for detailed messaging.
+		return AwaitingIntegrationsPhase, err
+	}
+
+	// Given integrations are in place, inspect the current state of the
+	// cluster deployment job.
+	jobState, err := job.GetState(ctx)
+	if err != nil {
+		// If job state cannot be determined, it's an operational error.
+		// Return InstallerErrorPhase with the original error.
+		return InstallerErrorPhase, err
+	}
+
+	// Map the job state to an installer phase.
+	switch jobState {
+	case installer.NotFound:
+		return ReadyToDeployPhase, nil
+	case installer.Deploying, installer.Failed:
+		// Both 'Deploying' and 'Failed' states indicate that the deployment
+		// process is active or has attempted to run, thus falling under
+		// the 'DeployingPhase' for overall status reporting.
+		return DeployingPhase, nil
+	case installer.Done:
+		return CompletedPhase, nil
+	default:
+		// Unrecognized installer state from s.job.GetState.
+		// This is also an operational error.
+		return InstallerErrorPhase,
+			errors.New("unknown installer job state reported by cluster")
+	}
+}

--- a/pkg/mcptools/statustool.go
+++ b/pkg/mcptools/statustool.go
@@ -17,11 +17,9 @@ import (
 // StatusTool represents the MCP tool that's responsible to report the current
 // installer status in the cluster.
 type StatusTool struct {
-	cm              *config.ConfigMapManager  // cluster configuration
-	topologyBuilder *resolver.TopologyBuilder // topology builder
-	job             *installer.Job            // cluster deployment job
-
-	phase string // current deployment phase
+	cm  *config.ConfigMapManager  // cluster configuration
+	tb  *resolver.TopologyBuilder // topology builder
+	job *installer.Job            // cluster deployment job
 }
 
 var _ Interface = &StatusTool{}
@@ -44,20 +42,10 @@ const (
 	// CompletedPhase final step, the installation process is complete, and the
 	// cluster is ready.
 	CompletedPhase = "COMPLETED"
+	// InstallerErrorPhase indicates an error occurred while trying to determine
+	// the installer's operational status (e.g., failed to get job state).
+	InstallerErrorPhase = "INSTALLER_ERROR"
 )
-
-// resultWithPhaseF uses the global phase, the informed message format and
-// arguments to compose the tool result. The installer status name is place before
-// the informed message.
-func (s *StatusTool) resultWithPhaseF(
-	format string,
-	a ...any,
-) *mcp.CallToolResult {
-	return mcp.NewToolResultText(
-		fmt.Sprintf("# Current Status: %q\n", s.phase) +
-			fmt.Sprintf(format, a...),
-	)
-}
 
 // statusHandler shows the installer overall status by inspecting the cluster to
 // determine the current state of the installation.
@@ -65,52 +53,53 @@ func (s *StatusTool) statusHandler(
 	ctx context.Context,
 	_ mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
-	// Ensure the cluster is configured, if the ConfigMap is not found, creates a
-	// message to inform the user about MCP configuration tools.
-	s.phase = AwaitingConfigurationPhase
-	cfg, err := s.cm.GetConfig(ctx)
-	if err != nil {
-		return s.resultWithPhaseF(`
-The cluster is not configured yet, use the tool %q to configure it. That's the
-first step to deploy TSSC components.
+	phase, err := getInstallerPhase(ctx, s.cm, s.tb, s.job)
 
-Inspecting the configuration in the cluster returned the following error:
-
-> %s`,
-			ConfigInitTool, err.Error(),
-		), nil
+	// Shell command to get the logs of the deployment job.
+	var logsCmdEx string
+	if cfg, cfgErr := s.cm.GetConfig(ctx); cfgErr == nil {
+		logsCmdEx = s.job.GetJobLogFollowCmd(cfg.Installer.Namespace)
 	}
 
-	// Given the cluster is configured, let's inspect the topology to ensure all
-	// dependencies and integrations are resolved.
-	s.phase = AwaitingIntegrationsPhase
-	if _, err = s.topologyBuilder.Build(ctx, cfg); err != nil {
+	switch phase {
+	case AwaitingConfigurationPhase:
+		return mcp.NewToolResultText(fmt.Sprintf(
+			"# Current Status: %q\n\n%s",
+			phase, missingClusterConfigErrorFromErr(err),
+		)), nil
+	case AwaitingIntegrationsPhase:
 		switch {
 		case errors.Is(err, resolver.ErrCircularDependency) ||
 			errors.Is(err, resolver.ErrDependencyNotFound) ||
 			errors.Is(err, resolver.ErrInvalidCollection):
-			return s.resultWithPhaseF(`
+			return mcp.NewToolResultText(fmt.Sprintf(`
+# Current Status: %q
+
 ATTENTION: The installer set of dependencies, Helm charts, are not properly
 resolved. Please check the dependencies given to the installer. Preferably use the
 embedded dependency collection.
 
 %s`,
-				err.Error(),
-			), nil
+				phase, err.Error(),
+			)), nil
 		case errors.Is(err, resolver.ErrInvalidExpression) ||
 			errors.Is(err, resolver.ErrUnknownIntegration):
-			return s.resultWithPhaseF(`
+			return mcp.NewToolResultText(fmt.Sprintf(`
+# Current Status: %q
+
 ATTENTION: The installer set of dependencies, Helm charts, are referencing invalid
 required integrations expressions and/or using invalid integration names. Please
 check the dependencies given to the installer. Preferably use the embedded
 dependency collection.
 
 %s`,
-				err.Error(),
-			), nil
+				phase, err.Error(),
+			)), nil
 		case errors.Is(err, resolver.ErrMissingIntegrations) ||
 			errors.Is(err, resolver.ErrPrerequisiteIntegration):
-			return s.resultWithPhaseF(`
+			return mcp.NewToolResultText(fmt.Sprintf(`
+# Current Status: %q
+
 ATTENTION: One or more required integrations are missing. You must interpret the
 CEL expression to help the user decide which integrations to configure. Ask the
 user for input about optional integrations.
@@ -121,65 +110,68 @@ configure them.
 You can use %q to verify whether the integrations are configured.
 
 > %s`,
+				phase,
 				IntegrationListTool,
 				IntegrationScaffoldTool,
 				IntegrationStatusTool,
 				err.Error(),
-			), nil
+			)), nil
 		default:
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-	}
+	case ReadyToDeployPhase:
+		return mcp.NewToolResultText(fmt.Sprintf(`
+# Current Status: %q
 
-	// Given integrations are in place, let's inspect the current state of the
-	// cluster deployment job.
-	jobState, err := s.job.GetState(ctx)
-	if err != nil {
-		return nil, err
-	}
-	// Shell command to get the logs of the deployment job.
-	logsCmdEx := s.job.GetJobLogFollowCmd(cfg.Installer.Namespace)
-
-	// Handle different states of the deployment job.
-	switch jobState {
-	case installer.NotFound:
-		s.phase = ReadyToDeployPhase
-		return s.resultWithPhaseF(`
 The cluster is ready to deploy the TSSC components. Use the tool %q to deploy the
 TSSC components.`,
-			DeployToolName,
-		), nil
-	case installer.Deploying:
-		s.phase = DeployingPhase
-		return s.resultWithPhaseF(`
-The cluster is deploying the TSSC components. Please wait for the deployment to
-complete. You can use the following command to follow the deployment job logs:
+			phase, DeployToolName,
+		)), nil
+	case DeployingPhase:
+		jobState, err := s.job.GetState(ctx)
+		if err != nil {
+			return nil, err
+		}
 
-> %s`,
-			logsCmdEx,
-		), nil
-	case installer.Failed:
-		s.phase = DeployingPhase
-		return s.resultWithPhaseF(`
+		if jobState == installer.Failed {
+			return mcp.NewToolResultText(fmt.Sprintf(`
+# Current Status: %q
+
 The deployment job has failed. You can use the following command to view the
 related POD logs:
 
 > %s`,
-			logsCmdEx,
-		), nil
-	case installer.Done:
-		s.phase = CompletedPhase
-		return s.resultWithPhaseF(`
+				phase, logsCmdEx,
+			)), nil
+		}
+
+		// Assume Deploying if not Failed.
+		return mcp.NewToolResultText(fmt.Sprintf(`
+# Current Status: %q
+
+The cluster is deploying the TSSC components. Please wait for the deployment to
+complete. You can use the following command to follow the deployment job logs:
+
+> %s`,
+			phase, logsCmdEx,
+		)), nil
+	case CompletedPhase:
+		return mcp.NewToolResultText(fmt.Sprintf(`
+# Current Status: %q
+
 The TSSC components have been deployed successfully. You can use the following
 command to inspect the installation logs and get initial information for each
 product deployed:
 
 > %s`,
-			logsCmdEx,
-		), nil
+			phase, logsCmdEx,
+		)), nil
+	case InstallerErrorPhase:
+		// Indicates an operational error during job state determination.
+		return mcp.NewToolResultError(err.Error()), nil
+	default:
+		return mcp.NewToolResultError("unknown installer state"), nil
 	}
-
-	return mcp.NewToolResultError("unknown installer state"), nil
 }
 
 // Init registers the status tool.
@@ -203,8 +195,8 @@ func NewStatusTool(
 	job *installer.Job,
 ) *StatusTool {
 	return &StatusTool{
-		cm:              cm,
-		topologyBuilder: tb,
-		job:             job,
+		cm:  cm,
+		tb:  tb,
+		job: job,
 	}
 }

--- a/pkg/mcptools/utils.go
+++ b/pkg/mcptools/utils.go
@@ -10,6 +10,25 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// missingClusterConfigErrorFromErr constructs a user-friendly error message
+// indicating that the cluster configuration is missing. It advises the user
+// on the next steps, including using `ConfigInitTool` to configure the cluster
+// and `StatusToolName` to check the installation status.
+func missingClusterConfigErrorFromErr(err error) string {
+	return fmt.Sprintf(`
+The cluster is not configured yet, use the tool %q to configure it. That's the
+first step to deploy TSSC components. Next, you can use %q to check the overall
+installation status.
+
+Inspecting the configuration in the cluster returned the following error:
+
+> %s`,
+		ConfigInitTool,
+		StatusToolName,
+		err.Error(),
+	)
+}
+
 // generateIntegrationSubCmdUsage generates a formatted usage string for an
 // integration subcommand. It includes the command name, its long description, and
 // an example usage showing required flags with placeholder values.

--- a/pkg/resolver/topologybuilder.go
+++ b/pkg/resolver/topologybuilder.go
@@ -17,6 +17,11 @@ type TopologyBuilder struct {
 	integrationsManager *integrations.Manager // integrations manager
 }
 
+// GetCollection exposes the collection instance.
+func (t *TopologyBuilder) GetCollection() *Collection {
+	return t.collection
+}
+
 // Build inspects the dependencies, based on the cluster configuration, inspects
 // the integrations and generates a consolidated Topology
 func (t *TopologyBuilder) Build(

--- a/pkg/subcmd/mcpserver.go
+++ b/pkg/subcmd/mcpserver.go
@@ -81,8 +81,10 @@ func (m *MCPServer) Run() error {
 
 	deployTools := mcptools.NewDeployTools(cm, tb, jm, m.image)
 
+	notesTool := mcptools.NewNotesTool(m.logger, m.flags, m.kube, cm, tb)
+
 	s := mcpserver.NewMCPServer()
-	s.AddTools(configTools, statusTool, integrationTools, deployTools)
+	s.AddTools(configTools, statusTool, integrationTools, deployTools, notesTool)
 	return s.Start()
 }
 


### PR DESCRIPTION
Shows the connection information for products.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Notes tool to fetch product-specific deployment NOTES and connection instructions.
  * Added deployment verification with automatic retries and a direct way to retrieve release notes.

* **Improvements**
  * Clearer, phase-aware installer status messages and improved status behavior.
  * More actionable cluster-configuration error text with guided next steps.
  * Exposed topology collection for easier inspection and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->