### PR TITLE
Check status of pipeline right when it is finished

### DIFF
--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -344,6 +344,10 @@ spec:
         # Store results
         printf '%s\n' "${PIPELINERUNS_ARRAY[@]}" | jq -R . | jq -s . > $(results.pipeline-runs.path)
 
+        RESULTS_CACHE="/tmp/pipeline_status_cache"
+        touch "$RESULTS_CACHE"
+        export RESULTS_CACHE
+
         # Wait for completion function
         waitFor() {
           local CONDITION="$1"
@@ -365,6 +369,11 @@ spec:
                 else
                   # Pipeline is finished, remove it from the array
                   echo "Pipeline $PIPELINE_RUN has finished"
+                  if [[ "$MESSAGE_DONE" == "All nested pipelines finished" ]]; then
+                    STATUS=$(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}" 2>/dev/null)
+                    echo "${PIPELINE_RUN}=${STATUS}" >> "$RESULTS_CACHE"
+                    echo "Succeeded: $STATUS"
+                  fi
                 fi
               done
               # Update the array with only running pipelines
@@ -391,14 +400,17 @@ spec:
         SOME_PIPELINE_FAILED=false
         SOME_PIPELINE_SUCCEEDED=false
         for PIPELINE_RUN in "${PIPELINERUNS_ARRAY[@]}"; do
-          if [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "False" ]]; then
+          STATUS=$(grep "^${PIPELINE_RUN}=" "$RESULTS_CACHE" | cut -d'=' -f2)
+          if [[ "$STATUS" == "False" ]]; then
             if ! $SOME_PIPELINE_FAILED ; then
               echo "List of failed PLRs:"
             fi
             echo "${KONFLUX_URL}/ns/${KONFLUX_NAMESPACE}/applications/${KONFLUX_APPLICATION_NAME}/pipelineruns/${PIPELINE_RUN}"
             SOME_PIPELINE_FAILED=true
-          elif [[ $(oc get pipelinerun/$PIPELINE_RUN -n ${KONFLUX_NAMESPACE} -o jsonpath="{.status.conditions[?(@.type==\"Succeeded\")].status}") == "True" ]]; then
+          elif [[ "$STATUS" == "True" ]]; then
             SOME_PIPELINE_SUCCEEDED=true
+          else
+            echo "Could not determine status for pipeline run ${PIPELINE_RUN}"
           fi
         done
         if $SOME_PIPELINE_SUCCEEDED ; then


### PR DESCRIPTION
This will decrease the chance of rise condition with the pruner of PLRs. We get the status right after it is determined that the PLR is done instead of waiting at the end when all PLRs are done. Saving the results in a file that can then be access in the final loop to determine success or failure.

Assisted by AI: Gemini 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integration test harness now creates and uses a per-run status cache: pipeline outcomes are captured as runs complete and written to the cache during the wait phase. The final summary reads statuses from that cache instead of re-querying the API for each run, preserving the start/wait/summarize flow while reducing repeated service calls and improving test efficiency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->