### PR TITLE
Update trusted software factory documentation and environment template

### DIFF
--- a/docs/trusted-software-factory.md
+++ b/docs/trusted-software-factory.md
@@ -2,14 +2,55 @@
 
 ## Quickstart
 
-1. Clone this repository/branch with `git clone https://github.com/redhat-appstudio/tssc-cli --branch tsf tsf`.
-2. `cd tsf`.
-2. Copy `hack/private.env.template` to `tsf.env`.
-3. Edit `tsf.env` and set the variables.
-4. Get a clean OCP cluster (4.18 to 4.20).
-5. From the terminal, log on that cluster.
-6. Run `./hack/deploy.sh -e tsf.env -i github` and wait for the cluster to be configured. Add `-i cert-manager` to the command if the Cert Manager operator is already installed on the cluster.
-7. Optionally, run `./hack/get-credentials.sh` to get the login information for the various services.
+1. Copy [private.env.template](../hack/private.env.template) as `tsf.env` and fill in the blanks.
+2. Start a container with `podman run -it --rm --env-file tmp/tsf.env --entrypoint bash -p 8228:8228 quay.io/roming22-org/tsf:latest`.
+3. Log on the cluster with `oc login "$OCP__API_ENDPOINT" --username "$OCP__USERNAME" --password "$OCP__PASSWORD"`
+4. Create the TSF config on the cluster with `tssc config --create`.
+5. Check if the `Red Hat Cert-Manager` operator is already installed in the cluster. If it is, edit the `tssc-config` ConfigMap in the `tssc` namespace to set `manageSubscription: false` for that product.
+5. Create the github app integration with `tssc integration github --create --org "$GITHUB__ORG" "tsf-$(date +%m%d-%H%M)"`. Open the link to create the app, follow the instructions, and install the application to your GitHub organization.
+6. Create the quay integration with `tssc integration quay --organization="$QUAY__ORG" --token="$QUAY__API_TOKEN" --url="$QUAY__URL"`. If you need information on how to generate the token, look further in this document.
+7. Deploy all the services with `tssc deploy`.
+8. Cluster users (including the admin user) should now be able to login the Konflux UI. You can get the hostname with `oc get routes -n konflux-ui --output jsonpath="{.items[0].spec.host}"; echo`.
+
+## Getting the information for tsf.env
+
+### GitHub
+
+If you don't have one, create a test organization.
+Use the name of that organization for `GITHUB__ORG`.
+
+### OpenShift
+
+* `OCP__API_ENDPOINT`: the full url of the cluster's api endpoint. Example: ``.
+* `OCP__USERNAME`: User with admin privileges on the cluster. Example: `admin`.
+* `OCP__PASSWORD`: Credential for the user.
+
+### Quay
+
+* `QUAY__URL`: full url of the quay instance. Example: `https://quay.io`.
+* `QUAY_RHOST`: hostname of the quay instance. Example: `quay.io`.
+* `QUAY__API_TOKEN`: token giving access to an organization on the quay instance.
+* `QUAY__ORG`: the organization that the token gives access to.
+
+To create the API token:
+* Go to quay homepage.
+* On the right hand side, click on the organization you wish to use. The use of an organization is mandatory. If you do not have one, you can create one by clicking `Create New Organization`.
+* On the left hand side, click on the `Applications` icon (second to last icon).
+* On the right hand side, click on `Create New Application`, and enter the application name (e.g. `tsf`).
+* Click the name of the newly created application.
+* On the left hand side, click on the `Generate Token` icon (last icon).
+* Select everything (TODO: find the minimum set of permissions required).
+* Click on `Generate Access Token`.
+* Click on `Authorize Application`.
+* Copy the access token.
+
+## Services
+
+### Quay
+
+When a new component is created in Konflux, a new repository is created, in the organization specified at install time.
+If you are using a free quay.io account, the visibility of the repository should be changed to public manually because of the account limitations.
+If you are use a corporate account, or your own Quay instance, the repository visibility can remain private.
 
 ## Troubleshooting
 

--- a/hack/private.env.template
+++ b/hack/private.env.template
@@ -1,6 +1,11 @@
 # github.com
 GITHUB__ORG=myOrg
 
+# OpenShift
+OCP__API_ENDPOINT=
+OCP__USERNAME=
+OCP__PASSWORD=
+
 # quay.io
 QUAY__API_TOKEN=
 QUAY__HOST=quay.io


### PR DESCRIPTION
- Revised the Quickstart section in `trusted-software-factory.md` to provide clearer instructions for setting up the TSF environment, including detailed steps for GitHub and Quay integrations.
- Added a new section for obtaining information required for `tsf.env`, enhancing user guidance.
- Updated `private.env.template` to include placeholders for OpenShift credentials, ensuring users have a complete template for configuration.

These changes improve the clarity and usability of the setup documentation for new users.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED