### PR TITLE
fix: Make the config options obvious in the error message

### DIFF
--- a/pkg/subcmd/config.go
+++ b/pkg/subcmd/config.go
@@ -113,7 +113,7 @@ func (c *Config) validateFlags() error {
 		return fmt.Errorf("cannot get and delete at the same time")
 	}
 	if !c.create && !c.force && !c.get && !c.delete {
-		return fmt.Errorf("either create, get or delete must be set")
+		return fmt.Errorf("either --create, --get or --delete must be set")
 	}
 	if c.cmd.Flags().Changed("namespace") && !c.create {
 		return fmt.Errorf("--namespace flag can only be used with --create")


### PR DESCRIPTION
A new user running `tssc config` for the first time is greeted with an error message that guides them to try `tssc config create` next, but the right thing to do is `tssc config --create`.

Update the error message to help the user do the right thing the first time.