### PR TITLE
Use startswith for snapshot component matching

### DIFF
--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -93,8 +93,8 @@ spec:
         echo "Decoded rhads-config content:"
         echo "$DECODED_RHADS_CONFIG"
         # Extract images from snapshot
-        tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-cli").containerImage')
-        tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
+        tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name | startswith("tssc-cli")).containerImage')
+        tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name | startswith("tssc-test")).containerImage')
 
         GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
         KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"


### PR DESCRIPTION
Turns out, when we are running tests for some release branch, the component is named `tssc-cli-1.8` which doesn't get matched and we end up running latest tssc-cli instead of running one from snapshot from 1.8 branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated component selection logic in snapshot extraction to use prefix matching instead of exact name matching, allowing greater flexibility when identifying components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->