### PR TITLE
chore: migrate Tekton resources from v1beta1 to v1 API

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: e2e-main-pipeline

--- a/integration-tests/pipelines/e2e-periodic-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-periodic-pipeline.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: e2e-periodic-pipeline

--- a/integration-tests/pipelines/static-code-analysis.yaml
+++ b/integration-tests/pipelines/static-code-analysis.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: static-code-analysis

--- a/integration-tests/pipelines/tssc-cli-e2e.yaml
+++ b/integration-tests/pipelines/tssc-cli-e2e.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: tssc-install-e2e

--- a/integration-tests/tasks/get-rhads-config.yaml
+++ b/integration-tests/tasks/get-rhads-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: get-rhads-config

--- a/integration-tests/tasks/process-periodic-configs.yaml
+++ b/integration-tests/tasks/process-periodic-configs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: process-periodic-configs

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: start-pipelines


### PR DESCRIPTION
Updates all Tekton Task and Pipeline definitions from deprecated v1beta1 API to stable v1 API version across integration tests.

Co-Authored-By: Claude Sonnet 4.5

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Tekton Pipeline and Task resources to API version v1 in integration tests, upgrading from the previous v1beta1 version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->