### PR TITLE
Konflux: change channel and add TPA url

### DIFF
--- a/installer/charts/tssc-konflux/Chart.yaml
+++ b/installer/charts/tssc-konflux/Chart.yaml
@@ -7,4 +7,4 @@ version: "1.6.0"
 appVersion: "0.0"
 annotations:
   tssc.redhat-appstudio.github.com/product-name: Konflux
-  tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-pipelines, tssc-tas
+  tssc.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-pipelines, tssc-tas, tssc-tpa

--- a/installer/charts/tssc-konflux/templates/konflux.yaml
+++ b/installer/charts/tssc-konflux/templates/konflux.yaml
@@ -15,6 +15,12 @@
 {{- $tufInternalUrl := required (printf "tuf_service_url not found in secret 'tssc-tas-integration' in namespace '%s'" .Values.konflux.tssc.namespace) (get $secretData "tuf_service_url") | b64dec | toString -}}
 {{- $tufExternalUrl := required (printf "tuf_url not found in secret 'tssc-tas-integration' in namespace '%s'" .Values.konflux.tssc.namespace) (get $secretData "tuf_url") | b64dec | toString -}}
 
+{{- /* Lookup Trusted Profile Analyzer integration secret to get URLs */ -}}
+{{- $tpaSecretObj := (lookup "v1" "Secret" .Values.konflux.tssc.namespace "tssc-tpa-integration") | default dict -}}
+{{- $secretData := required (printf "Secret 'tssc-tpa-integration' not found in namespace '%s'" .Values.konflux.tssc.namespace) (get $tpaSecretObj "data") | default dict -}}
+{{- $trustifyServerInternalUrl := required (printf "trustify_server_internal_url not found in secret 'tssc-tpa-integration' in namespace '%s'" .Values.konflux.tssc.namespace) (get $secretData "trustify_server_internal_url") | b64dec | toString -}}
+{{- $trustifyServerExternalUrl := required (printf "trustify_server_external_url not found in secret 'tssc-tpa-integration' in namespace '%s'" .Values.konflux.tssc.namespace) (get $secretData "trustify_server_external_url") | b64dec | toString -}}
+
 ---
 apiVersion: konflux.konflux-ci.dev/v1alpha1
 kind: Konflux
@@ -28,6 +34,7 @@ spec:
     spec:
       clusterConfig:
         data:
+          enableKeylessSigning: true
           defaultOIDCIssuer: https://kubernetes.default.svc
           fulcioInternalUrl: {{ $fulcioInternalUrl | quote }}
           fulcioExternalUrl: {{ $fulcioExternalUrl | quote }}
@@ -35,7 +42,12 @@ spec:
           rekorExternalUrl: {{ $rekorExternalUrl | quote }}
           tufInternalUrl: {{ $tufInternalUrl | quote }}
           tufExternalUrl: {{ $tufExternalUrl | quote }}
+          trustifyServerInternalUrl: {{ $trustifyServerInternalUrl | quote }}
+          trustifyServerExternalUrl: {{ $trustifyServerExternalUrl | quote }}
       publicInfo:
         integrations:
           github:
             application_url: {{ $applicationURL | quote }}
+          sbom_server:
+            url: "{{ $trustifyServerExternalUrl }}/sbom/content/<PLACEHOLDER>"
+            sbom_sha: "{{ $trustifyServerExternalUrl }}/sboms/<PLACEHOLDER>"

--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -6,7 +6,7 @@ subscriptions:
     apiResource: konfluxes.konflux.konflux-ci.dev
     namespace: konflux-operator
     name: konflux-operator
-    channel: stable-v0
+    channel: stable-v0.0
     source: community-operators
     sourceNamespace: openshift-marketplace
     operatorGroup:

--- a/installer/charts/tssc-tpa/templates/tpa-integration.secret.yaml
+++ b/installer/charts/tssc-tpa/templates/tpa-integration.secret.yaml
@@ -1,0 +1,9 @@
+kind: Secret
+type: Opaque
+apiVersion: v1
+metadata:
+  name: tssc-tpa-integration
+  namespace: {{ .Values.trustedProfileAnalyzer.integrationSecret.namespace }}
+stringData:
+  trustify_server_internal_url: https://server.{{ .Release.Namespace }}.svc.cluster.local
+  trustify_server_external_url: https://server{{ .Values.trustedProfileAnalyzer.appDomain }}

--- a/installer/charts/tssc-tpa/values.yaml
+++ b/installer/charts/tssc-tpa/values.yaml
@@ -174,7 +174,9 @@ trustedProfileAnalyzer:
     serviceEnabled: true
     # Additional CA certificates to trust, which is fundamental to support
     # OpenShift internal TLS communication.
-    additionalTrustAnchor: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt 
+    additionalTrustAnchor: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  integrationSecret:
+    namespace: __OVERWRITE_ME__
   # TPA is composed by services, each service needs integration with S3 bucket and
   # Kafka topics. When the bucket receives a new document, a message is issued to
   # the "stored" Kafka topic.

--- a/installer/charts/values.yaml.tpl
+++ b/installer/charts/values.yaml.tpl
@@ -252,6 +252,9 @@ trustedProfileAnalyzer:
               key: testingManager
 {{- end }}
 
+  integrationSecret:
+    namespace: {{ .Installer.Namespace }}
+
 trustification:
   name: trustedprofileanalyzer
   namespace: "{{ $tpa.Namespace }}"


### PR DESCRIPTION

feat: add TPA server URLs and enableKeylessSigning for Konflux
    
    Pass the Trustify server internal and external URLs to the Konflux CR
    by reading them from a tssc-tpa-integration secret, following the same
    pattern used for TAS URLs via tssc-tas-integration.
    
    Also enable keyless signing in the Konflux cluster config.
    
    Assisted-By: Cursor
    Signed-off-by: Gal Ben Haim <gbenhaim@redhat.com>



Use channel stable-v0.0 for Konflux
    
    In preparation to code freeze, we created a new channel
    that should be used by the installer.
    
    After code freeze, this channel will include only critical bug
    fixes.
    
    Signed-off-by: Gal Ben Haim <gbenhaim@redhat.com>
