### PR TITLE
Konflux integration improvments

### DIFF
--- a/installer/charts/tssc-konflux/Chart.yaml
+++ b/installer/charts/tssc-konflux/Chart.yaml
@@ -7,4 +7,4 @@ version: "1.6.0"
 appVersion: "0.0"
 annotations:
   tssc.redhat-appstudio.github.com/product-name: Konflux
-  tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions
+  tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-pipelines

--- a/installer/charts/tssc-konflux/templates/job-public-key.yaml
+++ b/installer/charts/tssc-konflux/templates/job-public-key.yaml
@@ -1,0 +1,64 @@
+{{- $pipelinesNamespace := .Values.pipelines.namespace }}
+{{- $signingSecretName := "signing-secrets" -}}
+{{- $publicKeySecretName := "public-key" -}}
+{{- $signingSecretObj := (
+      lookup "v1" "Secret" $pipelinesNamespace $signingSecretName
+    ) | default dict
+-}}
+{{- $signingSecretData := (get $signingSecretObj "data") | default dict -}}
+{{- $signingCosignPubB64 := (get $signingSecretData "cosign.pub") | default "" -}}
+{{- $signingCosignPub := ternary ($signingCosignPubB64 | b64dec) "" (ne $signingCosignPubB64 "") -}}
+{{- $publicKeySecretObj := (
+      lookup "v1" "Secret" $pipelinesNamespace $publicKeySecretName
+    ) | default dict
+-}}
+{{- $publicKeySecretData := (get $publicKeySecretObj "data") | default dict -}}
+{{- $publicKeyCosignPubB64 := (get $publicKeySecretData "cosign.pub") | default "" -}}
+{{- $publicKeyCosignPub := ternary ($publicKeyCosignPubB64 | b64dec) "" (ne $publicKeyCosignPubB64 "") -}}
+{{- if and (ne $signingCosignPub "") (ne $signingCosignPub $publicKeyCosignPub) }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+  name: tssc-konflux-public-key
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      restartPolicy: Never
+      containers:
+        - name: copy-public-key
+          image: quay.io/codeready-toolchain/oc-client-base:latest
+          command:
+          - /bin/bash
+          - -c
+          - |
+            set -o errexit
+            set -o nounset
+            set -o pipefail
+
+            PUBLIC_KEY=${0:?Public key is required}
+            PIPELINES_NAMESPACE=${1:?Pipelines namespace is required}
+            PUBLIC_KEY_SECRET_NAME="public-key"
+
+            echo "Deleting existing public-key secret if it exists"
+            oc delete secret -n "$PIPELINES_NAMESPACE" "$PUBLIC_KEY_SECRET_NAME" || :
+
+            echo "Creating public-key secret in $PIPELINES_NAMESPACE namespace"
+            oc create secret generic \
+              "$PUBLIC_KEY_SECRET_NAME" \
+              --from-literal=cosign.pub="$PUBLIC_KEY" \
+              --namespace="$PIPELINES_NAMESPACE"
+
+            echo "Public key secret created successfully in $PIPELINES_NAMESPACE namespace"
+
+          args:
+            - {{ $signingCosignPub | quote }}
+            - {{ $pipelinesNamespace }}
+          securityContext:
+            allowPrivilegeEscalation: false
+{{- end }}

--- a/installer/charts/tssc-konflux/templates/konflux.yaml
+++ b/installer/charts/tssc-konflux/templates/konflux.yaml
@@ -11,6 +11,8 @@ metadata:
   name: konflux
   namespace: {{ .Values.konflux.namespace }}
 spec:
+  imageController:
+    enabled: true
   info:
     spec:
       publicInfo:

--- a/installer/charts/tssc-konflux/templates/konflux.yaml
+++ b/installer/charts/tssc-konflux/templates/konflux.yaml
@@ -1,7 +1,19 @@
+{{- $ghSecretObj := (lookup "v1" "Secret" .Values.konflux.tssc.namespace "tssc-github-integration") | default dict -}}
+{{- $secretData := (get $ghSecretObj "data") | default dict -}}
+{{- $applicationURL := "" -}}
+{{- if $secretData }}
+  {{- $applicationURL = (get $secretData "htmlURL") | b64dec | toString -}}
+{{- end }}
 ---
 apiVersion: konflux.konflux-ci.dev/v1alpha1
 kind: Konflux
 metadata:
   name: konflux
   namespace: {{ .Values.konflux.namespace }}
-spec: {}
+spec:
+  info:
+    spec:
+      publicInfo:
+        integrations:
+          github:
+            application_url: {{ $applicationURL | quote }}

--- a/installer/charts/tssc-konflux/templates/namespaces.yaml
+++ b/installer/charts/tssc-konflux/templates/namespaces.yaml
@@ -1,4 +1,4 @@
-{{- range (list "build-service" "integration-service") }}
+{{- range (list "build-service" "integration-service" "image-controller") }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/installer/charts/tssc-konflux/templates/public-key-viewer.yaml
+++ b/installer/charts/tssc-konflux/templates/public-key-viewer.yaml
@@ -1,0 +1,29 @@
+{{- $pipelinesNamespace := .Values.pipelines.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-chains-public-key-viewer
+  namespace: {{ $pipelinesNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-chains-public-key-viewer
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-chains-public-key-viewer
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - public-key
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/installer/charts/tssc-konflux/templates/quaytoken-secret.yaml
+++ b/installer/charts/tssc-konflux/templates/quaytoken-secret.yaml
@@ -1,0 +1,14 @@
+{{- $quaySecretObj := (lookup "v1" "Secret" .Values.konflux.tssc.namespace "tssc-quay-integration") -}}
+{{- $secretData := (required "Secret tssc-quay-integration not found in namespace" (get $quaySecretObj "data")) -}}
+{{- $quaytoken := (required "token field not found in secret" (get $secretData "token")) | b64dec | toString -}}
+{{- $organization := (required "organization field not found in secret" (get $secretData "organization")) | b64dec | toString -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: quaytoken
+  namespace: image-controller
+type: Opaque
+stringData:
+  quaytoken: {{ $quaytoken | quote }}
+  organization: {{ $organization | quote }}

--- a/installer/charts/tssc-konflux/templates/service-account.yaml
+++ b/installer/charts/tssc-konflux/templates/service-account.yaml
@@ -21,3 +21,18 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-secret-rw-pipelines
+  namespace: {{ .Values.pipelines.namespace }}
+  labels: {{- include "common.postDeployDeleteLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-secret-rw
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}

--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -16,13 +16,6 @@ tssc:
       # Uses the installer's namespace.
       properties:
         manageSubscription: true
-    # Community Konflux Operator  provides the CRDs for the Trusted Software Factory
-    # platform.
-    - name: Konflux
-      enabled: true
-      namespace: konflux-ui
-      properties:
-        manageSubscription: true
     # Red Hat Trusted Artifact Signer (TAS) enhances software supply chain
     # security by simplifying cryptographic signing and verification of software
     # artifacts like container images, binaries, and documents, leveraging an
@@ -38,6 +31,13 @@ tssc:
     - name: OpenShift Pipelines
       enabled: true
       # Uses the installer's namespace.
+      properties:
+        manageSubscription: true
+    # Community Konflux Operator  provides the CRDs for the Trusted Software Factory
+    # platform.
+    - name: Konflux
+      enabled: true
+      namespace: konflux-ui
       properties:
         manageSubscription: true
     # Red Hat Trusted Profile Analyzer (TPA), which leverages the community-driven


### PR DESCRIPTION
- Enable image controller and the creation of a quay token for it
- Create a secret with the public key chains is using, and give authenticated users permission to see chains public key. required by pipelines which runs Conforma.
- Inject github app url to the konflux config so it would be presented in konflux UI.