### PR TITLE
Upgrade OpenShift pipelines to 1.21

### DIFF
--- a/installer/charts/tssc-pipelines/Chart.yaml
+++ b/installer/charts/tssc-pipelines/Chart.yaml
@@ -4,7 +4,7 @@ name: tssc-pipelines
 description: TSSC OpenShift Pipelines
 type: application
 version: "1.8.0"
-appVersion: "1.20"
+appVersion: "1.21"
 annotations:
   helmet.redhat-appstudio.github.com/product-name: OpenShift Pipelines
   helmet.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions

--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -28,7 +28,7 @@ subscriptions:
     description: OpenShift Pipelines Operator
     namespace: openshift-operators
     name: openshift-pipelines-operator-rh
-    channel: pipelines-1.20
+    channel: pipelines-1.21
     source: redhat-operators
     sourceNamespace: openshift-marketplace
   openshiftTrustedArtifactSigner:


### PR DESCRIPTION
Jira: [RHTAP-6056](https://issues.redhat.com/browse/RHTAP-6056)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped application/service release reference from 1.20 to 1.21 to align with the latest release stream.
  * Updated the OpenShift Pipelines subscription channel to the 1.21 stream to receive the newer pipeline updates.
  * Added an integrations-required annotation to indicate this release needs specific integrations configured for deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->