### PR TITLE
Disable product after adding integration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -222,6 +222,21 @@ func (c *Config) SetProduct(name string, spec Product) error {
 	return fmt.Errorf("product %q not found", name)
 }
 
+// EnableDisableProduct enables or disables a product by its name in the
+// configuration. It searches for the product and updates its 'Enabled' field
+// accordingly. The updated configuration is then returned.
+func (c *Config) EnableDisableProduct(name string, enabled bool) (*Config, error) {
+	spec, err := c.GetProduct(name)
+	if err != nil {
+		return nil, err
+	}
+	spec.Enabled = enabled
+	if err := c.SetProduct(name, *spec); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
 // MarshalYAML marshals the Config into a YAML byte array.
 func (c *Config) MarshalYAML() ([]byte, error) {
 	var buf bytes.Buffer

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -160,4 +160,28 @@ func TestNewConfigFromFile(t *testing.T) {
 		g.Expect(err.Error()).To(o.ContainSubstring(
 			"product \"NonExistentProduct\" not found"))
 	})
+
+	t.Run("EnableDisableProduct", func(t *testing.T) {
+		acsProductName := "Advanced Cluster Security"
+
+		// Disable the product
+		config, err := cfg.EnableDisableProduct(acsProductName, false)
+		g.Expect(err).To(o.Succeed())
+
+		// Verify the product is disabled
+		spec, err := config.GetProduct(acsProductName)
+		g.Expect(err).To(o.Succeed())
+		g.Expect(spec).NotTo(o.BeNil())
+		g.Expect(spec.Enabled).To(o.BeFalse())
+
+		// Enabled the product
+		config, err = cfg.EnableDisableProduct(acsProductName, true)
+		g.Expect(err).To(o.Succeed())
+
+		// Verify the product is enabled
+		spec, err = config.GetProduct(acsProductName)
+		g.Expect(err).To(o.Succeed())
+		g.Expect(spec).NotTo(o.BeNil())
+		g.Expect(spec.Enabled).To(o.BeTrue())
+	})
 }

--- a/pkg/subcmd/integration_acs.go
+++ b/pkg/subcmd/integration_acs.go
@@ -17,18 +17,22 @@ type IntegrationACS struct {
 	logger      *slog.Logger             // application logger
 	cfg         *config.Config           // installer configuration
 	kube        *k8s.Kube                // kubernetes client
+	manager     *config.ConfigMapManager // cluster configuration manager
 	integration *integration.Integration // integration instance
 }
 
 var _ Interface = &IntegrationACS{}
 
