### PR TITLE
Use startswith for snapshot component matching

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -64,9 +64,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/redhat-appstudio/tssc-cli.git
+            value: https://github.com/rhopp/tssc-cli.git
           - name: revision
-            value: release-1.8
+            value: fix/snapshot-component-matching-1.8
           - name: pathInRepo
             value: integration-tests/tasks/start-pipelines.yaml
       params:

--- a/integration-tests/tasks/start-pipelines.yaml
+++ b/integration-tests/tasks/start-pipelines.yaml
@@ -93,8 +93,8 @@ spec:
         echo "Decoded rhads-config content:"
         echo "$DECODED_RHADS_CONFIG"
         # Extract images from snapshot
-        tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-cli").containerImage')
-        tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name=="tssc-test").containerImage')
+        tssc_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name | startswith("tssc-cli")).containerImage')
+        tssc_test_image=$(echo "${SNAPSHOT}" | jq -r '.components[] |select(.name | startswith("tssc-test")).containerImage')
 
         GIT_REPO="$(jq -r '.git.repo // empty' <<< $JOB_SPEC)"
         KONFLUX_URL="https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com"


### PR DESCRIPTION
Cherrypick of https://github.com/redhat-appstudio/tssc-cli/pull/1656 to release 1.8 branch