### PR TITLE
fix: use source repo name from PR for rhads-config download

### DIFF
--- a/integration-tests/tasks/get-rhads-config.yaml
+++ b/integration-tests/tasks/get-rhads-config.yaml
@@ -28,7 +28,9 @@ spec:
         set -euo pipefail
 
         echo "Downloading rhads-config file:"
-        GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
+        # Extract the repository name from the source_repo_url
+        SOURCE_REPO_URL=$(jq -r '.git.source_repo_url' <<< $JOB_SPEC)
+        GIT_REPO=$(basename "$SOURCE_REPO_URL" .git)
         REPO_ORG=$(jq -r '.git.source_repo_org' <<< $JOB_SPEC)
         # Determine the branch name for the curl command.
         # If source_repo_branch starts with "refs/heads/", strip that prefix; otherwise, use as is.


### PR DESCRIPTION
The get-rhads-config task was incorrectly using '.git.repo' field which doesn't exist in the job-spec. This caused issues when forks still use the old 'rhtap-cli' repository name instead of the new 'tssc-cli' name.

Changed to extract the repository name from 'source_repo_url' which correctly reflects the actual fork's repository name, whether it's 'rhtap-cli' or 'tssc-cli'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes.** This release includes internal maintenance updates to how configuration is processed, with no impact to end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->