### PR TITLE
Using isAzurePipelinesAvailable given annotations we used in catalog

### DIFF
--- a/installer/charts/tssc-dh/templates/plugins-content.yaml
+++ b/installer/charts/tssc-dh/templates/plugins-content.yaml
@@ -65,7 +65,7 @@ plugins:
                     gridColumn: "1 / -1"
                   if:
                     allOf:
-                      - isAzureDevOpsAvailable
+                      - isAzurePipelinesAvailable
 {{- end }}
 {{- if (lookup "v1" "Secret" $integrationNamespace "tssc-github-integration") }}
   - disabled: false


### PR DESCRIPTION
Fixes [RHTAP-6074](https://issues.redhat.com//browse/RHTAP-6074)

In our catalog-info.yaml we use dev.azure.com/project and dev.azure.com/build-definition and therefore we should use isAzurePipelinesAvailable availability helper instead of isAzureDevOpsAvailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected the condition used to detect Azure Pipelines integration availability. The system now properly recognizes when your environment has Azure Pipelines configured, ensuring the integration plugin displays and functions appropriately.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->