### PR TITLE
fix(plugins): use Red Hat ArgoCD backend plugin

### DIFF
--- a/installer/charts/tssc-dh/templates/plugins-content.yaml
+++ b/installer/charts/tssc-dh/templates/plugins-content.yaml
@@ -18,6 +18,14 @@ plugins:
         appLocatorMethods:
           - type: 'config'
             instances: []
+
+  - disabled: false
+    package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-argocd-dynamic
+    pluginConfig:
+      argocd:
+        appLocatorMethods:
+          - type: 'config'
+            instances: []
 {{- end }}
   #
   # CI

--- a/installer/charts/tssc-dh/templates/plugins-content.yaml
+++ b/installer/charts/tssc-dh/templates/plugins-content.yaml
@@ -18,7 +18,6 @@ plugins:
         appLocatorMethods:
           - type: 'config'
             instances: []
-
   - disabled: false
     package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-argocd-dynamic
     pluginConfig:

--- a/installer/charts/tssc-dh/templates/plugins-content.yaml
+++ b/installer/charts/tssc-dh/templates/plugins-content.yaml
@@ -12,14 +12,7 @@ plugins:
   - disabled: false
     package: ./dynamic-plugins/dist/backstage-community-plugin-redhat-argocd
   - disabled: false
-    package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend-dynamic
-    pluginConfig:
-      argocd:
-        appLocatorMethods:
-          - type: 'config'
-            instances: []
-  - disabled: false
-    package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-argocd-dynamic
+    package: oci://quay.io/redhat-tssc/backstage-plugins:1.8.0!tssc-plugins-backstage-community-plugin-redhat-argocd-backend
     pluginConfig:
       argocd:
         appLocatorMethods:


### PR DESCRIPTION
The RoadieHQ ArgoCD backend plugin is no longer supported with the Red Hat ArgoCD front end plugin.

JIRA: 
- [RHTAP-6073](https://issues.redhat.com/browse/RHTAP-6073)
- [RHTAP-5684](https://issues.redhat.com/browse/RHTAP-5684)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the ArgoCD backend plugin source from local dynamic packages to a single OCI-hosted image reference. This centralizes plugin delivery while preserving existing ArgoCD integration settings and runtime behavior. No other plugin configurations were altered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->