### PR TITLE
[catalog_url] Switches catalog url to main branch

### DIFF
--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -64,7 +64,7 @@ tssc:
       enabled: true
       namespace: tssc-dh
       properties:
-        catalogURL: https://github.com/redhat-appstudio/tssc-dev-multi-ci/blob/pre-release-v1.9.x/samples/all.yaml
+        catalogURL: https://github.com/redhat-appstudio/tssc-dev-multi-ci/blob/main/samples/all.yaml
         manageSubscription: true
         # namespacePrefixes:
         #   - tssc-app


### PR DESCRIPTION
This PR switches `catalogURL` to `main` branch to correctly propagate changes from tssc-dev-multi-ci.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Developer Hub catalog configuration to point to the main branch release channel instead of pre-release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->