### PR TITLE
Moving reference for templates to consolidated repo

### DIFF
--- a/hack/code-freeze.sh
+++ b/hack/code-freeze.sh
@@ -102,7 +102,7 @@ update_charts() {
 update_template() {
     CONFIG="installer/config.yaml"
     get_version "developerHub"
-    CATALOG_URL="https://github.com/redhat-appstudio/tssc-sample-templates/blob/release-v${VERSION_XY}.x/all.yaml" \
+    CATALOG_URL="https://github.com/redhat-appstudio/tssc-dev-multi-ci/blob/release-v${VERSION_XY}.x/samples/all.yaml" \
     yq -i '(.tssc.products[] | select( .name == "Developer Hub") | .properties.catalogURL) = strenv(CATALOG_URL)' "$CONFIG"
 }
 

--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -64,7 +64,7 @@ tssc:
       enabled: true
       namespace: tssc-dh
       properties:
-        catalogURL: https://github.com/redhat-appstudio/tssc-sample-templates/blob/release-v1.8.x/all.yaml
+        catalogURL: https://github.com/redhat-appstudio/tssc-dev-multi-ci/blob/pre-release-v1.9.x/samples/all.yaml
         manageSubscription: true
         # namespacePrefixes:
         #   - tssc-app


### PR DESCRIPTION
Both tssc-sample-templates and tssc-sample-pipelines have been consolidated under tssc-dev-multi-ci. Changing reference in installer config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Developer Hub template catalog location in the installer configuration and related update script to point to a new repository path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->