### PR TITLE
Remove reading tarball in pkg/subcmd/installer.go

### DIFF
--- a/cmd/tssc/main.go
+++ b/cmd/tssc/main.go
@@ -56,6 +56,7 @@ func main() {
 		cfs,
 		framework.WithIntegrations(subcmd.StandardModules()...),
 		framework.WithMCPImage(mcpImage),
+		framework.WithInstallerTarball(installer.InstallerTarball),
 	)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create application: %v\n", err)

--- a/pkg/framework/app.go
+++ b/pkg/framework/app.go
@@ -28,8 +28,9 @@ type App struct {
 	flags              *flags.Flags            // global flags
 	kube               *k8s.Kube               // kubernetes client
 
-	mcpToolsBuilder mcptools.MCPToolsBuilder // tools builder
-	mcpImage        string                   // installer image
+	mcpToolsBuilder  mcptools.MCPToolsBuilder // tools builder
+	mcpImage         string                   // installer image
+	installerTarball []byte                   // embedded installer tarball
 }
 
 // Command exposes the Cobra command.
@@ -113,10 +114,12 @@ func (a *App) setupRootCmd() error {
 			a.ChartFS,
 			a.kube,
 			a.integrationManager,
+			a.installerTarball,
 		),
 		subcmd.NewInstaller(
 			a.AppCtx,
 			a.flags,
+			a.installerTarball,
 		),
 		subcmd.NewMCPServer(
 			a.AppCtx,
@@ -133,6 +136,7 @@ func (a *App) setupRootCmd() error {
 			a.flags,
 			a.ChartFS,
 			a.kube,
+			a.installerTarball,
 		),
 		subcmd.NewTopology(
 			a.AppCtx,

--- a/pkg/framework/options.go
+++ b/pkg/framework/options.go
@@ -30,3 +30,10 @@ func WithMCPToolsBuilder(builder mcptools.MCPToolsBuilder) Option {
 		a.mcpToolsBuilder = builder
 	}
 }
+
+// WithInstallerTarball sets the embedded installer tarball for the application.
+func WithInstallerTarball(tarball []byte) Option {
+	return func(a *App) {
+		a.installerTarball = tarball
+	}
+}

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -27,8 +27,9 @@ type Installer struct {
 	kube   *k8s.Kube            // kubernetes client
 	dep    *resolver.Dependency // dependency to install
 
-	valuesBytes []byte           // rendered values
-	values      chartutil.Values // helm chart values
+	valuesBytes      []byte           // rendered values
+	values           chartutil.Values // helm chart values
+	installerTarball []byte           // embedded installer tarball
 }
 
 // SetValues prepares the values template for the Helm chart installation.
@@ -148,11 +149,13 @@ func NewInstaller(
 	f *flags.Flags,
 	kube *k8s.Kube,
 	dep *resolver.Dependency,
+	installerTarball []byte,
 ) *Installer {
 	return &Installer{
-		logger: dep.LoggerWith(logger),
-		flags:  f,
-		kube:   kube,
-		dep:    dep,
+		logger:           dep.LoggerWith(logger),
+		flags:            f,
+		kube:             kube,
+		dep:              dep,
+		installerTarball: installerTarball,
 	}
 }

--- a/pkg/subcmd/deploy.go
+++ b/pkg/subcmd/deploy.go
@@ -33,6 +33,7 @@ type Deploy struct {
 	topologyBuilder    *resolver.TopologyBuilder // topology builder
 	chartPath          string                    // single chart path
 	valuesTemplatePath string                    // values template file path
+	installerTarball   []byte                    // embedded installer tarball
 }
 
 var _ api.SubCommand = &Deploy{}
@@ -155,7 +156,7 @@ subcommand to configure them. For example:
 		)
 		fmt.Printf("%s\n", strings.Repeat("#", 60))
 
