### PR TITLE
Reset cancel-nested-pipelines taskref to redhat-appstudio main repo

### DIFF
--- a/integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -99,9 +99,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/chetna14manku/tssc-cli.git
+            value: https://github.com/redhat-appstudio/tssc-cli.git
           - name: revision
-            value: RHTAP-6134
+            value: main
           - name: pathInRepo
             value: integration-tests/tasks/cancel-nested-pipelines.yaml
       params:


### PR DESCRIPTION
Linked to https://github.com/redhat-appstudio/tssc-cli/pull/1664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline configuration to reference the correct repository and default branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->