-const acsIntegrationLongDesc = `
+const (
+	acsIntegrationLongDesc = `
 Manages the ACS integration with TSSC, by storing the required
 credentials required by the TSSC services to interact with ACS.
 
 The credentials are stored in a Kubernetes Secret in the configured namespace
 for RHDH.
 `
+	acsProductName = "Advanced Cluster Security"
+)
 
 // Cmd exposes the cobra instance.
 func (a *IntegrationACS) Cmd() *cobra.Command {
@@ -49,7 +53,16 @@ func (a *IntegrationACS) Validate() error {
 
 // Run creates or updates the ACS integration secret.
 func (a *IntegrationACS) Run() error {
-	return a.integration.Create(a.cmd.Context(), a.cfg)
+	if err := a.integration.Create(a.cmd.Context(), a.cfg); err != nil {
+		return err
+	}
+	// Integration tssc-acs-integration created, disable ACS
+	config, err := a.cfg.EnableDisableProduct(acsProductName, false)
+	if err != nil {
+		return err
+	}
+	return a.manager.Update(a.cmd.Context(), config)
+
 }
 
 // NewIntegrationACS creates the sub-command for the "integration acs"
@@ -69,6 +82,7 @@ func NewIntegrationACS(
 
 		logger:      logger,
 		kube:        kube,
+		manager:     config.NewConfigMapManager(kube),
 		integration: i,
 	}
 	i.PersistentFlags(a.cmd)

--- a/pkg/subcmd/integration_trustedartifactsigner.go
+++ b/pkg/subcmd/integration_trustedartifactsigner.go
@@ -17,16 +17,20 @@ type IntegrationTrustedArtifactSigner struct {
 	logger      *slog.Logger             // application logger
 	cfg         *config.Config           // installer configuration
 	kube        *k8s.Kube                // kubernetes client
+	manager     *config.ConfigMapManager // cluster configuration manager
 	integration *integration.Integration // integration instance
 }
 
 var _ Interface = &IntegrationTrustedArtifactSigner{}
 
-const trustedArtifactSignerIntegrationLongDesc = `
+const (
+	trustedArtifactSignerIntegrationLongDesc = `
 Manages the TrustedArtifactSigner integration with TSSC, by storing the required
 URL required to interact with Trusted Artifact Signer.
 
 The credentials are stored in a Kubernetes Secret in the configured namespace for TSSC.`
+	tasProductName = "Trusted Artifact Signer"
+)
 
 // Cmd exposes the cobra instance.
 func (t *IntegrationTrustedArtifactSigner) Cmd() *cobra.Command {
@@ -47,7 +51,15 @@ func (t *IntegrationTrustedArtifactSigner) Validate() error {
 
 // Run creates or updates the TrustedArtifactSigner integration secret.
 func (t *IntegrationTrustedArtifactSigner) Run() error {
-	return t.integration.Create(t.cmd.Context(), t.cfg)
+	if err := t.integration.Create(t.cmd.Context(), t.cfg); err != nil {
+		return err
+	}
+	// Integration created, disable TAS product
+	config, err := t.cfg.EnableDisableProduct(tasProductName, false)
+	if err != nil {
+		return err
+	}
+	return t.manager.Update(t.cmd.Context(), config)
 }
 
 // NewIntegrationTrustedArtifactSigner creates the sub-command for the "integration
@@ -68,6 +80,7 @@ func NewIntegrationTrustedArtifactSigner(
 
 		logger:      logger,
 		kube:        kube,
+		manager:     config.NewConfigMapManager(kube),
 		integration: i,
 	}
 	i.PersistentFlags(t.cmd)

--- a/pkg/subcmd/integration_trustification.go
+++ b/pkg/subcmd/integration_trustification.go
@@ -17,18 +17,22 @@ type IntegrationTrustification struct {
 	logger      *slog.Logger             // application logger
 	cfg         *config.Config           // installer configuration
 	kube        *k8s.Kube                // kubernetes client
+	manager     *config.ConfigMapManager // cluster configuration manager
 	integration *integration.Integration // integration instance
 }
 
 var _ Interface = &IntegrationTrustification{}
 
-const trustificationIntegrationLongDesc = `
+const (
+	trustificationIntegrationLongDesc = `
 Manages the Trustification integration with TSSC, by storing the required
 credentials required by the TSSC services to interact with Trustification.
 
 The credentials are stored in a Kubernetes Secret in the configured namespace
 for RHDH.
 `
+	tpaProductName = "Trusted Profile Analyzer"
+)
 
 // Cmd exposes the cobra instance.
 func (t *IntegrationTrustification) Cmd() *cobra.Command {
@@ -49,7 +53,15 @@ func (t *IntegrationTrustification) Validate() error {
 
 // Run creates or updates the Trustification integration secret.
 func (t *IntegrationTrustification) Run() error {
-	return t.integration.Create(t.cmd.Context(), t.cfg)
+	if err := t.integration.Create(t.cmd.Context(), t.cfg); err != nil {
+		return err
+	}
+	// Integration created, disable TPA product
+	config, err := t.cfg.EnableDisableProduct(tpaProductName, false)
+	if err != nil {
+		return err
+	}
+	return t.manager.Update(t.cmd.Context(), config)
 }
 
 // NewIntegrationTrustification creates the sub-command for the "integration
@@ -70,6 +82,7 @@ func NewIntegrationTrustification(
 
 		logger:      logger,
 		kube:        kube,
+		manager:     config.NewConfigMapManager(kube),
 		integration: i,
 	}
 	i.PersistentFlags(t.cmd)


### PR DESCRIPTION
For ACS, TAS and TPA, disable the product in cluster ConfigMap if the related integration is created.

Jira: [RHTAP-5697](https://issues.redhat.com/browse/RHTAP-5697)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to enable/disable products in cluster configuration.
  * Integration workflows now automatically update product state after setup for Advanced Cluster Security, Trusted Artifact Signer, and Trusted Profile Analyzer.

* **Tests**
  * Added test coverage validating enabling and disabling products and verifying state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->