-		i := installer.NewInstaller(d.log(), d.flags, d.kube, &dep)
+		i := installer.NewInstaller(d.log(), d.flags, d.kube, &dep, d.installerTarball)
 
 		err := i.SetValues(d.cmd.Context(), d.cfg, string(valuesTmpl))
 		if err != nil {
@@ -198,6 +199,7 @@ func NewDeploy(
 	cfs *chartfs.ChartFS,
 	kube *k8s.Kube,
 	manager *integrations.Manager,
+	installerTarball []byte,
 ) api.SubCommand {
 	d := &Deploy{
 		cmd: &cobra.Command{

--- a/pkg/subcmd/installer.go
+++ b/pkg/subcmd/installer.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/redhat-appstudio/tssc-cli/installer"
 	"github.com/redhat-appstudio/tssc-cli/pkg/api"
 	"github.com/redhat-appstudio/tssc-cli/pkg/flags"
 
@@ -22,8 +21,9 @@ type Installer struct {
 	cmd   *cobra.Command // cobra command
 	flags *flags.Flags   // global flags
 
-	list    bool   // list the embedded resources
-	extract string // extract into a directory
+	list             bool   // list the embedded resources
+	extract          string // extract into a directory
+	installerTarball []byte // embedded installer tarball
 }
 
 var _ api.SubCommand = &Installer{}
@@ -84,7 +84,7 @@ func (i *Installer) Validate() error {
 
 // listResources lists the embedded resources.
 func (i *Installer) listResources() error {
-	tr := tar.NewReader(bytes.NewReader(installer.InstallerTarball))
+	tr := tar.NewReader(bytes.NewReader(i.installerTarball))
 
 	for {
 		header, err := tr.Next()
@@ -104,7 +104,7 @@ func (i *Installer) listResources() error {
 
 // extractResources extracts the embedded resources into the base directory.
 func (i *Installer) extractResources() error {
-	tr := tar.NewReader(bytes.NewReader(installer.InstallerTarball))
+	tr := tar.NewReader(bytes.NewReader(i.installerTarball))
 
 	for {
 		header, err := tr.Next()
@@ -214,14 +214,15 @@ func (i *Installer) Run() error {
 }
 
 // NewInstaller creates a new installer subcommand.
-func NewInstaller(appCtx *api.AppContext, f *flags.Flags) *Installer {
+func NewInstaller(appCtx *api.AppContext, f *flags.Flags, installerTarball []byte) *Installer {
 	i := &Installer{
 		cmd: &cobra.Command{
 			Use:   "installer",
 			Short: "Lists or extract the embedded installer resources",
 			Long:  installerDesc,
 		},
-		flags: f,
+		flags:            f,
+		installerTarball: installerTarball,
 	}
 
 	p := i.cmd.PersistentFlags()

--- a/pkg/subcmd/template.go
+++ b/pkg/subcmd/template.go
@@ -33,6 +33,7 @@ type Template struct {
 	showManifests      bool                // show rendered manifests
 	namespace          string              // dependency namespace
 	dep                resolver.Dependency // chart to render
+	installerTarball   []byte              // embedded installer tarball
 }
 
 var _ api.SubCommand = &Template{}
@@ -113,7 +114,7 @@ func (t *Template) Run() error {
 		return fmt.Errorf("failed to read values template file: %w", err)
 	}
 
-	i := installer.NewInstaller(t.logger, t.flags, t.kube, &t.dep)
+	i := installer.NewInstaller(t.logger, t.flags, t.kube, &t.dep, t.installerTarball)
 
 	// Setting values and loading cluster's information.
 	if err = i.SetValues(
@@ -153,6 +154,7 @@ func NewTemplate(
 	f *flags.Flags,
 	cfs *chartfs.ChartFS,
 	kube *k8s.Kube,
+	installerTarball []byte,
 ) *Template {
 	t := &Template{
 		cmd: &cobra.Command{
@@ -161,14 +163,15 @@ func NewTemplate(
 			Long:         templateDesc,
 			SilenceUsage: true,
 		},
-		logger:        logger.WithGroup("template"),
-		flags:         f,
-		appCtx:        appCtx,
-		cfs:           cfs,
-		kube:          kube,
-		showValues:    true,
-		showManifests: true,
-		namespace:     "default",
+		logger:           logger.WithGroup("template"),
+		flags:            f,
+		appCtx:           appCtx,
+		cfs:              cfs,
+		kube:             kube,
+		showValues:       true,
+		showManifests:    true,
+		namespace:        "default",
+		installerTarball: installerTarball,
 	}
 
 	p := t.cmd.PersistentFlags()


### PR DESCRIPTION
1. Add `installerTarball` to `app.go`
2. Calling `i.installerTarball` instead of reading from `embed.go` 
3. Add `WithInstallerTarball` in `main.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring an embedded installer tarball as an application option
  * Installer tarball can now be passed through the framework initialization and is automatically propagated to deploy, template, and installer subcommands
  * Subcommands can now utilize the embedded tarball during their operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->