### PR TITLE
[WIP] [pipeline_secret_workaround] Adds dummy secret to pass Openshift pipelines verification

### DIFF
--- a/installer/charts/tssc-app-namespaces/templates/secrets/pipelines.yaml
+++ b/installer/charts/tssc-app-namespaces/templates/secrets/pipelines.yaml
@@ -2,7 +2,7 @@
 # to be able to establish the webhook
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "tssc-github-integration") | default dict -}}
 {{- $secretData := (get $secretObj "data") | default dict -}}
-{{- if $secretData }}
+{{- $webhookSecret := (get $secretData "webhookSecret") | default ("dummyWebhookSecret" | b64enc) -}}
   {{- range .Values.appNamespaces.namespace_prefixes }}
     {{- $namespace := . }}
 ---
@@ -13,6 +13,5 @@ metadata:
   name: pipelines-secret
   namespace: {{ $namespace }}-ci
 data:
-  webhook.secret: {{ $secretData.WebhookSecret }}
+  webhook.secret: {{ $webhookSecret }}
   {{- end }}
-{{- end }}

--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -64,7 +64,7 @@ tssc:
       enabled: true
       namespace: tssc-dh
       properties:
-        catalogURL: https://github.com/redhat-appstudio/tssc-dev-multi-ci/blob/main/samples/all.yaml
+        catalogURL: https://github.com/jsmid1/tssc-dev-multi-ci/blob/fix_gitlab-webhook-secret/samples/all.yaml
         manageSubscription: true
         # namespacePrefixes:
         #   - tssc-app

--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -24,6 +24,13 @@
           "registry": "nexus",
           "tpa": "local",
           "acs": "local"
+        },        
+        {
+          "git": "gitlab",
+          "ci": "tekton",
+          "registry": "nexus",
+          "tpa": "local",
+          "acs": "local"
         }
       ],
       "tests": ["full_workflow.test.ts"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure webhook secret is populated across all namespaces by emitting a safe fallback when the secret is absent.
  * Update the Developer Hub catalog URL to point to the corrected repository path.
  * Add integration test coverage for a GitLab + Tekton CI scenario to broaden backend testing and validate additional VCS/CI combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->