### PR TITLE
fix: GitOps could not be deployed without RHDH

### DIFF
--- a/installer/values.yaml.tpl
+++ b/installer/values.yaml.tpl
@@ -219,7 +219,7 @@ appNamespaces:
 #
 
 argoCD:
-  enabled: {{ $rhdh.Enabled }}
+  enabled: {{ $gitops.Enabled }}
   name: {{ $argoCDName }}
   namespace: {{ $gitops.Namespace }}
   integrationSecret:


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AppNamespaces ArgoCD configuration to use GitOps settings instead of RHDH settings for determining component enablement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->