### PR TITLE
RHTAP-6090 Add script for periodic jobs for reuse in jobs

### DIFF
--- a/integration-tests/scripts/periodic/README.md
+++ b/integration-tests/scripts/periodic/README.md
@@ -1,0 +1,15 @@
+# Script for tssc-cli repo
+
+Copy **`run-periodic-integration.sh`** into the tssc-cli repository at:
+
+**`integration-tests/scripts/periodic/run-periodic-integration.sh`**
+
+See: https://github.com/redhat-appstudio/tssc-cli/tree/main/integration-tests/scripts/periodic
+
+Konflux CronJobs in konflux-release-data fetch and run this script at runtime via:
+
+```text
+curl -sL https://raw.githubusercontent.com/redhat-appstudio/tssc-cli/main/integration-tests/scripts/periodic/run-periodic-integration.sh | bash
+```
+
+After copying to tssc-cli, commit and push. Then merge the konflux-release-data changes that switch the CronJobs to this URL (and remove the ConfigMap approach).

--- a/integration-tests/scripts/periodic/README.md
+++ b/integration-tests/scripts/periodic/README.md
@@ -1,12 +1,6 @@
 # Script for tssc-cli repo
 
-Copy **`run-periodic-integration.sh`** into the tssc-cli repository at:
-
-**`integration-tests/scripts/periodic/run-periodic-integration.sh`**
-
-See: https://github.com/redhat-appstudio/tssc-cli/tree/main/integration-tests/scripts/periodic
-
-Konflux CronJobs in konflux-release-data fetch and run this script at runtime via:
+Konflux CronJobs in konflux-release-data repository fetch and run this script at runtime via:
 
 ```text
 curl -sL https://raw.githubusercontent.com/redhat-appstudio/tssc-cli/main/integration-tests/scripts/periodic/run-periodic-integration.sh | bash

--- a/integration-tests/scripts/periodic/README.md
+++ b/integration-tests/scripts/periodic/README.md
@@ -11,5 +11,3 @@ Konflux CronJobs in konflux-release-data fetch and run this script at runtime vi
 ```text
 curl -sL https://raw.githubusercontent.com/redhat-appstudio/tssc-cli/main/integration-tests/scripts/periodic/run-periodic-integration.sh | bash
 ```
-
-After copying to tssc-cli, commit and push. Then merge the konflux-release-data changes that switch the CronJobs to this URL (and remove the ConfigMap approach).

--- a/integration-tests/scripts/periodic/run-periodic-integration.sh
+++ b/integration-tests/scripts/periodic/run-periodic-integration.sh
@@ -22,6 +22,7 @@ KONFLUX_UI_BASE_URL="${KONFLUX_UI_BASE_URL:-https://konflux-ui.apps.stone-prd-rh
 
 # Optional: extra args for the scheduler (e.g. --no-old-commits-run or install params for RHDH)
 PERIODIC_SCHEDULER_EXTRA_ARGS="${PERIODIC_SCHEDULER_EXTRA_ARGS:-}"
+read -r -a PERIODIC_SCHEDULER_EXTRA_ARGS_ARR <<< "${PERIODIC_SCHEDULER_EXTRA_ARGS}"
 
 waitFor() {
   local PLR="$1"
@@ -52,7 +53,7 @@ curl -sL https://raw.githubusercontent.com/konflux-ci/tekton-integration-catalog
   --konflux-application-name "${PERIODIC_KONFLUX_APP_NAME}" \
   --konflux-component-name "${PERIODIC_KONFLUX_COMPONENT_NAME}" \
   --schedule "${PERIODIC_SCHEDULE_DAYS}" \
-  ${PERIODIC_SCHEDULER_EXTRA_ARGS}
+  "${PERIODIC_SCHEDULER_EXTRA_ARGS_ARR[@]}"
 
 sleep 15
 
@@ -84,7 +85,7 @@ echo "[INFO] Found running PipelineRun: $LATEST_PIPELINE_RUN"
 waitFor "$LATEST_PIPELINE_RUN" "$PERIODIC_KONFLUX_TENANT_NAME" "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
 
 echo "[INFO] Getting pipeline run status and logs URL"
-status=$(oc get pipelinerun/${LATEST_PIPELINE_RUN} -n ${PERIODIC_KONFLUX_TENANT_NAME} -o jsonpath="{.status.conditions[].message}")
+status=$(oc get "pipelinerun/${LATEST_PIPELINE_RUN}" -n "${PERIODIC_KONFLUX_TENANT_NAME}" -o jsonpath="{.status.conditions[].message}")
 logsUrl="${KONFLUX_UI_BASE_URL}/ns/${PERIODIC_KONFLUX_TENANT_NAME}/applications/${PERIODIC_LOGS_APP_NAME}/pipelineruns/${LATEST_PIPELINE_RUN}"
 
 echo "[INFO] Setting icon and run status in message"

--- a/integration-tests/scripts/periodic/run-periodic-integration.sh
+++ b/integration-tests/scripts/periodic/run-periodic-integration.sh
@@ -60,7 +60,7 @@ sleep 15
 LATEST_PIPELINE_RUN=$(tkn pipelinerun list -n "${PERIODIC_KONFLUX_TENANT_NAME}" -o json | jq -r --arg scenario "${PERIODIC_SCENARIO_NAME}" '
   .items
   | map(select(
-      .metadata.labels."test.appstudio.openshift.io/run" == $scenario and
+      .metadata.labels."test.appstudio.openshift.io/scenario" == $scenario and
       (
         (.status.conditions // [])
         | map(select(

--- a/integration-tests/scripts/periodic/run-periodic-integration.sh
+++ b/integration-tests/scripts/periodic/run-periodic-integration.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Run periodic integration job: trigger scheduler, wait for PipelineRun, send Slack.
+# Hosted in tssc-cli (integration-tests/scripts/periodic/). Invoked by Konflux CronJobs in konflux-release-data
+# via: curl -sL https://raw.githubusercontent.com/redhat-appstudio/tssc-cli/main/integration-tests/scripts/periodic/run-periodic-integration.sh | bash
+# Configure via environment variables; see defaults below.
+
+set -euo pipefail
+
+# Required
+: "${PERIODIC_SCENARIO_NAME:?PERIODIC_SCENARIO_NAME must be set}"
+
+# Optional with defaults
+PERIODIC_KONFLUX_TENANT_NAME="${PERIODIC_KONFLUX_TENANT_NAME:-rhtap-shared-team-tenant}"
+PERIODIC_KONFLUX_APP_NAME="${PERIODIC_KONFLUX_APP_NAME:-tssc-cli}"
+PERIODIC_KONFLUX_COMPONENT_NAME="${PERIODIC_KONFLUX_COMPONENT_NAME:-tssc-cli}"
+PERIODIC_REPO_URL="${PERIODIC_REPO_URL:-https://github.com/redhat-appstudio/tssc-cli.git}"
+PERIODIC_BRANCH="${PERIODIC_BRANCH:-main}"
+PERIODIC_SCHEDULE_DAYS="${PERIODIC_SCHEDULE_DAYS:-5d}"
+PERIODIC_LOGS_APP_NAME="${PERIODIC_LOGS_APP_NAME:-rhtap-task-runner}"
+PERIODIC_MSG_LABEL="${PERIODIC_MSG_LABEL:-tssc-ci-weekly job}"
+KONFLUX_UI_BASE_URL="${KONFLUX_UI_BASE_URL:-https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com}"
+
+# Optional: extra args for the scheduler (e.g. --no-old-commits-run or install params for RHDH)
+PERIODIC_SCHEDULER_EXTRA_ARGS="${PERIODIC_SCHEDULER_EXTRA_ARGS:-}"
+
+waitFor() {
+  local PLR="$1"
+  local NAMESPACE="$2"
+  local MSG_RUNNING="$3"
+  local MSG_DONE="$4"
+
+  echo "[INFO] Waiting for PipelineRun '${PLR}' to complete..."
+  timeout --foreground 120m bash -c "
+    while true; do
+      status=\$(oc get pipelinerun/${PLR} -n ${NAMESPACE} -o jsonpath='{.status.conditions[?(@.type==\"Succeeded\")].status}')
+      if [[ \"\$status\" == \"True\" || \"\$status\" == \"False\" ]]; then
+        echo \"$MSG_DONE\"
+        break
+      else
+        echo \"$MSG_RUNNING\"
+        sleep 60
+      fi
+    done
+  "
+}
+
+curl -sL https://raw.githubusercontent.com/konflux-ci/tekton-integration-catalog/main/scripts/integration-tests-scheduler/integration-tests-scheduler.sh | bash -s -- \
+  --repository-url "${PERIODIC_REPO_URL}" \
+  --branch "${PERIODIC_BRANCH}" \
+  --konflux-scenario-name "${PERIODIC_SCENARIO_NAME}" \
+  --konflux-tenant-name "${PERIODIC_KONFLUX_TENANT_NAME}" \
+  --konflux-application-name "${PERIODIC_KONFLUX_APP_NAME}" \
+  --konflux-component-name "${PERIODIC_KONFLUX_COMPONENT_NAME}" \
+  --schedule "${PERIODIC_SCHEDULE_DAYS}" \
+  ${PERIODIC_SCHEDULER_EXTRA_ARGS}
+
+sleep 15
+
+LATEST_PIPELINE_RUN=$(tkn pipelinerun list -n "${PERIODIC_KONFLUX_TENANT_NAME}" -o json | jq -r --arg scenario "${PERIODIC_SCENARIO_NAME}" '
+  .items
+  | map(select(
+      .metadata.labels."test.appstudio.openshift.io/run" == $scenario and
+      (
+        (.status.conditions // [])
+        | map(select(
+            .type == "Succeeded" and
+            .status == "Unknown"
+          ))
+        | length > 0
+      )
+    ))
+  | sort_by(.metadata.creationTimestamp)
+  | last
+  | .metadata.name // empty
+')
+
+if [[ -z "$LATEST_PIPELINE_RUN" ]]; then
+  echo "[ERROR] No matching running PipelineRun found for scenario: $PERIODIC_SCENARIO_NAME"
+  echo "[DEBUG] Consider listing all PipelineRuns with: tkn pipelinerun list -n ${PERIODIC_KONFLUX_TENANT_NAME}"
+  exit 1
+fi
+echo "[INFO] Found running PipelineRun: $LATEST_PIPELINE_RUN"
+
+waitFor "$LATEST_PIPELINE_RUN" "$PERIODIC_KONFLUX_TENANT_NAME" "Nested pipelines are still running. Waiting 1 minute" "All nested pipelines finished"
+
+echo "[INFO] Getting pipeline run status and logs URL"
+status=$(oc get pipelinerun/${LATEST_PIPELINE_RUN} -n ${PERIODIC_KONFLUX_TENANT_NAME} -o jsonpath="{.status.conditions[].message}")
+logsUrl="${KONFLUX_UI_BASE_URL}/ns/${PERIODIC_KONFLUX_TENANT_NAME}/applications/${PERIODIC_LOGS_APP_NAME}/pipelineruns/${LATEST_PIPELINE_RUN}"
+
+echo "[INFO] Setting icon and run status in message"
+MSG="<icon> *${PERIODIC_MSG_LABEL}* pipeline run <pr_name> *<run_status>* <icon> <<logs_url>|View logs>"
+if [[ "${status}" == *"Failed: 0"* ]]; then
+  MSG="${MSG//<icon>/:success-kid:}"
+  MSG="${MSG//<run_status>/succeeded}"
+else
+  MSG="${MSG//<icon>/:fuuuuuu:}"
+  MSG="${MSG//<run_status>/failed}"
+fi
+MSG="${MSG//<logs_url>/$logsUrl}"
+MSG="${MSG//<pr_name>/$LATEST_PIPELINE_RUN}"
+
+echo "[INFO] Sending Slack notification"
+curl --no-progress-meter -X POST -H 'Content-Type: application/json' \
+  --data "{\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"${MSG}\"}}]}" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a user-facing README that explains how to deploy and run the periodic integration test workflow and how to commit and propagate related release-data updates.

* **Chores**
  * Added a configurable automation to schedule periodic integration runs, monitor pipeline progress with retries/timeouts, and post formatted Slack notifications with status and a link to logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->