### PR TITLE
Fix test-metadata task in  e2e-periodic-pipeline.yaml

### DIFF
--- a/integration-tests/pipelines/e2e-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-periodic-pipeline.yaml
@@ -37,11 +37,11 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/test-metadata/0.2/test-metadata.yaml
+            value: tasks/test-metadata/0.2/test-metadata.yaml
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated periodic end-to-end test pipeline to point to an updated test-definitions source and manifest location so scheduled tests use revised test metadata.
  * No changes to exported/public interfaces; this is an internal test configuration update only.
  * Ensures periodic e2e runs use the latest cataloged test tasks and resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->