### PR TITLE
Change DEVELOPER_HUB_CATALOG_URL if repo is tssc-dev-multi-ci

### DIFF
--- a/hack/private.env.template
+++ b/hack/private.env.template
@@ -7,7 +7,7 @@ ACS__CENTRAL_ENDPOINT=foo.bar.com:443
 #
 # DH
 #
-# CATALOG_URL="https://github.com/redhat-appstudio/tssc-sample-templates/blob/main/all.yaml"
+# CATALOG_URL="https://github.com/redhat-appstudio/tssc-dev-multi-ci/blob/main/samples/all.yaml"
 
 #
 # SCM

--- a/integration-tests/scripts/.ci-env
+++ b/integration-tests/scripts/.ci-env
@@ -1,5 +1,5 @@
 #### Templates
-# For testing your changes, replace with your fork and branch of tssc-sample-templates
+# For testing your changes, replace with your fork and branch of tssc-dev-multi-ci
 export DEVELOPER_HUB_CATALOG_URL=
 
 #### Customize App Deployment Namespaces

--- a/integration-tests/scripts/.env.template
+++ b/integration-tests/scripts/.env.template
@@ -5,7 +5,7 @@ export scm_config="github,gitlab,bitbucket"  # github, gitlab, bitbucket
 export pipeline_config="tekton,jenkins,actions,gitlabci" # tekton, jenkins, actions, gitlabci, azure
 
 #### Templates
-# For testing your changes, replace with your fork and branch of tssc-sample-templates
+# For testing your changes, replace with your fork and branch of tssc-dev-multi-ci
 export DEVELOPER_HUB_CATALOG_URL=
 
 #### Customize App Deployment Namespaces

--- a/integration-tests/tasks/tssc-install.yaml
+++ b/integration-tests/tasks/tssc-install.yaml
@@ -102,11 +102,11 @@ spec:
         echo "export pipeline_config=\"$PIPELINE_CONFIG\"" >> ${env_file}
         echo "export auth_config=\"$AUTH_CONFIG\"" >> ${env_file}
 
-        # Check if GIT_REPO is tssc-sample-templates and update Developer Hub catalog url based on PR changes
-        if [[ "${GIT_REPO}" = "tssc-sample-templates" ]]; then
+        # Check if GIT_REPO is tssc-dev-multi-ci and update Developer Hub catalog url based on PR changes
+        if [[ "${GIT_REPO}" = "tssc-dev-multi-ci" ]]; then
             GIT_REVISION="${GIT_REVISION:-$(echo "$JOB_SPEC" | jq -r '.git.commit_sha')}"
             GIT_URL="${GIT_URL:-$(echo "$JOB_SPEC" | jq -r '.git.source_repo_url')}"
-            TEST_DH_CATALOG_URL="$GIT_URL/blob/$GIT_REVISION/all.yaml"
+            TEST_DH_CATALOG_URL="$GIT_URL/blob/$GIT_REVISION/samples/all.yaml"
             # Update DEVELOPER_HUB_CATALOG_URL value in .ci-env
             sed -i "s|^export DEVELOPER_HUB_CATALOG_URL.*|export DEVELOPER_HUB_CATALOG_URL=${TEST_DH_CATALOG_URL}|" "${env_file}"
         fi


### PR DESCRIPTION
Changing logic to modify the DEVELOPER_HUB_CATALOG_URL in .ci-env if repo is tssc-dev-multi-ci instead of tssc-sample-templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated template and catalog configuration file references to point to new repository sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->