### PR TITLE
fix: add 'go mod verify' to test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ test: test-unit
 # Runs the unit tests.
 .PHONY: test-unit
 test-unit: installer-tarball
+	go mod verify
 	go test $(GOFLAGS_TEST) $(CMD) $(PKG) $(ARGS)
 
 # Uses golangci-lint to inspect the code base.


### PR DESCRIPTION
This change ensures the CI fails if the go project is not in a clean state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test validation process to verify dependencies before running unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->