### PR TITLE
Add mcp tool tssc_topology

### DIFF
--- a/pkg/mcpserver/instructions.md
+++ b/pkg/mcpserver/instructions.md
@@ -25,6 +25,7 @@ This is the starting point. You must define the installation configuration.
 1. Use `tssc_status` to view the overall installer status.
 2. Use `tssc_config_get` to view the current configuration. Take note of each `.tssc.products[]` top comment to understand what each product does, so you can decide whether to install it or not.
 3. Use `tssc_config_get` to view the current configuration. For each entry in `.tssc.products[]`, read its leading comment/description to understand what the product does so you can decide whether to install it
+4. Use `tssc_topology` to display the dependency topology of the installer based on the cluster configuration and installer dependencies (Helm charts). After the installer configuration is updated, the user can inspect the topology of the Helm charts to be deployed.
 
 Once the configuration is successfully applied, we will proceed to the next phase.
 

--- a/pkg/mcptools/topology.go
+++ b/pkg/mcptools/topology.go
@@ -1,0 +1,96 @@
+package mcptools
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/redhat-appstudio/tssc-cli/pkg/chartfs"
+	"github.com/redhat-appstudio/tssc-cli/pkg/config"
+	"github.com/redhat-appstudio/tssc-cli/pkg/constants"
+	"github.com/redhat-appstudio/tssc-cli/pkg/resolver"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// TopologyTool represents the MCP tool that's responsible to report
+// the dependency topology of the installer based on the cluster
+// configuration and Helm charts.
+type TopologyTool struct {
+	cfs *chartfs.ChartFS          // embedded filesystem
+	cm  *config.ConfigMapManager  // cluster configuration
+	tb  *resolver.TopologyBuilder // topology builder
+}
+
+const (
+	// TopologyToolName mcp topology tool name
+	TopologyToolName = constants.AppName + "_topology"
+)
+
+// topologyHandler shows a table of the topology.
+func (t *TopologyTool) topologyHandler(
+	ctx context.Context,
+	_ mcp.CallToolRequest,
+) (*mcp.CallToolResult, error) {
+	// Load the installer configuration from the cluster.
+	cfg, err := t.cm.GetConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Inspect the topology to ensure all dependencies and
+	// integrations are resolved.
+	if _, err := t.tb.Build(ctx, cfg); err != nil {
+		return nil, err
+	}
+	// Resolving the dependency topology based on the installer configuration and
+	// Helm charts.
+	r := resolver.NewResolver(cfg, t.tb.GetCollection(), resolver.NewTopology())
+	if err := r.Resolve(); err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	r.Print(&buf)
+
+	return mcp.NewToolResultText(fmt.Sprintf(`
+The topology is a table with following columns:
+
+  - Index: the index of the chart in the dependency graph.
+  - Dependency: the name of the Helm chart.
+  - Namespace: the OpenShift namespace where the chart is installed.
+  - Product: the name of the product the chart is associated with.
+  - Depends-On: comma-separated list of charts the chart depends on.
+  - Provided-Integrations: comma-separated integrations provided by the chart.
+  - Required-Integrations: CEL expressions with the required integrations.
+
+---
+%s`,
+		buf.String())), nil
+}
+
+func (t *TopologyTool) Init(s *server.MCPServer) {
+	s.AddTools([]server.ServerTool{{
+		Tool: mcp.NewTool(
+			TopologyToolName,
+			mcp.WithDescription(`
+Report the dependency topology of the installer based on the
+cluster configuration and installer dependencies (Helm charts).
+			`),
+		),
+		Handler: t.topologyHandler,
+	}}...)
+}
+
+// NewTopologyTool instantiates a new TopologyTool.
+func NewTopologyTool(
+	cfs *chartfs.ChartFS,
+	cm *config.ConfigMapManager,
+	tb *resolver.TopologyBuilder,
+) *TopologyTool {
+	return &TopologyTool{
+		cfs: cfs,
+		cm:  cm,
+		tb:  tb,
+	}
+}

--- a/pkg/subcmd/mcpserver.go
+++ b/pkg/subcmd/mcpserver.go
@@ -81,8 +81,10 @@ func (m *MCPServer) Run() error {
 
 	notesTool := mcptools.NewNotesTool(m.logger, m.flags, m.kube, cm, tb)
 
+	topologyTool := mcptools.NewTopologyTool(m.cfs, cm, tb)
+
 	s := mcpserver.NewMCPServer()
-	s.AddTools(configTools, statusTool, integrationTools, deployTools, notesTool)
+	s.AddTools(configTools, statusTool, integrationTools, deployTools, notesTool, topologyTool)
 	return s.Start()
 }
 


### PR DESCRIPTION
Add mcp tool `tssc_topology`

Jira: [RHTAP-5750](https://issues.redhat.com/browse/RHTAP-5750)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Phase 1, Step 4: dependency topology visualization during configuration. Users can generate and view a textual topology table of installer/chart dependencies based on cluster configuration to inspect topology after configuration updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->