### PR TITLE
fix: improve macos compatibility of hack scripts

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -14,6 +14,12 @@ SCRIPT_DIR="$(
     pwd
 )"
 
+if [ "$(uname -s)" == "Darwin" ]; then
+    READLINK="greadlink"
+else
+    READLINK="readlink"
+fi
+
 usage() {
     echo "
 Usage:
@@ -56,7 +62,7 @@ parse_args() {
             shift
             ;;
         -e | --env-file)
-            ENVFILE="$(readlink -e "$2")"
+            ENVFILE="$($READLINK -e "$2")"
             shift
             ;;
         -i|--integration)
@@ -168,7 +174,9 @@ run_container() {
 }
 
 unshare() {
-    podman unshare chown -R 0:0 "$CONFIG_DIR"
+    if [ "$(uname -s)" != "Darwin" ]; then
+        podman unshare chown -R 0:0 "$CONFIG_DIR"
+    fi
 }
 
 configure() {

--- a/hack/reset.sh
+++ b/hack/reset.sh
@@ -12,6 +12,12 @@ SCRIPT_DIR="$(
     pwd
 )"
 
+if [ "$(uname -s)" == "Darwin" ]; then
+    READLINK="greadlink"
+else
+    READLINK="readlink"
+fi
+
 usage() {
     echo "
 Usage:
@@ -55,7 +61,7 @@ parse_args() {
             CLUSTER=1
             ;;
         -e | --env-file)
-            ENVFILE="$(readlink -e "$2")"
+            ENVFILE="$($READLINK -e "$2")"
             shift
             ;;
         -i|--integration)


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved macOS compatibility issues for deployment and reset workflows, enabling proper functionality on Apple systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->