### PR TITLE
fix: update container images to use ubi9 and ose-tools-rhel9:v4.19

### DIFF
--- a/installer/charts/_common/_copy-scripts.tpl
+++ b/installer/charts/_common/_copy-scripts.tpl
@@ -5,7 +5,7 @@
 */}}
 {{- define "common.copyScripts" -}}
 - name: copy-scripts
-  image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+  image: registry.access.redhat.com/ubi9/ubi-minimal:latest
   workingDir: /scripts
   command:
     - /bin/bash

--- a/installer/charts/_common/_no_op.tpl
+++ b/installer/charts/_common/_no_op.tpl
@@ -3,7 +3,7 @@
 # No op container
 #
 - name: no-op
-    image: registry.redhat.io/openshift4/ose-tools-rhel9
+    image: registry.access.redhat.com/ubi9/ubi-minimal:latest
     command:
         - bash
         - -c

--- a/installer/charts/tssc-acs-test/templates/tests/scanner.yaml
+++ b/installer/charts/tssc-acs-test/templates/tests/scanner.yaml
@@ -10,7 +10,7 @@
     # Test ACS availibility, pending https://issues.redhat.com/browse/RFE-6727
     #
     - name: acs-image-scan-test
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       command:
         - /scripts/test-acs-image-scan.sh
         - -d

--- a/installer/charts/tssc-acs-test/templates/tests/test.yaml
+++ b/installer/charts/tssc-acs-test/templates/tests/test.yaml
@@ -7,7 +7,7 @@
     #
 {{- range tuple "central" "central-db" "scanner" "scanner-db" }}
     - name: acs-{{ . }}-rollout
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ $namespace }}

--- a/installer/charts/tssc-acs/templates/job-stackrox-api.yaml
+++ b/installer/charts/tssc-acs/templates/job-stackrox-api.yaml
@@ -29,7 +29,7 @@ spec:
         # Generates a token for StackRox API, using the ACS Central credentials.
         #
         - name: stackrox-api-generate-token
-          image: registry.redhat.io/openshift4/ose-tools-rhel9
+          image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
           env:
             - name: ROX_ENDPOINT
               value: {{ include "acs.centralEndPoint" . }}

--- a/installer/charts/tssc-app-namespaces/templates/serviceaccounts/patch-serviceaccounts.yaml
+++ b/installer/charts/tssc-app-namespaces/templates/serviceaccounts/patch-serviceaccounts.yaml
@@ -29,7 +29,7 @@ spec:
     {{- include "common.copyScripts" $context | nindent 8 }}
   containers:
     - name: patch-serviceaccounts
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       command:
         - /scripts/patch-serviceaccounts.sh
       args:

--- a/installer/charts/tssc-dh/templates/tests/test.yaml
+++ b/installer/charts/tssc-dh/templates/tests/test.yaml
@@ -6,7 +6,7 @@
 {{- include "common.test" (merge $pod .) }}
   containers:
     - name: rollout-status-test
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ .Release.Namespace }}

--- a/installer/charts/tssc-gitops/templates/job-post-deploy.yaml
+++ b/installer/charts/tssc-gitops/templates/job-post-deploy.yaml
@@ -68,7 +68,7 @@ spec:
         # on a environment file.
         #
         - name: argocd-store-token
-          image: registry.redhat.io/openshift4/ose-tools-rhel9
+          image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
           env:
             - name: SECRET_NAME
               value: {{ $argoCD.integrationSecret.name }}

--- a/installer/charts/tssc-gitops/templates/tests/test.yaml
+++ b/installer/charts/tssc-gitops/templates/tests/test.yaml
@@ -7,7 +7,7 @@
     # Test the ArgoCD rollout status.
     #
     - name: {{ printf "argocd-%s" $argoCD.name }}
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ $argoCD.namespace }}

--- a/installer/charts/tssc-iam/templates/tests/test.yaml
+++ b/installer/charts/tssc-iam/templates/tests/test.yaml
@@ -12,7 +12,7 @@
   {{- $rhdh := $keycloak.keycloakCR.rhdhRealm }}
 
     - name: {{ printf "keycloak-%s" $keycloakName }}
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ $keycloak.namespace }}
@@ -32,7 +32,7 @@
         allowPrivilegeEscalation: false
   {{- if or $tas.enabled $tpa.enabled $rhdh.enabled }}
     - name: realm-test
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ $keycloak.keycloakCR.namespace }}

