### PR TITLE
RHTAP-6048: Use ConfigMap Namespace as Primary Installer Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 Red Hat Trusted Software Supply Chain CLI (`tssc`)
-------------------------------------------------------------
+--------------------------------------------------
 
 # Abstract
 
@@ -37,6 +37,9 @@ tssc config --help
 
 # Creates a new default configuration in the cluster, showing the result.
 tssc config --create --get
+
+# Creates a new default configuration in the cluster in a specific namespace.
+tssc config --create --namespace tssc
 ```
 
 2. Run the command `tssc` to display help text that shows all the supported commands and options. 
@@ -70,14 +73,12 @@ The [`config.yaml`](installer/config.yaml) file is structured to outline key com
 ```yaml
 ---
 tssc:
-  namespace: tssc
   settings: {}
   products: {}
 ```
 
 The attributes of the `tssc` object are as follows:
 
-- `.namespace`: Specifies the default namespace used by the installer, set to `tssc`. This namespace acts as the primary operational area for the installation process.
 - `.settings`: Defines the settings of the deployment. This can control a wide set of properties.
 - `.products`: Defines the features to be deployed by the installer. Each feature is identified by a unique name and a set of properties.
 

--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -1,7 +1,5 @@
 ---
 tssc:
-  # Main installer namespace.
-  namespace: &installerNamespace tssc
   settings:
     # Toggles the CRC settings for the installer, which adapts the deployment to
     # work on a CRC development environment.
@@ -45,8 +43,7 @@ tssc:
     # application delivery and reduces time to market on Red Hat OpenShift.
     - name: OpenShift Pipelines
       enabled: true
-      # No new resources will be created in the namespace
-      namespace: *installerNamespace
+      # Uses the installer's namespace.
       properties:
         manageSubscription: true
     # Red Hat Trusted Profile Analyzer (TPA), which leverages the community-driven

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,7 +14,7 @@ func TestNewConfigFromFile(t *testing.T) {
 	cfs, err := chartfs.NewChartFS("../../installer")
 	g.Expect(err).To(o.Succeed())
 
-	cfg, err := NewConfigFromFile(cfs, "config.yaml")
+	cfg, err := NewConfigFromFile(cfs, "config.yaml", "test-namespace")
 	g.Expect(err).To(o.Succeed())
 	g.Expect(cfg).NotTo(o.BeNil())
 	g.Expect(cfg.Installer).NotTo(o.BeNil())
@@ -65,13 +65,6 @@ func TestNewConfigFromFile(t *testing.T) {
 
 		// Asserting the original configuration looks like the marshaled one.
 		g.Expect(string(original)).To(o.Equal(configString))
-	})
-
-	t.Run("SetNamespace", func(t *testing.T) {
-		err := cfg.Set("tssc.namespace", "testnamespace")
-		g.Expect(err).To(o.Succeed())
-		configString := cfg.String()
-		g.Expect(string(configString)).To(o.ContainSubstring("testnamespace"))
 	})
 
 	t.Run("SetSettings", func(t *testing.T) {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -104,7 +104,7 @@ func (m *ConfigMapManager) GetConfig(ctx context.Context) (*Config, error) {
 		)
 	}
 
-	return NewConfigFromBytes([]byte(payload))
+	return NewConfigFromBytes([]byte(payload), configMap.GetNamespace())
 }
 
 // configMapForConfig generate a ConfigMap resource based on informed Config.
@@ -114,7 +114,7 @@ func (m *ConfigMapManager) configMapForConfig(
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      Name,
-			Namespace: cfg.Installer.Namespace,
+			Namespace: cfg.Namespace(),
 			Labels: map[string]string{
 				Label: "true",
 			},
@@ -131,12 +131,12 @@ func (m *ConfigMapManager) Create(ctx context.Context, cfg *Config) error {
 	if err != nil {
 		return err
 	}
-	coreClient, err := m.kube.CoreV1ClientSet(cfg.Installer.Namespace)
+	coreClient, err := m.kube.CoreV1ClientSet(cfg.Namespace())
 	if err != nil {
 		return nil
 	}
 	_, err = coreClient.
-		ConfigMaps(cfg.Installer.Namespace).
+		ConfigMaps(cfg.Namespace()).
 		Create(ctx, cm, metav1.CreateOptions{})
 	return err
 }
@@ -147,12 +147,12 @@ func (m *ConfigMapManager) Update(ctx context.Context, cfg *Config) error {
 	if err != nil {
 		return err
 	}
-	coreClient, err := m.kube.CoreV1ClientSet(cfg.Installer.Namespace)
+	coreClient, err := m.kube.CoreV1ClientSet(cfg.Namespace())
 	if err != nil {
 		return nil
 	}
 	_, err = coreClient.
-		ConfigMaps(cfg.Installer.Namespace).
+		ConfigMaps(cfg.Namespace()).
 		Update(ctx, cm, metav1.UpdateOptions{})
 	return err
 }

--- a/pkg/config/product.go
+++ b/pkg/config/product.go
@@ -19,9 +19,8 @@ type Product struct {
 	Name string `yaml:"name"`
 	// Enabled product toggle.
 	Enabled bool `yaml:"enabled"`
-	// Namespace target namespace for the product, which may involve different
-	// Helm charts targeting the specific product namespace, while the chart
-	// target is deployed in a different namespace.
+	// Namespace target namespace for product's dependency (Helm chart). If empty,
+	// it defaults to the installer's namespace.
 	Namespace *string `yaml:"namespace,omitempty"`
 	// Properties contains the product specific configuration.
 	Properties map[string]interface{} `yaml:"properties"`

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,6 +6,9 @@ const (
 	// AppName is the name of the application.
 	AppName = "tssc"
 
+	// Namespace is the default namespace for the application.
+	Namespace = "tssc"
+
 	// OrgName is the name of the organization.
 	OrgName = "redhat-appstudio"
 
@@ -16,10 +19,11 @@ const (
 var (
 	// RepoURI is the reverse repository URI for the application.
 	RepoURI = fmt.Sprintf("%s.%s.%s", AppName, OrgName, Domain)
+
+	// Version is the application version, set at build time via ldflags.
+	Version = "v0.0.0-SNAPSHOT"
+
+	// CommitID is the commit ID of the application, set at build time via git
+	// commit hash.
+	CommitID = ""
 )
-
-// Version is the application version, set at build time via ldflags.
-var Version = "v0.0.0-SNAPSHOT"
-
-// CommitID is the commit ID of the application, set at build time via git commit hash.
-var CommitID = ""

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -32,11 +32,11 @@ func TestEngine_Render(t *testing.T) {
 	cfs, err := chartfs.NewChartFS("../../installer")
 	g.Expect(err).To(o.Succeed())
 
-	cfg, err := config.NewConfigFromFile(cfs, "config.yaml")
+	cfg, err := config.NewConfigFromFile(cfs, "config.yaml", "test-namespace")
 	g.Expect(err).To(o.Succeed())
 
 	variables := NewVariables()
-	err = variables.SetInstaller(&cfg.Installer)
+	err = variables.SetInstaller(cfg)
 	g.Expect(err).To(o.Succeed())
 
 	t.Logf("Template: %s", testYamlTmpl)
@@ -60,7 +60,7 @@ func TestEngine_Render(t *testing.T) {
 
 	root := outputMap["root"].(map[string]interface{})
 	g.Expect(root).To(o.HaveKey("namespace"))
-	g.Expect(root["namespace"]).To(o.Equal(cfg.Installer.Namespace))
+	g.Expect(root["namespace"]).To(o.Equal(cfg.Namespace()))
 
 	g.Expect(root).To(o.HaveKey("settings"))
 	g.Expect(root["settings"]).NotTo(o.BeNil())

--- a/pkg/engine/variables.go
+++ b/pkg/engine/variables.go
@@ -18,15 +18,15 @@ type Variables struct {
 }
 
 // SetInstaller sets the installer configuration.
-func (v *Variables) SetInstaller(cfg *config.Spec) error {
-	v.Installer["Namespace"] = cfg.Namespace
-	settings, err := UnstructuredType(cfg.Settings)
+func (v *Variables) SetInstaller(cfg *config.Config) error {
+	v.Installer["Namespace"] = cfg.Namespace()
+	settings, err := UnstructuredType(cfg.Installer.Settings)
 	if err != nil {
 		return err
 	}
 	v.Installer["Settings"] = settings.AsMap()
 	products := map[string]interface{}{}
-	for _, product := range cfg.Products {
+	for _, product := range cfg.Installer.Products {
 		products[product.KeyName()] = product
 	}
 	v.Installer["Products"], err = UnstructuredType(products)

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/redhat-appstudio/tssc-cli/pkg/chartfs"
+	"github.com/redhat-appstudio/tssc-cli/pkg/constants"
 	"github.com/redhat-appstudio/tssc-cli/pkg/resolver"
 
 	o "github.com/onsi/gomega"
@@ -22,7 +23,7 @@ func TestNewHooks(t *testing.T) {
 	g.Expect(err).To(o.Succeed())
 
 	h := NewHooks(
-		resolver.NewDependencyWithNamespace(chart, "tssc"),
+		resolver.NewDependencyWithNamespace(chart, constants.Namespace),
 		&stdout,
 		&stderr,
 	)

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -34,7 +34,7 @@ type Installer struct {
 // SetValues prepares the values template for the Helm chart installation.
 func (i *Installer) SetValues(
 	ctx context.Context,
-	cfg *config.Spec,
+	cfg *config.Config,
 	valuesTmpl string,
 ) error {
 	i.logger.Debug("Preparing values template context")

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -59,7 +59,7 @@ func (i *Integration) log() *slog.Logger {
 // secretName generates the namespaced name for the integration secret.
 func (i *Integration) secretName(cfg *config.Config) types.NamespacedName {
 	return types.NamespacedName{
-		Namespace: cfg.Installer.Namespace,
+		Namespace: cfg.Namespace(),
 		Name:      i.name,
 	}
 }

--- a/pkg/mcptools/configtools.go
+++ b/pkg/mcptools/configtools.go
@@ -76,7 +76,7 @@ func (c *ConfigTools) getHandler(
 
 	// The cluster is not configured yet, showing the user a default configuration
 	// and hints on how to proceed.
-	if cfg, err = config.NewConfigDefault(); err != nil {
+	if cfg, err = config.NewConfigDefault(""); err != nil {
 		return nil, err
 	}
 
@@ -102,23 +102,22 @@ func (c *ConfigTools) initHandler(
 	ctx context.Context,
 	ctr mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
+	// Setting the namespace from user input, if provided.
+	ns, ok := ctr.GetArguments()[NamespaceArg].(string)
+	if !ok || ns == "" {
+		return nil, fmt.Errorf("namespace argument is required")
+	}
+
 	// Deep-copy the default config to avoid mutating c.defaultCfg.
 	payload, err := c.defaultCfg.MarshalYAML()
 	if err != nil {
 		return nil, err
 	}
-	cfgPtr, err := config.NewConfigFromBytes(payload)
+	cfgPtr, err := config.NewConfigFromBytes(payload, ns)
 	if err != nil {
 		return nil, err
 	}
 	cfg := cfgPtr
-
-	// Setting the namespace from user input, if provided.
-	if ns, ok := ctr.GetArguments()[NamespaceArg].(string); ok {
-		if err := cfg.Set("tssc.namespace", ns); err != nil {
-			return nil, err
-		}
-	}
 
 	// Ensure the configuration is valid.
 	if err := cfg.Validate(); err != nil {
@@ -131,7 +130,7 @@ func (c *ConfigTools) initHandler(
 		ctx,
 		c.logger,
 		c.kube,
-		cfg.Installer.Namespace,
+		cfg.Namespace(),
 	); err != nil {
 		return nil, err
 	}
@@ -143,7 +142,7 @@ func (c *ConfigTools) initHandler(
 
 	return mcp.NewToolResultText(fmt.Sprintf(`
 TSSC default configuration is successfully applied in %q namespace`,
-		cfg.Installer.Namespace,
+		cfg.Namespace(),
 	)), nil
 }
 
@@ -447,7 +446,7 @@ exists yet.`,
 The main namespace for TSSC ('.tssc.namespace'), where Red Hat Developer Hub (DH)
 and other fundamental services will be deployed.`,
 				),
-				mcp.DefaultString(c.defaultCfg.Installer.Namespace),
+				mcp.DefaultString(c.defaultCfg.Namespace()),
 			),
 		),
 		Handler: c.initHandler,
@@ -552,7 +551,7 @@ func NewConfigTools(
 	cm *config.ConfigMapManager,
 ) (*ConfigTools, error) {
 	// Loading the default configuration to serve as a reference for MCP tools.
-	defaultCfg, err := config.NewConfigDefault()
+	defaultCfg, err := config.NewConfigDefault("")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcptools/deploytools.go
+++ b/pkg/mcptools/deploytools.go
@@ -73,10 +73,10 @@ place. Inspect the error message below to assess the issue.`,
 	}
 
 	// Command to get the logs of the deployment job.
