### PR TITLE
docs: improve Trusted Software Factory installation guide

### DIFF
--- a/docs/trusted-software-factory.md
+++ b/docs/trusted-software-factory.md
@@ -1,16 +1,22 @@
 # Trusted Software Factory Installer
 
+## Prerequisites
+
+* An OpenShift cluster with admin access
+* A GitHub organization (create a test organization if needed)
+* A Quay.io account with access to an organization (or your own Quay instance)
+
 ## Quickstart
 
 1. Copy [private.env.template](../hack/private.env.template) as `tsf.env` and fill in the blanks. See the [Getting the information for tsf.env](#getting-the-information-for-tsfenv) section if you need help finding the required values.
 2. Start a container with `podman run -it --rm --env-file tsf.env --entrypoint bash -p 8228:8228 --pull always quay.io/roming22-org/tsf:latest --login`.
 3. Log on the cluster with `oc login "$OCP__API_ENDPOINT" --username "$OCP__USERNAME" --password "$OCP__PASSWORD"`
 4. Create the TSF config on the cluster with `tssc config --create`.
-5. Check if the `Red Hat Cert-Manager` operator is already installed in the cluster. If it is, edit the `tssc-config` ConfigMap in the `tssc` namespace to set `manageSubscription: false` for that product.
-5. Create the github app integration with `tssc integration github --create --org "$GITHUB__ORG" "tsf-$(date +%m%d-%H%M)"`. Open the link to create the app, follow the instructions, and install the application to your GitHub organization.
-6. Create the quay integration with `tssc integration quay --organization="$QUAY__ORG" --token="$QUAY__API_TOKEN" --url="$QUAY__URL"`. If you need information on how to generate the token, look further in this document.
-7. Deploy all the services with `tssc deploy`.
-8. Cluster users (including the admin user) should now be able to login the Konflux UI. You will find the URL in the logs of the deployment. You can also access it through the GitHub App (via the `Website` link on the application public page, or via the link displayed on the application configuration page which was the last page displayed after you installed the application).
+5. Check if the `Red Hat Cert-Manager` operator is already installed in the cluster. If it is, edit the `tssc-config` ConfigMap in the `tssc` namespace to set `manageSubscription: false` for that product. Alternatively, you can use the `-i cert-manager` flag with the `tssc deploy` command in step 8.
+6. Create the github app integration with `tssc integration github --create --org "$GITHUB__ORG" "tsf-$(date +%m%d-%H%M)"`. Open the link to create the app, follow the instructions, and install the application to your GitHub organization.
+7. Create the quay integration with `tssc integration quay --organization="$QUAY__ORG" --token="$QUAY__API_TOKEN" --url="$QUAY__URL"`. If you need information on how to generate the token, look further in this document.
+8. Deploy all the services with `tssc deploy`.
+9. Cluster users (including the admin user) should now be able to login the Konflux UI. You will find the URL in the logs of the deployment. You can also access it through the GitHub App (via the `Website` link on the application public page, or via the link displayed on the application configuration page which was the last page displayed after you installed the application).
 
 ## Getting the information for tsf.env
 
@@ -21,7 +27,7 @@ Use the name of that organization for `GITHUB__ORG`.
 
 ### OpenShift
 
-* `OCP__API_ENDPOINT`: the full url of the cluster's api endpoint. Example: ``.
+* `OCP__API_ENDPOINT`: the full url of the cluster's api endpoint. Example: `https://api.example.com:6443`.
 * `OCP__USERNAME`: User with admin privileges on the cluster. Example: `admin`.
 * `OCP__PASSWORD`: Credential for the user.
 
@@ -49,7 +55,7 @@ To create the API token:
 
 When a new component is created in Konflux, a new repository is created, in the organization specified at install time.
 If you are using a free quay.io account, the visibility of the repository should be changed to public manually because of the account limitations.
-If you are use a corporate account, or your own Quay instance, the repository visibility can remain private.
+If you are using a corporate account, or your own Quay instance, the repository visibility can remain private.
 
 ## Troubleshooting
 

--- a/docs/trusted-software-factory.md
+++ b/docs/trusted-software-factory.md
@@ -4,7 +4,7 @@
 
 * An OpenShift cluster with admin access
 * A GitHub organization (create a test organization if needed)
-* A Quay.io account with access to an organization (or your own Quay instance)
+* A Quay.io account with access to an organization (currently only quay.io is supported; support for other Quay instances is planned for the future)
 
 ## Quickstart
 
@@ -33,8 +33,8 @@ Use the name of that organization for `GITHUB__ORG`.
 
 ### Quay
 
-* `QUAY__URL`: full url of the quay instance. Example: `https://quay.io`.
-* `QUAY__API_TOKEN`: token giving access to an organization on the quay instance.
+* `QUAY__URL`: full url of quay.io. Use: `https://quay.io`.
+* `QUAY__API_TOKEN`: token giving access to an organization on quay.io.
 * `QUAY__ORG`: the organization that the token gives access to.
 
 To create the API token:
@@ -55,7 +55,7 @@ To create the API token:
 
 When a new component is created in Konflux, a new repository is created, in the organization specified at install time.
 If you are using a free quay.io account, the visibility of the repository should be changed to public manually because of the account limitations.
-If you are using a corporate account, or your own Quay instance, the repository visibility can remain private.
+If you are using a paid quay.io account, the repository visibility can remain private.
 
 ## Troubleshooting
 

--- a/docs/trusted-software-factory.md
+++ b/docs/trusted-software-factory.md
@@ -73,4 +73,4 @@ The subscription has already been installed by a third party. Helm does not want
 
 #### Workaround
 
-* Add `-i cert-manager` to the `./hack/tssc deploy` command.
+* Add `-i cert-manager` to the `tssc deploy` command.


### PR DESCRIPTION
## Summary
Enhance the TSF installation documentation to reduce user confusion and provide clearer, more accurate guidance.

## Changes
- Add prerequisites section to help users understand requirements upfront
- Fix step numbering error (duplicate step 5) in quickstart
- Clarify cert-manager handling options (ConfigMap edit vs CLI flag)
- Provide concrete API endpoint example instead of empty placeholder
- Clarify quay.io as the only currently supported Quay instance to prevent users from attempting unsupported configurations
- Fix inconsistent command references throughout the document
- Correct grammar errors