--- a/installer/charts/tssc-infrastructure/templates/tests/test.yaml
+++ b/installer/charts/tssc-infrastructure/templates/tests/test.yaml
@@ -37,7 +37,7 @@
     # Tests the OpenShift Pipelines rollout status.
     #
     - name: test-rollout-openshift-pipelines
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ $osp.namespace }}

--- a/installer/charts/tssc-integrations/templates/acs/pod.yaml
+++ b/installer/charts/tssc-integrations/templates/acs/pod.yaml
@@ -36,7 +36,7 @@ spec:
     # Create the Artifactory integration.
     #
     - name: artifactory-integration
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ .Release.Namespace }}
@@ -66,7 +66,7 @@ spec:
     # Create the Nexus integration.
     #
     - name: nexus-integration
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ .Release.Namespace }}
@@ -96,7 +96,7 @@ spec:
     # Create the Quay integration.
     #
     - name: quay-integration
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ .Release.Namespace }}
@@ -124,7 +124,7 @@ spec:
     # Make sure there's at least one container
     #
     - name: no-op
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       command:
         - bash
         - -c

--- a/installer/charts/tssc-subscriptions/templates/tests/test.yaml
+++ b/installer/charts/tssc-subscriptions/templates/tests/test.yaml
@@ -5,7 +5,7 @@
     # Tests the subcriptions CRDs.
     #
     - name: test-subscriptions-crds
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       command:
         - /scripts/test-subscriptions.sh
       args:
@@ -25,7 +25,7 @@
     # Tests the {{ $sub.name }} rollout status.
     #
     - name: {{ printf "test-%s" ($sub.name | lower) }} 
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ $sub.namespace }}

--- a/installer/charts/tssc-tas/templates/_copy-scripts.tpl
+++ b/installer/charts/tssc-tas/templates/_copy-scripts.tpl
@@ -5,7 +5,7 @@
 */}}
 {{- define "common.copyScripts" -}}
 - name: copy-scripts
-  image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+  image: registry.access.redhat.com/ubi9/ubi-minimal:latest
   workingDir: /scripts
   command:
     - /bin/bash

--- a/installer/charts/tssc-tas/templates/tests/test.yaml
+++ b/installer/charts/tssc-tas/templates/tests/test.yaml
@@ -4,7 +4,7 @@
 {{- include "common.test" . }}
   containers:
     - name: statefulsets-test
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ $secureSign.namespace }}

--- a/installer/charts/tssc-tpa/templates/_copy-scripts.tpl
+++ b/installer/charts/tssc-tpa/templates/_copy-scripts.tpl
@@ -5,7 +5,7 @@
 */}}
 {{- define "common.copyScripts" -}}
 - name: copy-scripts
-  image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+  image: registry.access.redhat.com/ubi9/ubi-minimal:latest
   workingDir: /scripts
   command:
     - /bin/bash

--- a/installer/charts/tssc-tpa/templates/tests/pre-install.yaml
+++ b/installer/charts/tssc-tpa/templates/tests/pre-install.yaml
@@ -3,7 +3,7 @@
 {{- include "common.preInstall" . }}
   containers:
     - name: test-url
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: URL
           value: {{

--- a/installer/charts/tssc-tpa/templates/tests/test.yaml
+++ b/installer/charts/tssc-tpa/templates/tests/test.yaml
@@ -2,7 +2,7 @@
 {{- include "common.test" . }}
   containers:
     - name: deployments-test
-      image: registry.redhat.io/openshift4/ose-tools-rhel9
+      image: registry.redhat.io/openshift4/ose-tools-rhel9:v4.19
       env:
         - name: NAMESPACE
           value: {{ .Release.Namespace }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base container images from UBI8 to UBI9 for improved compatibility
  * Pinned container image versions to v4.19 across deployment templates for version consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->