-	logsCmd := d.job.GetJobLogFollowCmd(cfg.Installer.Namespace)
+	logsCmd := d.job.GetJobLogFollowCmd(cfg.Namespace())
 
 	// Issue the deployment job using the informed flags.
-	err = d.job.Run(ctx, debug, dryRun, force, cfg.Installer.Namespace, d.image)
+	err = d.job.Run(ctx, debug, dryRun, force, cfg.Namespace(), d.image)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf(`
 Unable to issue the deployment Job, it returned the following error:

--- a/pkg/mcptools/statustool.go
+++ b/pkg/mcptools/statustool.go
@@ -58,7 +58,7 @@ func (s *StatusTool) statusHandler(
 	// Shell command to get the logs of the deployment job.
 	var logsCmdEx string
 	if cfg, cfgErr := s.cm.GetConfig(ctx); cfgErr == nil {
-		logsCmdEx = s.job.GetJobLogFollowCmd(cfg.Installer.Namespace)
+		logsCmdEx = s.job.GetJobLogFollowCmd(cfg.Namespace())
 	}
 
 	switch phase {

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -41,7 +41,7 @@ func (r *Resolver) setDependencyNamespace(d *Dependency) error {
 	// defined for it, while regular charts will use the installer's namespace.
 	var namespace string
 	if product == "" {
-		namespace = r.cfg.Installer.Namespace
+		namespace = r.cfg.Namespace()
 	} else {
 		spec, err := r.cfg.GetProduct(product)
 		if err != nil {

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -15,7 +15,8 @@ func TestNewResolver(t *testing.T) {
 	cfs, err := chartfs.NewChartFS("../../installer")
 	g.Expect(err).To(o.Succeed())
 
-	cfg, err := config.NewConfigFromFile(cfs, "config.yaml")
+	installerNamespace := "test-namespace"
+	cfg, err := config.NewConfigFromFile(cfs, "config.yaml", installerNamespace)
 	g.Expect(err).To(o.Succeed())
 
 	charts, err := cfs.GetAllCharts()
@@ -50,19 +51,19 @@ func TestNewResolver(t *testing.T) {
 		// Validating the order of the resolved dependencies, as well as the
 		// namespace of each dependency.
 		g.Expect(dependencyNamespaceMap).To(o.Equal(map[string]string{
-			"tssc-openshift":      "tssc",
-			"tssc-subscriptions":  "tssc",
-			"tssc-infrastructure": "tssc",
-			"tssc-iam":            "tssc",
+			"tssc-openshift":      installerNamespace,
+			"tssc-subscriptions":  installerNamespace,
+			"tssc-infrastructure": installerNamespace,
+			"tssc-iam":            installerNamespace,
 			"tssc-tpa":            "tssc-tpa",
 			"tssc-tas":            "tssc-tas",
-			"tssc-pipelines":      "tssc",
+			"tssc-pipelines":      installerNamespace,
 			"tssc-gitops":         "tssc-gitops",
-			"tssc-app-namespaces": "tssc",
+			"tssc-app-namespaces": installerNamespace,
 			"tssc-dh":             "tssc-dh",
 			"tssc-acs":            "tssc-acs",
 			"tssc-acs-test":       "tssc-acs",
-			"tssc-integrations":   "tssc",
+			"tssc-integrations":   installerNamespace,
 		}))
 		g.Expect(dependencySlice).To(o.Equal([]string{
 			"tssc-openshift",

--- a/pkg/subcmd/deploy.go
+++ b/pkg/subcmd/deploy.go
@@ -154,7 +154,7 @@ subcommand to configure them. For example:
 
 		i := installer.NewInstaller(d.log(), d.flags, d.kube, &dep)
 
-		err := i.SetValues(d.cmd.Context(), &d.cfg.Installer, string(valuesTmpl))
+		err := i.SetValues(d.cmd.Context(), d.cfg, string(valuesTmpl))
 		if err != nil {
 			return err
 		}
@@ -176,7 +176,7 @@ subcommand to configure them. For example:
 		if err = k8s.RetryDeleteResources(
 			d.cmd.Context(),
 			d.kube,
-			d.cfg.Installer.Namespace,
+			d.cfg.Namespace(),
 		); err != nil {
 			d.log().Debug(err.Error())
 		}

--- a/pkg/subcmd/template.go
+++ b/pkg/subcmd/template.go
@@ -116,7 +116,7 @@ func (t *Template) Run() error {
 	// Setting values and loading cluster's information.
 	if err = i.SetValues(
 		t.cmd.Context(),
-		&t.cfg.Installer,
+		t.cfg,
 		string(valuesTmplPayload),
 	); err != nil {
 		return err


### PR DESCRIPTION
The `tssc` installer previously stored the target namespace in the configuration payload under `.tssc.namespace`. This change removes that attribute and instead relies on the namespace where the `ConfigMap` is stored (or provided via CLI during creation) to identify the primary installer namespace.

```bash
tssc config --namespace="tssc" --create
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --namespace flag to config command (default: "tssc"); config creation accepts explicit installer namespace.

* **Documentation**
  * README updated with namespace-specific example, separator, and adjusted configuration snippet; clarified product namespace behavior and defaults.

* **Chores**
  * Replaced "Trusted Artifact Signer" with "Trusted Profile Analyzer".
  * Internal namespace handling standardized via a namespace accessor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->