### PR TITLE
fix(hack/deploy.sh): remove unused configure_ci function and call fro…

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -252,22 +252,12 @@ deploy() {
     time tssc_cli deploy "${DEBUG:-}"
 }
 
-configure_ci() {
-    if [[ -n "${GITHUB:-}" ]]; then
-        "$CI_VAR_DIR/ci-set-org-vars.sh" --backend github
-    fi
-    if [[ -n "${GITLAB:-}" ]]; then
-        "$CI_VAR_DIR/ci-set-org-vars.sh" --backend gitlab
-    fi
-}
-
 action() {
     build
     init_config
     configure
     integrations
     deploy
-    configure_ci
 }
 
 main() {


### PR DESCRIPTION
…m deploy flow

The `configure_ci` function and its invocation in the `action` function have been removed from `hack/deploy.sh`, as they are not relevant to the TSF deployment flow.