### PR TITLE
Remove unused quay-io-creds variable for jenkins path

### DIFF
--- a/scripts/ci-set-org-vars.sh
+++ b/scripts/ci-set-org-vars.sh
@@ -404,11 +404,7 @@ jenkinsGetValues() {
     JENKINS__USERNAME="$(echo "$JENKINS_SECRET_JSON" | jq -r '.data.username | @base64d')"
     JENKINS__TOKEN="$(echo "$JENKINS_SECRET_JSON" | jq -r '.data.token | @base64d')"
 
-    # Add usernames with passwords
-    if oc get secrets -n "$NAMESPACE" "tssc-quay-integration" -o name >/dev/null 2>&1; then
-        echo "Setting QUAY_IO_CREDS: *********"
-        add_username_with_password "QUAY_IO_CREDS" "$IMAGE_REGISTRY_USER" "$IMAGE_REGISTRY_PASSWORD"
-    fi
+    # Add gitops credentials
     echo "Setting GITOPS_CREDENTIALS: *********"
     add_username_with_password "GITOPS_CREDENTIALS" "$GIT_USER" "$GIT_TOKEN"
 }


### PR DESCRIPTION
Jenkins templates were already cleanup so that pipelines only rely on generic registry variables instead of specific quay variables. Cleaning the scripts that generates and push these vars to CI backend.

Partially implements [RHTAP-5699](https://issues.redhat.com/browse/RHTAP-5699)

Note: Gitops Credentials are required to establish webhooks between Jenkins instance and gitops repositories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to streamline deployment credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->