### PR TITLE
Upgrade ACS to 4.10

### DIFF
--- a/installer/charts/tssc-acs-test/Chart.yaml
+++ b/installer/charts/tssc-acs-test/Chart.yaml
@@ -4,7 +4,7 @@ name: tssc-acs-test
 description: TSSC Advanced Cluster Security Test
 type: application
 version: "1.8.0"
-appVersion: "4.8"
+appVersion: "4.10"
 annotations:
   helmet.redhat-appstudio.github.com/use-product-namespace: Advanced Cluster Security
   helmet.redhat-appstudio.github.com/depends-on: tssc-acs

--- a/installer/charts/tssc-acs/Chart.yaml
+++ b/installer/charts/tssc-acs/Chart.yaml
@@ -4,7 +4,7 @@ name: tssc-acs
 description: TSSC Advanced Cluster Security
 type: application
 version: "1.8.0"
-appVersion: "4.9"
+appVersion: "4.10"
 annotations:
   helmet.redhat-appstudio.github.com/product-name: Advanced Cluster Security
   helmet.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions

--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -44,7 +44,7 @@ subscriptions:
     enabled: false
     description: Red Hat Advanced Cluster Security Operator
     apiResource: centrals.platform.stackrox.io
-    channel: rhacs-4.9
+    channel: rhacs-4.10
     namespace: rhacs-operator
     name: rhacs-operator
     source: redhat-operators


### PR DESCRIPTION
Upgrade ACS operator to 4.10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated application version to 4.10.
  * Updated Advanced Cluster Security subscription channel to 4.10.
  * Added a deployment annotation to influence resource prioritization.
  * Switched ACS integration-test configuration from "remote" to "local".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->