### PR TITLE
Adding explicit timeouts instead of using konflux defaults

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -57,6 +57,7 @@ spec:
         - name: job-spec
           value: $(tasks.test-metadata.results.job-spec)
     - name: start-nested-pipelines
+      timeout: "2h30m"
       runAfter:
         - test-metadata
         - process-rhads-config

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -176,9 +176,14 @@ spec:
             "--prefix-name" "e2e-$ocp_version$config_suffix"
             "-o" "name"
             "--serviceaccount" "konflux-integration-runner"
+            "--pipeline-timeout" "2h0m"
           )
+
           echo "Starting pipeline with testplan (${#testplan_b64} chars): ${testplan_b64:0:50}..."
           pipeline_run=$(tkn pipeline start -f https://raw.githubusercontent.com/$REPO_ORG/$REPO/refs/heads/$BRANCH/integration-tests/pipelines/tssc-cli-e2e.yaml "${tkn_params[@]}")
+          #Verifying Timeout
+          pipeline_timeout=$(oc get pipelinerun "${pipeline_run}" -n "${KONFLUX_NAMESPACE}" -o jsonpath='{.spec.timeouts.pipeline}')
+          echo "Pipeline run timeout set to ${pipeline_timeout}"
           # Construct console URL for the new PipelineRun
           CONSOLE_URL="${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${pipeline_run}"
           echo "Started new pipelinerun: ${CONSOLE_URL}"


### PR DESCRIPTION
We are having issue with e2e sub-pipeline runs timing out after exactly 1 hour. Adding timeouts to override Konflux defaults that seem to have changed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended nested pipeline execution timeout to 2h30m to reduce unexpected terminations.
  * Added a pipeline start timeout parameter to allow specifying runtime timeouts when launching pipelines.
  * Added a post-start verification step that reads and logs the created PipelineRun timeout for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->