### PR TITLE
[RHTAP-5674] Makes UI tests mandatory for tssc-test

### DIFF
--- a/integration-tests/pipelines/tssc-cli-e2e.yaml
+++ b/integration-tests/pipelines/tssc-cli-e2e.yaml
@@ -46,6 +46,10 @@ spec:
       type: string
       description: 'Optional testplan.json content encoded in base64 format. If not provided, testplan will be downloaded from the repository.'
       default: ""
+    - name: ui-error-strategy
+      type: string
+      description: 'Error handling strategy for UI tests'
+      default: "continue"
   tasks:
     - name: rosa-hcp-metadata
       taskRef:
@@ -146,7 +150,7 @@ spec:
     - name: rhtap-ui-tests
       runAfter:
         - tssc-e2e-tests
-      onError: continue
+      onError: $(params.ui-error-strategy)
       taskRef:
         resolver: git
         params:

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -159,6 +159,10 @@ spec:
           if [[ "${tssc_test_image}" != "" ]]; then
             tkn_params+=("--param" "tssc-test-image=${tssc_test_image}")
           fi
+          # Set UI test error strategy based on source repo
+          if [[ "${GIT_REPO}" == "tssc-test" ]]; then
+            tkn_params+=("--param" "ui-error-strategy=stopAndFail")
+          fi
 
           # Add labels and other flags
           tkn_params+=(


### PR DESCRIPTION
This PR adds ui-error-strategy to tssc-cli-e2e pipeline and makes UI tests mandatory for tssc-test repository.

Issue: [RHTAP-5674](https://issues.redhat.com/browse/RHTAP-5674)