### PR TITLE
test with OCP 4.20

### DIFF
--- a/integration-tests/config/rhads-config
+++ b/integration-tests/config/rhads-config
@@ -1,4 +1,4 @@
-OCP="4.17,4.18,4.19"
+OCP="4.18,4.19,4.20"
 ACS="remote"
 REGISTRY="quay,artifactory,nexus"
 TPA="local"


### PR DESCRIPTION
Updated the OCP versions in the integration test configuration to include 4.20


rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported OpenShift Container Platform versions to 4.18, 4.19, and 4.20.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->