### PR TITLE
fix(plugins): conditionally render Gitlab pipelines

### DIFF
--- a/installer/charts/tssc-dh/templates/plugins-content.yaml
+++ b/installer/charts/tssc-dh/templates/plugins-content.yaml
@@ -74,6 +74,21 @@ plugins:
 {{- if (lookup "v1" "Secret" $integrationNamespace "tssc-gitlab-integration") }}
   - disabled: false
     package: ./dynamic-plugins/dist/immobiliarelabs-backstage-plugin-gitlab
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          immobiliarelabs.backstage-plugin-gitlab:
+            mountPoints:
+              - mountPoint: entity.page.ci/cards
+                importName: EntityGitlabPipelinesTable
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                  if:
+                    allOf:
+                      - isGitlabAvailable
+                      - hasAnnotation:
+                          - gitlab.com/project-id
   - disabled: false
     package: ./dynamic-plugins/dist/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic
 {{- end }}

--- a/installer/charts/tssc-dh/templates/plugins-content.yaml
+++ b/installer/charts/tssc-dh/templates/plugins-content.yaml
@@ -83,7 +83,7 @@ plugins:
                 importName: EntityGitlabPipelinesTable
                 config:
                   layout:
-                    gridColumn: 1 / -1
+                    gridColumn: "1 / -1"
                   if:
                     allOf:
                       - isGitlabAvailable


### PR DESCRIPTION
The Gitlab Pipelines card has an issue where it will always try to render in the CI tab.

This change adds a condition to how it's rendered to prevent that. Now in order to render the Gitlab Pipelines card you'll need to use the `gitlab.com/project-id` annotation.

[The templates](https://github.com/redhat-appstudio/tssc-sample-templates/blob/7a948d50565652b0a260b259027095dfa9e6e1f6/skeleton/source-repo/catalog-info.yaml#L20) use `gitlab.com/project-slug` so the Gitlab pipelines should be hidden from the CI tab now.

JIRA: [RHTAP-4055](https://issues.redhat.com//browse/RHTAP-4055)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitLab CI/CD pipelines table to entity pages.
  * The table displays full-width and appears only when GitLab integration is available and the entity is configured with the GitLab project identifier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->