### PR TITLE
Upgrade go version to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-appstudio/tssc-cli
 
-go 1.24.0
+go 1.24.6
 
 toolchain go1.25.4
 


### PR DESCRIPTION
Jira: [RHTAP-5681](https://issues.redhat.com/browse/RHTAP-5681)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Go language version from 1.24.0 to 1.24.6 for maintenance; toolchain setting remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->