### PR TITLE
fix: Makefile and deploy.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ image: image-podman
 # Builds the container image with Podman.
 image-podman:
 	@echo "# Building '$(IMAGE_FQN)'..."
-	podman build --tag="$(IMAGE_FQN)" .
+	podman build --build-arg COMMIT_ID=$(COMMIT_ID) --build-arg VERSION_ID=$(VERSION) --tag="$(IMAGE_FQN)" .
 
 # Logins into the container registry.
 login-buildah:
@@ -132,7 +132,7 @@ login-buildah:
 # Builds the container image with Buildah.
 image-buildah:
 	@echo "# Building '$(IMAGE_FQN)'..."
-	buildah bud --tag="$(IMAGE_FQN)" .
+	buildah bud --build-arg COMMIT_ID=$(COMMIT_ID) --build-arg VERSION_ID=$(VERSION) --tag="$(IMAGE_FQN)" .
 
 # Tags the container image with the provided arguments as tag.
 image-buildah-tag: NEW_IMAGE_FQN = $(IMAGE_REPO)/$(IMAGE_NAMESPACE)/$(APP):$(ARGS)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Image builds now receive commit and version as build-time variables so artifacts record build metadata.
  * Dev build flow now uses the containerized make image target and publishes a fully qualified registry image.
  * Deployment logic now discovers the target namespace by querying cluster ConfigMaps across namespaces; prior config-file namespace extraction was removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->