### PR TITLE
feat: Add welcome banner to Dockerfile and enhance TSF setup document…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,22 @@ LABEL \
   io.k8s.display-name="Red Hat Trusted Software Supply Chain CLI" \
   io.openshift.tags="tssc tas tpa rhdh ec tap openshift"
 
+# Banner
+RUN echo 'cat << "EOF"' >> /etc/profile && \
+    echo '╔═══════════════════════════════════════════════════════╗' >> /etc/profile && \
+    echo '║   Welcome to the Trusted Software Factory Installer   ║' >> /etc/profile && \
+    echo '╚═══════════════════════════════════════════════════════╝' >> /etc/profile && \
+    echo ' ' >> /etc/profile && \
+    echo 'To deploy the Trusted Software Factory:' >> /etc/profile && \
+    echo '  - Login to the cluster' >> /etc/profile && \
+    echo '  - Create the TSF config on the cluster' >> /etc/profile && \
+    echo '  - Create the integrations' >> /etc/profile && \
+    echo '  - Deploy TSF' >> /etc/profile && \
+    echo ' ' >> /etc/profile && \
+    echo 'For more information, please visit https://github.com/redhat-appstudio/tssc-cli/blob/tsf/docs/trusted-software-factory.md' >> /etc/profile && \
+    echo ' ' >> /etc/profile && \
+    echo 'EOF' >> /etc/profile
+
 WORKDIR /licenses
 
 COPY LICENSE.txt .

--- a/docs/trusted-software-factory.md
+++ b/docs/trusted-software-factory.md
@@ -2,8 +2,8 @@
 
 ## Quickstart
 
-1. Copy [private.env.template](../hack/private.env.template) as `tsf.env` and fill in the blanks.
-2. Start a container with `podman run -it --rm --env-file tsf.env --entrypoint bash -p 8228:8228 --pull always quay.io/roming22-org/tsf:latest`.
+1. Copy [private.env.template](../hack/private.env.template) as `tsf.env` and fill in the blanks. See the [Getting the information for tsf.env](#getting-the-information-for-tsfenv) section if you need help finding the required values.
+2. Start a container with `podman run -it --rm --env-file tsf.env --entrypoint bash -p 8228:8228 --pull always quay.io/roming22-org/tsf:latest --login`.
 3. Log on the cluster with `oc login "$OCP__API_ENDPOINT" --username "$OCP__USERNAME" --password "$OCP__PASSWORD"`
 4. Create the TSF config on the cluster with `tssc config --create`.
 5. Check if the `Red Hat Cert-Manager` operator is already installed in the cluster. If it is, edit the `tssc-config` ConfigMap in the `tssc` namespace to set `manageSubscription: false` for that product.


### PR DESCRIPTION
…ation

- Introduced a welcome banner in the Dockerfile that provides users with initial setup instructions for the Trusted Software Factory.
- Updated the Quickstart section in `trusted-software-factory.md` to clarify the Podman command and include a reference for obtaining required values for `tsf.env`.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED