### PR TITLE
fix: use correct k8s service DNS names in TAS integration secret

### DIFF
--- a/installer/charts/tssc-tas/templates/tas-integration.secret.yaml
+++ b/installer/charts/tssc-tas/templates/tas-integration.secret.yaml
@@ -5,9 +5,9 @@ metadata:
   name: tssc-tas-integration
   namespace: {{ .Values.trustedArtifactSigner.integrationSecret.namespace }}
 stringData:
-  fulcio_service_url: http://fulcio-server-{{ .Release.Namespace }}.{{ .Release.Namespace }}.svc
+  fulcio_service_url: http://fulcio-server.{{ .Release.Namespace }}.svc.cluster.local
   fulcio_url: https://fulcio-server-{{ .Release.Namespace }}.{{ .Values.trustedArtifactSigner.ingressDomain }}
-  rekor_service_url: http://rekor-server-{{ .Release.Namespace }}.{{ .Release.Namespace }}.svc
+  rekor_service_url: http://rekor-server.{{ .Release.Namespace }}.svc.cluster.local
   rekor_url: https://rekor-server-{{ .Release.Namespace }}.{{ .Values.trustedArtifactSigner.ingressDomain }}
-  tuf_service_url: http://tuf-{{ .Release.Namespace }}.{{ .Release.Namespace }}.svc
+  tuf_service_url: http://tuf.{{ .Release.Namespace }}.svc.cluster.local
   tuf_url: https://tuf-{{ .Release.Namespace }}.{{ .Values.trustedArtifactSigner.ingressDomain }}


### PR DESCRIPTION
The internal service URLs were incorrectly embedding the namespace into the service name (e.g. fulcio-server-<ns>.<ns>.svc), instead of using the proper fully qualified in-cluster DNS format (<service>.<namespace>.svc.cluster.local).

Assisted-By: Cursor