### PR TITLE
Upgrade ACS to 4.9

### DIFF
--- a/installer/charts/tssc-acs/Chart.yaml
+++ b/installer/charts/tssc-acs/Chart.yaml
@@ -4,7 +4,7 @@ name: tssc-acs
 description: TSSC Advanced Cluster Security
 type: application
 version: "1.8.0"
-appVersion: "4.8"
+appVersion: "4.9"
 annotations:
   helmet.redhat-appstudio.github.com/product-name: Advanced Cluster Security
   helmet.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions

--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -44,7 +44,7 @@ subscriptions:
     enabled: false
     description: Red Hat Advanced Cluster Security Operator
     apiResource: centrals.platform.stackrox.io
-    channel: rhacs-4.8
+    channel: rhacs-4.9
     namespace: rhacs-operator
     name: rhacs-operator
     source: redhat-operators


### PR DESCRIPTION
Jira: [RHTAP-6057](https://issues.redhat.com/browse/RHTAP-6057)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 4.9 with corresponding updates to the Red Hat Advanced Cluster Security Operator subscription channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->