### PR TITLE
feat: update dependency topology of integration trustificationauth

### DIFF
--- a/installer/charts/tssc-app-namespaces/Chart.yaml
+++ b/installer/charts/tssc-app-namespaces/Chart.yaml
@@ -5,4 +5,4 @@ type: application
 version: "1.8.0"
 annotations:
   helmet.redhat-appstudio.github.com/depends-on: tssc-acs, tssc-pipelines, tssc-tpa
-  helmet.redhat-appstudio.github.com/integrations-required: "(bitbucket || github || gitlab) && acs && trustification"
+  helmet.redhat-appstudio.github.com/integrations-required: "(bitbucket || github || gitlab) && acs && trustification && trustificationauth"

--- a/installer/charts/tssc-app-namespaces/templates/secrets/tpa.yaml
+++ b/installer/charts/tssc-app-namespaces/templates/secrets/tpa.yaml
@@ -1,4 +1,4 @@
-{{- $authSecret := (lookup "v1" "Secret" .Release.Namespace "tssc-authentication-integration") -}}
+{{- $authSecret := (lookup "v1" "Secret" .Release.Namespace "tssc-trustificationauth-integration") -}}
 {{- $trustificationSecret := (lookup "v1" "Secret" .Release.Namespace "tssc-trustification-integration") -}}
 {{- $authData := (get $authSecret "data") | default dict -}}
 {{- $trustificationData := (get $trustificationSecret "data") | default dict -}}

--- a/installer/charts/tssc-iam/Chart.yaml
+++ b/installer/charts/tssc-iam/Chart.yaml
@@ -6,3 +6,4 @@ type: application
 version: "1.8.0"
 annotations:
   helmet.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-infrastructure
+  helmet.redhat-appstudio.github.com/integrations-provided: trustificationauth

--- a/installer/charts/tssc-iam/templates/realm.yaml
+++ b/installer/charts/tssc-iam/templates/realm.yaml
@@ -113,7 +113,7 @@ metadata:
     required "iam.integrationSecret.namespace is required"
       .Values.iam.integrationSecret.namespace
   }}
-  name: tssc-authentication-integration
+  name: tssc-trustificationauth-integration
 type: Opaque
 stringData:
   oidc_issuer_url: {{

--- a/installer/charts/tssc-tpa/Chart.yaml
+++ b/installer/charts/tssc-tpa/Chart.yaml
@@ -9,3 +9,4 @@ annotations:
   helmet.redhat-appstudio.github.com/product-name: Trusted Profile Analyzer
   helmet.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions, tssc-infrastructure, tssc-iam
   helmet.redhat-appstudio.github.com/integrations-provided: trustification
+  helmet.redhat-appstudio.github.com/integrations-required: trustificationauth

--- a/integration-tests/scripts/install.sh
+++ b/integration-tests/scripts/install.sh
@@ -272,7 +272,8 @@ tpa_integration() {
     OIDC_CLIENT_SECRET="${OIDC_CLIENT_SECRET:-$(cat /usr/local/rhtap-cli-install/oidc-client-secret)}"
     OIDC_ISSUER_URL="${OIDC_ISSUER_URL:-$(cat /usr/local/rhtap-cli-install/oidc-issuer-url)}"
 
-    "${TSSC_BINARY}" integration --kube-config "$KUBECONFIG" trustification --bombastic-api-url="${BOMBASTIC_API_URL}" --oidc-client-id="${OIDC_CLIENT_ID}" --oidc-client-secret="${OIDC_CLIENT_SECRET}" --oidc-issuer-url="${OIDC_ISSUER_URL}" --supported-cyclonedx-version="${SUPPORTED_CYCLONEDX_VERSION}" --force
+    "${TSSC_BINARY}" integration --kube-config "$KUBECONFIG" trustificationauth --oidc-client-id="${OIDC_CLIENT_ID}" --oidc-client-secret="${OIDC_CLIENT_SECRET}" --oidc-issuer-url="${OIDC_ISSUER_URL}" --force
+    "${TSSC_BINARY}" integration --kube-config "$KUBECONFIG" trustification --bombastic-api-url="${BOMBASTIC_API_URL}" --supported-cyclonedx-version="${SUPPORTED_CYCLONEDX_VERSION}" --force
   fi
 }
 

--- a/scripts/ci-set-org-vars.sh
+++ b/scripts/ci-set-org-vars.sh
@@ -122,7 +122,7 @@ getValues() {
     ROX_API_TOKEN="$(oc get secrets -n "$NAMESPACE" "$SECRET" -o json | jq -r '.data.token | @base64d')"
 
     TPA_SECRET="tssc-trustification-integration"
-    AUTH_SECRET_JSON="tssc-authentication-integration"
+    AUTH_SECRET_JSON="tssc-trustificationauth-integration"
     TPA_SECRET_JSON=$(oc get secret -n "$NAMESPACE" "$TPA_SECRET" -o json)
     AUTH_SECRET_JSON=$(oc get secret -n "$NAMESPACE" "$AUTH_SECRET_JSON" -o json)
     TPA_URL="$(echo "$TPA_SECRET_JSON" | jq -r '.data.bombastic_api_url | @base64d')"


### PR DESCRIPTION
1. Rename `tssc-authentication-integration` to `tssc-trustificationauth-integration`
2. Add `integrations-required: trustificationauth` to chart tssc-tpa
3. Add `integrations-provided: trustificationauth` to chart tssc-iam
4. Add `trustificationauth` to `integrations-required` in chart tssc-app-namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated integration metadata to declare a new trustification-auth integration and mark it as required where applicable.
  * Switched the authentication secret/reference to the trustification-auth entry.
  * Installer/test flows now invoke authentication and trustification integrations as two distinct steps (OIDC-related auth separate from trustification service setup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->