### PR TITLE
feat: move TPA integration secret to tsf-tpa

### DIFF
--- a/installer/charts/tssc-app-namespaces/templates/secrets/tpa.yaml
+++ b/installer/charts/tssc-app-namespaces/templates/secrets/tpa.yaml
@@ -1,6 +1,8 @@
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "tssc-trustification-integration") -}}
-{{- $secretData := (get $secretObj "data") | default dict -}}
-{{- if $secretData -}}
+{{- $authSecret := (lookup "v1" "Secret" .Release.Namespace "tssc-authentication-integration") -}}
+{{- $trustificationSecret := (lookup "v1" "Secret" .Release.Namespace "tssc-trustification-integration") -}}
+{{- $authData := (get $authSecret "data") | default dict -}}
+{{- $trustificationData := (get $trustificationSecret "data") | default dict -}}
+{{- if and $authData $trustificationData -}}
   {{- range .Values.appNamespaces.namespace_prefixes }}
     {{- $namespace := . }}
 ---
@@ -11,12 +13,12 @@ metadata:
   name: tpa-secret
   namespace: {{ $namespace }}-ci
 data:
-  bombastic_api_url: {{ $secretData.bombastic_api_url }}
-  oidc_client_id:  {{ $secretData.oidc_client_id }}
-  oidc_client_secret:  {{ $secretData.oidc_client_secret }}
-  oidc_issuer_url: {{ $secretData.oidc_issuer_url }}
-  {{- if $secretData.supported_cyclonedx_version }}
-  supported_cyclonedx_version:  {{ $secretData.supported_cyclonedx_version }}
+  bombastic_api_url: {{ $trustificationData.bombastic_api_url }}
+  oidc_client_id: {{ $authData.oidc_client_id }}
+  oidc_client_secret: {{ $authData.oidc_client_secret }}
+  oidc_issuer_url: {{ $authData.oidc_issuer_url }}
+    {{- if $trustificationData.supported_cyclonedx_version }}
+  supported_cyclonedx_version: {{ $trustificationData.supported_cyclonedx_version }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/installer/charts/tssc-iam/templates/realm.yaml
+++ b/installer/charts/tssc-iam/templates/realm.yaml
@@ -99,9 +99,9 @@ data:
   {{ $k }}: {{ $s }}
   {{- end }}
 #
-# TPA Integration Secret
+# Authentication Integration Secret
 #
-#   Creates a secret to store integration details.
+#   Creates a secret with realm OIDC details.
 #
 ---
 apiVersion: v1
@@ -110,36 +110,18 @@ metadata:
   labels:
     app: keycloak
   namespace: {{
-    required ".Values.trustedProfileAnalyzerRealm.integrationSecret.namespace is required"
-      $tpa.integrationSecret.namespace
+    required "iam.integrationSecret.namespace is required"
+      .Values.iam.integrationSecret.namespace
   }}
-  name: {{
-    required "Values.trustedProfileAnalyzerRealm.integrationSecret.name is required"
-      $tpa.integrationSecret.name
-  }}
+  name: tssc-authentication-integration
 type: Opaque
 stringData:
-  bombastic_api_url: {{
-    required ".Values.trustedProfileAnalyzerRealm.integrationSecret.bombasticAPI is required"
-      $tpa.integrationSecret.bombasticAPI
-  }}
   oidc_issuer_url: {{
-    required ".Values.trustedProfileAnalyzerRealm.oidcIssuerURL is required"
+    required "iam.keycloakCR.trustedProfileAnalyzerRealm.oidcIssuerURL is required"
       $tpa.oidcIssuerURL
   }}
-  oidc_client_id: {{
-    required ".Values.trustedProfileAnalyzerRealm.integrationSecret.oidcClientID is required"
-      $tpa.integrationSecret.oidcClientID
-  }}
-  oidc_client_secret: {{
-    get $oidcCredentialsTPA
-      $tpa.integrationSecret.oidcClientID |
-        b64dec
-  }}
-  supported_cyclonedx_version: "{{
-    required ".Values.trustedProfileAnalyzerRealm.integrationSecret.cycloneDXVersion is required"
-      $tpa.integrationSecret.cycloneDXVersion
-  }}"
+  oidc_client_id: cli
+  oidc_client_secret: {{ get $oidcCredentialsTPA "cli" | b64dec }}
 {{- end }}
 #
 # RHDH Client

--- a/installer/charts/tssc-iam/values.yaml
+++ b/installer/charts/tssc-iam/values.yaml
@@ -5,6 +5,9 @@
 iam:
   enabled: false
   namespace: __OVERWRITE_ME__
+  # Authentication integration secret created by realm import.
+  integrationSecret:
+    namespace: __OVERWRITE_ME__
   instances: 1
   database:
     host: __OVERWRITE_ME__
@@ -85,15 +88,3 @@ iam:
         - "http://server-tssc-tpa.apps-crc.testing/*"
         - "http://sbom-tssc-tpa.apps-crc.testing"
         - "http://sbom-tssc-tpa.apps-crc.testing/*"
-      # Describe details of Trustification installation for integration with other
-      # components.
-      integrationSecret:
-        # Bombastic API URL.
-        bombasticAPI: __OVERWRITE_ME__
-        # OIDC client ID to interact with the Bombastic API endpoint.
-        oidcClientID: cli
-        # Secret namespace and name.
-        namespace: __OVERWRITE_ME__
-        name: tssc-trustification-integration
-        # CycloneDX version supported by TPA (Trustification).
-        cycloneDXVersion: 1.4

