### PR TITLE
feat: Upgrade GitOps to 1.19

### DIFF
--- a/installer/charts/tssc-gitops/Chart.yaml
+++ b/installer/charts/tssc-gitops/Chart.yaml
@@ -4,7 +4,7 @@ name: tssc-gitops
 description: TSSC OpenShift GitOps
 type: application
 version: "1.8.0"
-appVersion: "1.18"
+appVersion: "1.19"
 annotations:
   tssc.redhat-appstudio.github.com/product-name: OpenShift GitOps
   tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions

--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -6,7 +6,7 @@ subscriptions:
     apiResource: gitopsservices.pipelines.openshift.io
     namespace: openshift-operators
     name: openshift-gitops-operator
-    channel: gitops-1.18
+    channel: gitops-1.19
     source: redhat-operators
     sourceNamespace: openshift-marketplace
     config:


### PR DESCRIPTION
cf [RHTAP-6058](https://issues.redhat.com//browse/RHTAP-6058)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version from 1.18 to 1.19
  * Updated OpenShift GitOps subscription channel from gitops-1.18 to gitops-1.19

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->