### PR TITLE
Add periodic-cleanup pipeline and git-org cleanup scripts

### DIFF
--- a/hack/ci/git-org-cleanup/bitbucket-repos-cleanup.sh
+++ b/hack/ci/git-org-cleanup/bitbucket-repos-cleanup.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+# Bitbucket repository cleanup script
+# Run with --help for getting usage: 
+# ./bitbucket-repos-cleanup.sh --help
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Common configuration
+DAYS="${DAYS:-14}"
+repo_name_regex="${REPO_NAME_REGEX:-^[a-z0-9-]*(python|dotnet-basic|java-quarkus|go|nodejs|java-springboot)[a-z0-9-]*(-gitops)?$}"
+
+usage() {
+    echo "
+Usage:
+    ${0##*/} [options]
+
+Required environment variables:
+    BITBUCKET_WORKSPACE - Bitbucket workspace name
+    BITBUCKET_PROJECT   - Bitbucket project key
+    
+    Authentication (choose one):
+    Option 1: Username + App Password
+        BITBUCKET_USERNAME - Bitbucket username
+        BITBUCKET_APP_PASSWORD - Bitbucket app password
+    
+    Option 2: Email + Access Token  
+        BITBUCKET_EMAIL        - Your Bitbucket email address
+        BITBUCKET_ACCESS_TOKEN - Bitbucket scoped API token
+
+Optional environment variables:
+    DAYS                - Number of days old repositories must be to qualify for cleanup (default: 14)
+    REPO_NAME_REGEX     - Regex pattern to match repository names for cleanup (default is set to match the repository names created by tssc-test)
+
+Optional arguments:
+    -d, --dry-run       Enable dry run mode - no actual deletions
+    -h, --help          Show this help message
+
+Examples:
+    # Using Username + App Password
+    BITBUCKET_USERNAME=user BITBUCKET_APP_PASSWORD=app_pass BITBUCKET_WORKSPACE=workspace BITBUCKET_PROJECT=project ${0##*/} --dry-run
+    BITBUCKET_USERNAME=user BITBUCKET_APP_PASSWORD=app_pass BITBUCKET_WORKSPACE=workspace BITBUCKET_PROJECT=project ${0##*/}
+    
+    # Using Email + Access Token
+    BITBUCKET_EMAIL=user@example.com BITBUCKET_ACCESS_TOKEN=token BITBUCKET_WORKSPACE=workspace BITBUCKET_PROJECT=project ${0##*/} --dry-run
+    BITBUCKET_EMAIL=user@example.com BITBUCKET_ACCESS_TOKEN=token BITBUCKET_WORKSPACE=workspace BITBUCKET_PROJECT=project ${0##*/}
+"
+}
+
+bitbucket_cleanup() {
+    export BITBUCKET_USERNAME="${BITBUCKET_USERNAME:-$(cat /usr/local/rhtap-cli-install/bitbucket-username 2>/dev/null || echo "")}"
+    export BITBUCKET_APP_PASSWORD="${BITBUCKET_APP_PASSWORD:-$(cat /usr/local/rhtap-cli-install/bitbucket-app-password 2>/dev/null || echo "")}"
+    export BITBUCKET_EMAIL="${BITBUCKET_EMAIL:-$(cat /usr/local/rhtap-cli-install/bitbucket-email 2>/dev/null || echo "")}"
+    export BITBUCKET_ACCESS_TOKEN="${BITBUCKET_ACCESS_TOKEN:-$(cat /usr/local/rhtap-cli-install/bitbucket-access-token 2>/dev/null || echo "")}"
+    export BITBUCKET_WORKSPACE="${BITBUCKET_WORKSPACE:-rhtap-test}"
+    export BITBUCKET_PROJECT="${BITBUCKET_PROJECT:-RHTAP}"
+    
+    # Set up authentication for different auth methods
+    if [[ -n "$BITBUCKET_USERNAME" && -n "$BITBUCKET_APP_PASSWORD" ]]; then
+        # Option 1: Username + App Password
+        AUTH_CREDS="$BITBUCKET_USERNAME:$BITBUCKET_APP_PASSWORD"
+        echo "Using Username: $BITBUCKET_USERNAME + App Password authentication"
+
+    elif [[ -n "$BITBUCKET_EMAIL" && -n "$BITBUCKET_ACCESS_TOKEN" ]]; then
+        # Option 2: Email + Access Token
+        AUTH_CREDS="$BITBUCKET_EMAIL:$BITBUCKET_ACCESS_TOKEN"
+        echo "Using Email: $BITBUCKET_EMAIL + Access Token authentication"
+
+    else
+        echo "Error: No valid authentication method configured" >&2
+        echo "Please set either:"
+        echo "  - BITBUCKET_USERNAME and BITBUCKET_APP_PASSWORD (for app password auth)"
+        echo "  - BITBUCKET_EMAIL and BITBUCKET_ACCESS_TOKEN (for access token auth)"
+        exit 1
+    fi
+    
+    # Calculate cutoff time
+    cutoff_date=$(date -d "-${DAYS} days" --iso-8601)
+    cutoff_time=$(date -d "$cutoff_date" +%s)
+    
+    echo "Checking Bitbucket workspace: $BITBUCKET_WORKSPACE"
+    echo "Checking Bitbucket project: $BITBUCKET_PROJECT"
+    echo "Cutoff date: $cutoff_date"
+    echo ""
+    
+    # Fetch repositories using scoped API token (max pagelen=100 for Bitbucket)
+    # Sort by updated_on (oldest first) to prioritize older repositories for cleanup
+    repos=$(curl -s -u "$AUTH_CREDS" -H "Accept: application/json" \
+        "https://api.bitbucket.org/2.0/repositories/$BITBUCKET_WORKSPACE?q=project.key=\"$BITBUCKET_PROJECT\"&sort=updated_on&pagelen=100")
+
+    # Check for API errors (only if .error field exists and is not null)
+    if echo "$repos" | jq -e '.error' >/dev/null 2>&1; then
+        echo "Error fetching repositories: $(echo "$repos" | jq -r '.error.message')" >&2
+        return 1
+    fi
+    
+    # Check if we got a valid response with values array
+    if ! echo "$repos" | jq -e '.values' >/dev/null 2>&1; then
+        echo "Error: Invalid response format from Bitbucket API" >&2
+        echo "Response: $repos"
+        return 1
+    fi
+    
+    # Process repositories (using process substitution to avoid subshell)
+    while read -r repo; do
+        repo_name=$(echo "$repo" | jq -r '.name' 2>/dev/null)
+        updated_on=$(echo "$repo" | jq -r '.updated_on' 2>/dev/null)
+
+        # Convert updated_on to Unix timestamp for comparison
+        updated_time=$(date -d "$updated_on" +%s)
+
+        # Check if repository matches pattern and is old enough
+        if [[ $repo_name =~ $repo_name_regex ]] && [[ $updated_time -lt $cutoff_time ]]; then
+            if [[ "$dry_run" == "true" ]]; then
+                echo "[DRY RUN] Would delete repository '$repo_name'. Last updated: $updated_on"
+            else
+                echo "Deleting repository '$repo_name'. Last updated: $updated_on"
+                http_code=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+                    -u "$AUTH_CREDS" \
+                    "https://api.bitbucket.org/2.0/repositories/$BITBUCKET_WORKSPACE/$repo_name")
+                
+                if [[ "$http_code" -eq 204 ]]; then
+                    echo "Repository '$repo_name' deleted successfully."
+                else
+                    echo "Failed to delete repository '$repo_name': $http_code"
+                fi
+            fi
+        fi
+    done <<< "$(echo "$repos" | jq -c '.values[]')"
+
+}
+
+parse_args() {
+    # Default configuration
+    dry_run="false"
+
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -d|--dry-run)
+                dry_run="true"
+                shift
+                ;;
+            *)
+                echo "Error: Invalid command syntax" >&2
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    parse_args "$@"
+    
+    echo "==================================="
+    echo "Bitbucket Repository Cleanup Script"
+    echo "==================================="  
+    echo "Dry run: $dry_run"
+    echo "Days threshold: $DAYS"
+    echo ""
+    
+    bitbucket_cleanup
+    
+    echo "Bitbucket cleanup completed!"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/hack/ci/git-org-cleanup/github-repos-cleanup.sh
+++ b/hack/ci/git-org-cleanup/github-repos-cleanup.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# GitHub repository cleanup script
+# Run with --help for getting usage:
+# ./github-repos-cleanup.sh --help
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Common configuration
+DAYS="${DAYS:-14}"
+repo_name_regex="${REPO_NAME_REGEX:-^[a-z0-9-]*(python|dotnet-basic|java-quarkus|go|nodejs|java-springboot)[a-z0-9-]*(-gitops)?$}"
+
+usage() {
+    echo "
+Usage:
+    ${0##*/} [options]
+
+Required environment variables:
+    GITHUB_TOKEN        - GitHub personal access token
+    GITHUB_ORG          - GitHub organization name
+
+Optional environment variables:
+    DAYS                - Number of days old repositories must be to qualify for cleanup (default: 14)
+    REPO_NAME_REGEX     - Regex pattern to match repository names for cleanup (default is set to match the repository names created by tssc-test)
+
+Optional arguments:
+    -d, --dry-run       Enable dry run mode - no actual deletions
+    -h, --help          Show this help message
+
+Examples:
+    # Dry run for GitHub cleanup
+    GITHUB_TOKEN=xxx GITHUB_ORG=myorg ${0##*/} --dry-run
+
+    # Actually delete repositories (default behavior)
+    GITHUB_TOKEN=xxx GITHUB_ORG=myorg ${0##*/}
+"
+}
+
+github_cleanup() {
+    export GITHUB_TOKEN="${GITHUB_TOKEN:-$(cat /usr/local/rhtap-cli-install/github_token 2>/dev/null || echo "")}"
+    export GITHUB_ORG="${GITHUB_ORG:-rhtap-rhdh-qe}"
+    
+    # Validate required environment variables
+    if [[ -z "$GITHUB_TOKEN" || -z "$GITHUB_ORG" ]]; then
+        echo "Error: Required environment variables are not set" >&2
+        echo "Please set:"
+        echo "  - GITHUB_TOKEN (GitHub personal access token)"
+        echo "  - GITHUB_ORG (GitHub organization name)"
+        exit 1
+    fi
+    
+    AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
+    
+    # Calculate cutoff time
+    now=$(date +%s)
+    cutoff_time=$((now - DAYS * 24 * 60 * 60))
+    
+    echo "Checking GitHub organization: $GITHUB_ORG"
+    echo "Cutoff date: $(date -d "@$cutoff_time")"
+    
+    # Fetch repositories (sorted by creation date, oldest first)
+    repos=$(curl -s -X GET -H "$AUTH_HEADER" "https://api.github.com/orgs/$GITHUB_ORG/repos?per_page=200&sort=created&direction=asc")
+    if echo "$repos" | jq -e '.status' >/dev/null 2>&1; then
+        echo "Error fetching repositories: $repos" >&2
+        return 1
+    fi
+    
+    # Process repositories
+    while read -r repo; do
+        repo_name=$(echo "$repo" | jq -r '.name' 2>/dev/null)
+        last_push=$(echo "$repo" | jq -r '.pushed_at' 2>/dev/null)
+        
+        # Convert the last push time to Unix timestamp
+        last_push_time=$(date -d "$last_push" +%s)
+        
+        # Check if repository matches pattern and is old enough
+        if [[ $repo_name =~ $repo_name_regex ]] && [[ $last_push_time -lt $cutoff_time ]]; then
+            if [[ "$dry_run" == "true" ]]; then
+                echo "[DRY RUN] Would delete repository '$repo_name'. Last updated: $last_push"
+            else
+                echo "Deleting repository '$repo_name'. Last updated: $last_push"
+                http_code=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+                    -H "$AUTH_HEADER" \
+                    "https://api.github.com/repos/$GITHUB_ORG/$repo_name")
+                
+                if [[ "$http_code" -eq 204 ]]; then
+                    echo "Repository '$repo_name' deleted successfully."
+                else
+                    echo "Failed to delete repository '$repo_name': HTTP $http_code"
+                fi
+            fi
+        fi
+    done <<< "$(echo "$repos" | jq -c '.[]')"
+}
+
+parse_args() {
+    # Default configuration
+    dry_run="false"
+
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -d|--dry-run)
+                dry_run="true"
+                shift
+                ;;
+            *)
+                echo "Error: Invalid command syntax" >&2
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    parse_args "$@"
+    
+    echo "==================================="
+    echo "GitHub Repository Cleanup Script"
+    echo "==================================="  
+    echo "Dry run: $dry_run"
+    echo "Days threshold: $DAYS"
+    echo ""
+
+    github_cleanup
+
+    echo "GitHub cleanup completed!"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/hack/ci/git-org-cleanup/gitlab-repos-cleanup.sh
+++ b/hack/ci/git-org-cleanup/gitlab-repos-cleanup.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# GitLab repository cleanup script
+# Run with --help for getting usage: 
+# ./gitlab-repos-cleanup.sh --help
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+# Common configuration
+DAYS="${DAYS:-14}"
+repo_name_regex="${REPO_NAME_REGEX:-^[a-z0-9-]*(python|dotnet-basic|java-quarkus|go|nodejs|java-springboot)[a-z0-9-]*(-gitops)?$}"
+
+usage() {
+    echo "
+Usage:
+    ${0##*/} [options]
+
+Required environment variables:
+    GITLAB_TOKEN        - GitLab personal access token
+    GITLAB_GROUP        - GitLab group ID
+
+Optional environment variables:
+    GITLAB_URL          - GitLab instance URL (default: https://gitlab.com)
+    DAYS                - Number of days old repositories must be to qualify for cleanup (default: 14)
+    REPO_NAME_REGEX     - Regex pattern to match repository names for cleanup (default is set to match the repository names created by tssc-test)
+
+Optional arguments:
+    -d, --dry-run       Enable dry run mode - no actual deletions
+    -h, --help          Show this help message
+
+Examples:
+    # Dry run for GitLab cleanup
+    GITLAB_TOKEN=xxx GITLAB_GROUP=123 ${0##*/} --dry-run
+
+    # Actually delete repositories (default behavior)
+    GITLAB_TOKEN=xxx GITLAB_GROUP=123 ${0##*/}
+"
+}
+
+gitlab_cleanup() {
+    export GITLAB_TOKEN="${GITLAB_TOKEN:-$(cat /usr/local/rhtap-cli-install/gitlab_token 2>/dev/null || echo "")}"
+    export GITLAB_GROUP="${GITLAB_GROUP:-$(cat /usr/local/rhtap-cli-install/gitlab-group 2>/dev/null || echo "")}"
+    export GITLAB_URL="${GITLAB_URL:-https://gitlab.com}"
+    
+    # Validate required environment variables
+    if [[ -z "$GITLAB_TOKEN" || -z "$GITLAB_GROUP" ]]; then
+        echo "Error: Required environment variables are not set" >&2
+        echo "Please set:"
+        echo "  - GITLAB_TOKEN (GitLab personal access token)"
+        echo "  - GITLAB_GROUP (GitLab group ID)"
+        exit 1
+    fi
+    
+    AUTH_HEADER="PRIVATE-TOKEN: $GITLAB_TOKEN"
+    
+    
+    # Calculate cutoff time
+    cutoff_date=$(date -d "-${DAYS} days" --iso-8601)
+    
+    echo "Checking GitLab group: $GITLAB_GROUP"
+    echo "GitLab URL: $GITLAB_URL"
+    echo "Cutoff date: $cutoff_date"
+    echo ""
+    
+    # Fetch projects from group (sorted by creation date, oldest first)
+    projects=$(curl -s -H "$AUTH_HEADER" \
+        "$GITLAB_URL/api/v4/groups/$GITLAB_GROUP/projects?per_page=200&order_by=created_at&sort=asc")
+    
+    if echo "$projects" | jq -e '.message or .error' 2>/dev/null ; then
+        echo "Error fetching projects: $projects" >&2
+        return 1
+    fi
+    
+    # Process projects (using process substitution to avoid subshell)
+    while read -r project; do
+        project_name=$(echo "$project" | jq -r '.name' 2>/dev/null)
+        project_id=$(echo "$project" | jq -r '.id' 2>/dev/null)
+        last_activity=$(echo "$project" | jq -r '.last_activity_at' 2>/dev/null)
+        
+        # Convert last activity to Unix timestamp for comparison
+        last_activity_time=$(date -d "$last_activity" +%s)
+        cutoff_time=$(date -d "$cutoff_date" +%s)
+        
+        # Check if project matches pattern and is old enough
+        if [[ $project_name =~ $repo_name_regex ]] && [[ $last_activity_time -lt $cutoff_time ]]; then
+            if [[ "$dry_run" == "true" ]]; then
+                echo "[DRY RUN] Would delete project '$project_name' (ID: $project_id). Last activity: $last_activity"
+            else
+                echo "Deleting project '$project_name' (ID: $project_id). Last activity: $last_activity"
+                http_code=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+                    -H "$AUTH_HEADER" \
+                    "$GITLAB_URL/api/v4/projects/$project_id")
+                
+                if [[ "$http_code" -eq 202 ]] || [[ "$http_code" -eq 204 ]]; then
+                    echo "Project '$project_name' deleted successfully."
+                else
+                    echo "Failed to delete project '$project_name': HTTP $http_code"
+                fi
+            fi
+        fi
+    done <<< "$(echo "$projects" | jq -c '.[]')"
+}
+
+parse_args() {
+    # Default configuration
+    dry_run="false"
+
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -d|--dry-run)
+                dry_run="true"
+                shift
+                ;;
+            *)
+                echo "Error: Invalid command syntax" >&2
+                usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    parse_args "$@"
+    
+    echo "==================================="
+    echo "GitLab Repository Cleanup Script"
+    echo "==================================="  
+    echo "Dry run: $dry_run"
+    echo "Days threshold: $DAYS"
+    echo ""
+        
+    gitlab_cleanup
+
+    echo "GitLab cleanup completed!"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/integration-tests/pipelines/periodic-cleanup-pipeline.yaml
+++ b/integration-tests/pipelines/periodic-cleanup-pipeline.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: periodic-cleanup-pipeline
+spec:
+  description: >-
+    This pipeline executes multiple cleanup scripts in parallel using a matrix,
+    allowing all cleanup to complete regardless of individual failures.
+  tasks:
+    - name: cleanup-resources
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/redhat-appstudio/tssc-cli.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: integration-tests/tasks/download-and-execute-cleanup.yaml
+      matrix:
+        params:
+          - name: script-path
+            value:
+              - hack/ci/git-org-cleanup/github-repos-cleanup.sh
+              - hack/ci/git-org-cleanup/gitlab-repos-cleanup.sh
+              - hack/ci/git-org-cleanup/bitbucket-repos-cleanup.sh

--- a/integration-tests/tasks/download-and-execute-cleanup.yaml
+++ b/integration-tests/tasks/download-and-execute-cleanup.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: download-and-execute-cleanup
+spec:
+  description: >-
+    This task downloads a shell script from a URL from script-url and executes it.
+  params:
+    - name: script-path
+      type: string
+      description: The script path in the source git repo where script is located
+    - name: source-git-repo
+      type: string
+      default: "redhat-appstudio/tssc-cli"
+      description: Git repository in format owner/repo where script is located
+    - name: source-git-revision
+      type: string
+      default: "main"
+      description: Git branch or revision where script is located
+  volumes:
+    - name: tssc-cli-volume
+      secret:
+        secretName: rhtap-cli-install
+  steps:
+    - name: download-and-execute-cleanup
+      image: quay.io/konflux-ci/tekton-integration-catalog/utils:latest
+      volumeMounts:
+        - name: tssc-cli-volume
+          mountPath: /usr/local/rhtap-cli-install
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        # Get Script name
+        SCRIPT_NAME="$(basename $(params.script-path))"
+
+        # Build Script URL from parameters
+        SCRIPT_URL="https://raw.githubusercontent.com/$(params.source-git-repo)/$(params.source-git-revision)/$(params.script-path)"
+
+        # Function to prefix logs
+        log_prefix() {
+          while read -r line; do
+            echo "[$SCRIPT_NAME] $line"
+          done
+        }
+
+        # Redirect all script output through the log prefix function
+        exec > >(log_prefix) 2>&1
+
+        echo "Downloading script from: $SCRIPT_URL"
+        curl -sSL "$SCRIPT_URL" -o /tmp/script.sh
+
+        echo "Making script executable..."
+        chmod +x /tmp/script.sh
+
+        echo "Executing script..."
+        /tmp/script.sh


### PR DESCRIPTION
Link to the ticket: [RHTAP-6121](https://issues.redhat.com/browse/RHTAP-6121), [RHTAP-6120](https://issues.redhat.com/browse/RHTAP-6120)

Example Pipeline run in konflux with dry-run option: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-shared-team-tenant/applications/tssc-resources-cleanup/pipelineruns/periodic-cleanup-pipeline-run-dq5sm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated periodic cleanup pipeline for managing repositories across GitHub, GitLab, and Bitbucket platforms.
  * Supports configurable repository age thresholds and name pattern matching for selective cleanup.
  * Includes dry-run mode to preview cleanup actions before execution.
  * Enables parallel cleanup operations across multiple repository platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->