--- a/installer/charts/tssc-tpa/templates/integration-secret.yaml
+++ b/installer/charts/tssc-tpa/templates/integration-secret.yaml
@@ -1,0 +1,17 @@
+{{- $tpa := .Values.trustedProfileAnalyzer -}}
+{{- $protocol := "http" -}}
+{{- if $tpa.openshift.useServiceCa }}
+  {{- $protocol = "https" }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: trustedprofileanalyzer
+  namespace: {{ required "trustedProfileAnalyzer.integrationSecret.namespace is required" $tpa.integrationSecret.namespace }}
+  name: tssc-trustification-integration
+type: Opaque
+stringData:
+  bombastic_api_url: {{ printf "%s://server%s" $protocol $tpa.appDomain | quote }}
+  supported_cyclonedx_version: {{ required "trustedProfileAnalyzer.cycloneDXVersion is required" $tpa.cycloneDXVersion | quote }}

--- a/installer/charts/tssc-tpa/values.yaml
+++ b/installer/charts/tssc-tpa/values.yaml
@@ -9,11 +9,14 @@ trustedProfileAnalyzer:
   # which includes the deployment of the application components, and the Keycloak
   # Realm import.
   enabled: true
+  cycloneDXVersion: __OVERWRITE_ME__
   # Realm's OIDC issuer URL, the endpoint to TPA's realm.
   oidcIssuerURL: __OVERWRITE_ME__
   name: trustedprofileanalyzer
   namespace: __OVERWRITE_ME__
   appDomain: __OVERWRITE_ME__
+  integrationSecret:
+    namespace: __OVERWRITE_ME__
   replicas: 1
   rust:
     logFilter: debug

--- a/installer/values.yaml.tpl
+++ b/installer/values.yaml.tpl
@@ -120,6 +120,8 @@ infrastructure:
 iam:
   enabled: {{ $keycloakEnabled }}
   namespace: {{ $keycloakNamespace }}
+  integrationSecret:
+    namespace: {{ .Installer.Namespace }}
   instances: 1
   database:
     host: keycloak-pgsql
@@ -173,14 +175,6 @@ iam:
         - "{{ printf "%s://%s-%s.%s" $protocol . $tpa.Namespace $ingressDomain }}"
         - "{{ printf "%s://%s-%s.%s/*" $protocol . $tpa.Namespace $ingressDomain }}"
     {{- end }}
-      integrationSecret:
-        bombasticAPI: {{
-          printf "%s://server-%s.%s"
-            $protocol
-            $tpa.Namespace
-            $ingressDomain
-        }}
-        namespace: {{ .Installer.Namespace }}
 
 #
 # tssc-acs
@@ -309,9 +303,12 @@ developerHub:
 
 trustedProfileAnalyzer:
   enabled: {{ $tpa.Enabled }}
+  cycloneDXVersion: "1.4"
   oidcIssuerURL: {{ $tpaOIDCIssuerURL }}
   namespace: "{{ $tpa.Namespace }}"
   appDomain: "{{ $tpaAppDomain }}"
+  integrationSecret:
+    namespace: {{ .Installer.Namespace }}
   ingress: &tpaIngress
     className: openshift-default
   openshift: &tpaOpenShift

--- a/scripts/ci-set-org-vars.sh
+++ b/scripts/ci-set-org-vars.sh
@@ -122,11 +122,13 @@ getValues() {
     ROX_API_TOKEN="$(oc get secrets -n "$NAMESPACE" "$SECRET" -o json | jq -r '.data.token | @base64d')"
 
     TPA_SECRET="tssc-trustification-integration"
+    AUTH_SECRET_JSON="tssc-authentication-integration"
     TPA_SECRET_JSON=$(oc get secret -n "$NAMESPACE" "$TPA_SECRET" -o json)
+    AUTH_SECRET_JSON=$(oc get secret -n "$NAMESPACE" "$AUTH_SECRET_JSON" -o json)
     TPA_URL="$(echo "$TPA_SECRET_JSON" | jq -r '.data.bombastic_api_url | @base64d')"
-    TPA_OIDC_ISSUER_URL="$(echo "$TPA_SECRET_JSON" | jq -r '.data.oidc_issuer_url | @base64d')"
-    TPA_OIDC_CLIENT_ID="$(echo "$TPA_SECRET_JSON" | jq -r '.data.oidc_client_id | @base64d')"
-    TPA_OIDC_CLIENT_SECRET="$(echo "$TPA_SECRET_JSON" | jq -r '.data.oidc_client_secret | @base64d')"
+    TPA_OIDC_ISSUER_URL="$(echo "$AUTH_SECRET_JSON" | jq -r '.data.oidc_issuer_url | @base64d')"
+    TPA_OIDC_CLIENT_ID="$(echo "$AUTH_SECRET_JSON" | jq -r '.data.oidc_client_id | @base64d')"
+    TPA_OIDC_CLIENT_SECRET="$(echo "$AUTH_SECRET_JSON" | jq -r '.data.oidc_client_secret | @base64d')"
     TPA_SUPPORTED_CYCLONEDX_VERSION="$(echo "$TPA_SECRET_JSON" | jq -r '.data.supported_cyclonedx_version | @base64d')"
 
     TAS_SECRET="tssc-tas-integration"


### PR DESCRIPTION
- Created a new integration secret for authentication.
- Added integrationSecret configuration to trustedProfileAnalyzer in values.yaml.
- Removed deprecated trustification section and its related secret template.
- Moved the integration secret for storing TPA integration details to the tsf-tpa chart.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reorganized application secrets to separate authentication (OIDC) configuration from trustification integration data for improved maintainability.
  * Updated deployment templates and configuration values across all components to support the new secret structure.
  * Updated CI automation scripts to correctly reference authentication data from the dedicated secret source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->