### PR TITLE
feat: MCP Server Debug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,35 @@ make &&
     bin/tssc deploy --help
 ```
 
+## Debugging `tssc mcp-server`
+
+The [`tssc mcp-server`](docs/mcp.md) subcommand communicates [via `STDIO`][mcpTransports], to debug this subcommand using `dlv` you can use the [`hack/dlv-tssc-mcp-server.sh`](hack/dlv-tssc-mcp-server.sh) script, make sure [the debugger is installed][delveInstallation]. This script wraps `dlv exec` around `tssc mcp-server`, ensuring `STDIO` communication is properly redirected and the Delve API is exposed on a local port.
+
+When you start the [`dlv-tssc-mcp-server.sh`](hack/dlv-tssc-mcp-server.sh) script, it will wait for the Delve client to connect before continuing execution. This is important to note, especially when using this approach with an LLM agentic client, as it can cause the client to hang while waiting for the debugger to attach.
+
+To configure VSCode for debugging, you can use the following `launch.json` snippet:
+
+```json
+{
+    "name": "tssc-mcp-dlv",
+    "type": "go",
+    "mode": "remote",
+    "host": "localhost",
+    "port": 8282,
+    "request": "attach",
+}
+```
+
+Follow these steps to start debugging the MCP server:
+
+1. Build the project with debug symbols enabled:
+    ```sh
+    make debug
+    ```
+2. Configure the MCP server on your favorite LLM client, using the [`hack/dlv-tssc-mcp-server.sh`](hack/dlv-tssc-mcp-server.sh) script as command.
+3. Start the LLM client, and right after attach the debugger.
+4. With the debugger client attached, you can use the LLM client and debug the project as usual.
+
 # GitHub Release
 
 This project uses [GitHub Actions](.github/workflows/release.yaml) to automate the release process, triggered by a new tag in the repository.
@@ -130,3 +159,5 @@ make snapshot
 [podman]: https://podman.io
 [releases]: https://github.com/redhat-appstudio/tssc-cli/releases
 [gnuTar]: https://www.gnu.org/software/tar
+[mcpTransports]: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+[delveInstallation]: https://github.com/go-delve/delve/tree/master/Documentation/installation

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ $(BIN): installer-tarball
 .PHONY: build
 build: $(BIN)
 
+# Builds the application executable with debugging enabled.
+.PHONY: debug
+debug: GOFLAGS = "-gcflags=all=-N -l"
+debug: $(BIN)
+
 # Uses goreleaser to create a snapshot build.
 .PHONY: goreleaser-snapshot
 goreleaser-snapshot: installer-tarball

--- a/hack/dlv-tssc-mcp-server.sh
+++ b/hack/dlv-tssc-mcp-server.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Script's directory full path.
+declare SCRIPT_DIR
+SCRIPT_DIR="$(dirname "${0}")"
+# Installer executable, by default relative to this script.
+declare TSSC_BIN="${SCRIPT_DIR}/../bin/tssc"
+
+# Installer container image, a required flag for the mcp-server subcommand.
+declare TSSC_IMAGE="ghcr.io/redhat-appstudio/tssc:latest"
+# Port to expose DLV API.
+declare DLV_PORT="8282"
+
+# Shows the script usage and flags.
+usage() {
+    echo "
+This script wraps 'dlv exec' on 'tssc mcp-server', preserves the STDIO
+communication while exposing Delve's API on a local port. The goal is using this
+script as the command for the agentic LLM client while running Delve debugger
+against the CLI.
+
+Usage:
+    ${0##*/} [options]
+
+Optional arguments:
+    -i, --image IMAGE
+        The installer container image to use for 'tssc mcp-server'.
+        Default: ${TSSC_IMAGE}
+    -p, --port PORT
+        The port to expose Delve API.
+        Default: ${DLV_PORT}
+    -d, --debug
+        Enable debug information.
+    -h, --help
+        Display this message.
+" >&2
+}
+
+# Parse command-line flags.
+parse_args() {
+    while [[ ${#} -gt 0 ]]; do
+        case ${1} in
+        -d | --debug)
+            set -x
+            ;;
+        -i | --image)
+            TSSC_IMAGE="${2}"
+            shift
+            ;;
+        -p | --port)
+            DLV_PORT="${2}"
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "[ERROR] Unknown argument: '${1}'" >&2
+            usage
+            exit 1
+            ;;
+        esac
+        shift
+    done
+}
+
+# Runs the Delve debugger for the TSSC MCP server.
+main() {
+    parse_args "${@}"
+
+    if ! which dlv >/dev/null 2>&1; then
+        echo "[ERROR] Delve (dlv) is not installed. Please install it first." >&2
+        exit 1
+    fi
+
+    if [ ! -f "${TSSC_BIN}" ]; then
+        echo "ERROR: Can't find the executable at '${TSSC_BIN}'!" >&2
+        exit 1
+    fi
+
+    # Running "tssc mcp-server" ensuring the log output is suppressed.
+    exec dlv exec \
+        --headless \
+        --listen=":${DLV_PORT}" \
+        --log \
+        --log-dest="/dev/null" \
+        "${TSSC_BIN}" -- mcp-server --image="${TSSC_IMAGE}"
+}
+
+main "${@}"


### PR DESCRIPTION
Adding documentation and scripting to debug the `tssc mcp-server` subcommand using Delve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a debugging guide for the MCP server with step‑by‑step instructions, VSCode launch examples, and reference links.

* **Chores**
  * Added a debug build target that produces binaries suitable for debugging.
  * Added a helper script to simplify launching the Delve debugger against the MCP server for local development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->