### PR TITLE
fix(dh): remove GITHUB__TOKEN from the DH config

### DIFF
--- a/installer/charts/tssc-dh/templates/app-config-content.yaml
+++ b/installer/charts/tssc-dh/templates/app-config-content.yaml
@@ -188,7 +188,6 @@ integrations:
 {{- if $githubSecretObj }}
   github:
     - host: ${GITHUB__HOST}
-      token: ${GITHUB__TOKEN}
       apps:
         - appId: ${GITHUB__APP__ID}
           clientId: ${GITHUB__APP__CLIENT__ID}

--- a/installer/charts/tssc-dh/templates/extra-env.yaml
+++ b/installer/charts/tssc-dh/templates/extra-env.yaml
@@ -76,11 +76,9 @@ data:
     {{- if $pacRoute }}
     GITHUB__APP__WEBHOOK__URL: {{ print "https://" $pacRoute.spec.host | b64enc }}
     GITHUB__HOST: {{ $ghSecretData.host }}
-    GITHUB__TOKEN: {{ $ghSecretData.token }}
     {{- end }}
     {{- if .Values.developerHub.RBAC.enabled }}
     GITHUB__ORG: {{ $ghSecretData.ownerLogin }}
-    GITHUB__USERNAME: {{ $ghSecretData.username | b64dec | lower | b64enc }}
     {{- end }}
 {{- end }}
 {{- $glSecretObj := (lookup "v1" "Secret" $integrationNamespace "tssc-gitlab-integration") -}}


### PR DESCRIPTION
This change removes the GITHUB__TOKEN from the DH config to prevent the token from being exposed in the DH config, and removes the GITHUB__USERNAME variable as it is not used.

This change is part of the fix for the GH integration issue.

cf [RHTAP-6135](https://issues.redhat.com//browse/RHTAP-6135)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the GitHub integration token from application configuration templates so credentials are no longer emitted by default.
  * Removed GitHub authentication environment variables (token and username) from deployment configuration emissions to reduce exposed secrets during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->