### PR TITLE
RHTAP-6091: Ensure a Single Cluster Configuration (MCP)

### DIFF
--- a/pkg/config/product.go
+++ b/pkg/config/product.go
@@ -58,7 +58,8 @@ func (p *Product) GetNamespace() string {
 // Validate validates the product configuration, checking for missing fields.
 func (p *Product) Validate() error {
 	if p.Enabled && p.GetNamespace() == "" {
-		return fmt.Errorf("%w: missing namespace", ErrInvalidConfig)
+		return fmt.Errorf("%w: product %q: missing namespace",
+			ErrInvalidConfig, p.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
The MCP config initialization tool ensures that only one cluster configuration exists.

Assisted-by: Gemini

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages to clearly identify products when configuration validation fails, improving troubleshooting.
  * Added safeguards to prevent accidental re-initialization when configurations already exist.
  * Improved namespace configuration sourcing and error handling during configuration retrieval operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->