### PR TITLE
fix: GitOps could not be deployed without RHDH

### DIFF
--- a/installer/charts/values.yaml.tpl
+++ b/installer/charts/values.yaml.tpl
@@ -219,7 +219,7 @@ appNamespaces:
 #
 
 argoCD:
-  enabled: {{ $rhdh.Enabled }}
+  enabled: {{ $gitops.Enabled }}
   name: {{ $argoCDName }}
   namespace: {{ $gitops.Namespace }}
   integrationSecret:


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED