### PR TITLE
Remove useless keycloak settings

### DIFF
--- a/installer/charts/tssc-dh/templates/NOTES.txt
+++ b/installer/charts/tssc-dh/templates/NOTES.txt
@@ -5,6 +5,7 @@ Developer Hub:
 {{- $integrationNamespace := .Values.developerHub.integrationSecrets.namespace }}
 {{- $gitlabObj := (lookup "v1" "Secret" $integrationNamespace "tssc-gitlab-integration") | default dict -}}
 {{- $bitbucketObj := (lookup "v1" "Secret" $integrationNamespace "tssc-bitbucket-integration") | default dict -}}
+{{- $oidcEnabled := .Values.developerHub.oidc.enabled }}
 {{- if (or $gitlabObj $bitbucketObj) }}
 
 Tekton Pipelines as Code:
@@ -49,4 +50,12 @@ Trusted Artifact Signer:
 
 Trusted Artifact Signer: not installed
     {{- end }}
+{{- end }}
+
+{{- if $oidcEnabled }}
+
+OIDC Admin Credential:
+- Namespace:   {{ .Values.developerHub.oidc.secretNamespace }}
+  Username:    {{ .Values.developerHub.oidc.adminUserName }}
+  Secret:      {{ .Values.developerHub.oidc.adminSecretName }}
 {{- end }}

--- a/installer/charts/tssc-dh/values.yaml
+++ b/installer/charts/tssc-dh/values.yaml
@@ -13,6 +13,10 @@ developerHub:
     enabled: __OVERWRITE_ME__
     orgs: __OVERWRITE_ME__
   oidc:
+    adminUserName: admin
+    adminSecretName: tssc-realms-admin-user
+    secretNamespace: __OVERWRITE_ME__
+    enabled: false
     clientID: __OVERWRITE_ME__
     metadataURL: __OVERWRITE_ME__
     baseURL: __OVERWRITE_ME__

--- a/installer/charts/tssc-tas/templates/tests/test.yaml
+++ b/installer/charts/tssc-tas/templates/tests/test.yaml
@@ -1,7 +1,6 @@
 {{- $secureSign := .Values.trustedArtifactSigner.secureSign -}}
 {{- if $secureSign.enabled }}
 ---
-  {{- $keycloak := .Values.trustedArtifactSigner.keycloakRealmImport -}}
 {{- include "common.test" . }}
   containers:
     - name: statefulsets-test

--- a/installer/charts/tssc-tas/values.yaml
+++ b/installer/charts/tssc-tas/values.yaml
@@ -3,23 +3,6 @@ trustedArtifactSigner:
   # OpenShift cluster's ingress domain, e.g. apps.cluster.example.com. The domain
   # is used to generate the "trusted-artifact-signer" Fulcio's email.
   ingressDomain: __OVERWRITE_ME__
-  # Imports the "Trusted Artifact Signer" realm into Keycloak.
-  keycloakRealmImport:
-    # Enable the Keycloak realm import.
-    enabled: true
-    # Keycloak instance to import the realm into, the Kubernetes namespace and
-    # name of the Keycloak instance.
-    keycloakCR:
-      namespace: __OVERWRITE_ME__
-      name: __OVERWRITE_ME__
-    # Secret holding the commong user, "trusted-artifact-signer", credentials.
-    userSecretName: trusted-artifact-signer-user
-    # Secret holding the OIDC client secrets.
-    oidcClientsSecretName: trusted-artifact-signer-clients
-    # OIDC clients.
-    clients:
-      trustedArtifactSigner:
-        enabled: true
   # Configures the Trusted Artifact Signer.
   secureSign:
     # Enable the Trusted Artifact Signer.

--- a/installer/charts/values.yaml.tpl
+++ b/installer/charts/values.yaml.tpl
@@ -288,13 +288,16 @@ developerHub:
 {{- else if eq $authProvider "gitlab" }}
     adminUsers:
 {{ dig "Properties" "RBAC" "adminUsers" (list "${GITLAB__USERNAME}") $rhdh | toYaml | indent 6 }}
-{{- end }}
+{{- else if eq $authProvider "oidc" }}
   oidc:
+    secretNamespace: {{ .Installer.Namespace }}
+    enabled: true
     clientID: rhdh
     metadataURL: {{ printf "%s://%s/realms/%s/.well-known/openid-configuration" $protocol $keycloakRouteHost $realmsName }}
     baseURL: {{ printf "%s://%s" $protocol $keycloakRouteHost }}
     loginRealm: {{ $realmsName }}
     realm: {{ $realmsName }}
+{{- end }}
 
 #
 # tssc-tpa


### PR DESCRIPTION
1. Remove useless keycloak settings in tssc-tas namespace
2. Add OIDC credential information in tssc-dh NOTES.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OIDC (OpenID Connect) authentication configuration with optional admin credential display.
  * Enabled Secure Sign functionality with integrated OIDC and certificate support for signing workflows.
  * Extended Role-Based Access Control (RBAC) to support OIDC as an authentication provider option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->