### PR TITLE
[WIP] RHTAP-6071 Change BitBucket AppPassword to Token

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -210,7 +210,7 @@ integrations() {
     fi
     if [[ -n "${BITBUCKET:-}" ]]; then
         tssc_cli integration bitbucket --force \
-            --app-password='"$BITBUCKET__APP_PASSWORD"' \
+            --token='"$BITBUCKET__TOKEN"' \
             --host='"$BITBUCKET__HOST"' \
             --username='"$BITBUCKET__USERNAME"'
     fi

--- a/hack/private.env.template
+++ b/hack/private.env.template
@@ -13,8 +13,8 @@ ACS__CENTRAL_ENDPOINT=foo.bar.com:443
 # SCM
 #
 
-# bitbucket.org
-BITBUCKET__APP_PASSWORD=foo****bar
+# bitbucket.org (use API token)
+BITBUCKET__TOKEN=foo****bar
 BITBUCKET__HOST=bitbucket.org
 BITBUCKET__USERNAME=myUser
 BITBUCKET__PROJECT=myProject

--- a/hack/reset.sh
+++ b/hack/reset.sh
@@ -150,7 +150,7 @@ action() {
         CURL=(
             "curl"
             "--fail"
-            "--header" "Authorization: Basic $(echo -n "$BITBUCKET__USERNAME:$BITBUCKET__APP_PASSWORD" | base64)" \
+            "--header" "Authorization: Basic $(echo -n "$BITBUCKET__USERNAME:$BITBUCKET__TOKEN" | base64)" \
             "--header" "Content-Type: application/json"
             "--silent"
         )

--- a/installer/charts/tssc-app-namespaces/templates/secrets/bitbucket-auth.yaml
+++ b/installer/charts/tssc-app-namespaces/templates/secrets/bitbucket-auth.yaml
@@ -11,7 +11,7 @@ metadata:
   name: bitbucket-auth-secret
   namespace: {{ $namespace }}-ci
 data:
-  password: {{ $secretData.appPassword }}
+  password: {{ $secretData.token }}
   username: {{ $secretData.username }}
   {{- end }}
 {{- end }}

--- a/installer/charts/tssc-dh/templates/app-config-content.yaml
+++ b/installer/charts/tssc-dh/templates/app-config-content.yaml
@@ -182,8 +182,8 @@ integrations:
 {{- end }}
 {{- if $bbSecretObj }}
   bitbucketCloud:
-    - appPassword: ${BITBUCKET__APP_PASSWORD}
-      username: ${BITBUCKET__USERNAME}
+    - username: ${BITBUCKET__USERNAME}
+      token: ${BITBUCKET__TOKEN}
 {{- end }}
 {{- if $githubSecretObj }}
   github:

--- a/installer/charts/tssc-dh/templates/extra-env.yaml
+++ b/installer/charts/tssc-dh/templates/extra-env.yaml
@@ -57,7 +57,7 @@ data:
 {{- $bbSecretObj := (lookup "v1" "Secret" $integrationNamespace "tssc-bitbucket-integration") }}
 {{- $bbSecretData := ($bbSecretObj.data | default dict) }}
 {{- if $bbSecretData }}
-    BITBUCKET__APP_PASSWORD:  {{ $bbSecretData.appPassword }}
+    BITBUCKET__TOKEN: {{ $bbSecretData.token }}
     BITBUCKET__USERNAME: {{ $bbSecretData.username }}
 {{- end }}
     DEVELOPER_HUB__CATALOG__URL: {{

--- a/installer/charts/tssc-integrations/templates/gitops/bitbucket-auth.yaml
+++ b/installer/charts/tssc-integrations/templates/gitops/bitbucket-auth.yaml
@@ -4,7 +4,7 @@
   {{- if $secretData -}}
 apiVersion: v1
 data:
-  password: {{ $secretData.appPassword }}
+  password: {{ $secretData.token }}
   username: {{ $secretData.username }}
 kind: Secret
 metadata:

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -19,7 +19,7 @@ In order to succesfully run this integration test one must:
         * `acs-api-token`
         * `rhdh-github-client-secret`
         * `bitbucket-username`
-        * `bitbucket-app-password`
+        * `bitbucket-token`
         * `rhdh-github-webhook-secret`
         * `github-username`
         * `github-password`

--- a/integration-tests/scripts/.ci-env
+++ b/integration-tests/scripts/.ci-env
@@ -50,9 +50,9 @@ export AZURE_HOST=
 export AZURE_ORGANIZATION=
 
 #### Bitbucket
-# https://docs.redhat.com/en/documentation/red_hat_trusted_application_pipeline/1.3/html-single/installing_red_hat_trusted_application_pipeline/index#optional_integrating_bitbucket
+# API token
 export BITBUCKET_USERNAME=
-export BITBUCKET_APP_PASSWORD=
+export BITBUCKET_TOKEN=
 export BITBUCKET_HOST="bitbucket.org"
 
 #### TPA

--- a/integration-tests/scripts/.env.template
+++ b/integration-tests/scripts/.env.template
@@ -56,9 +56,9 @@ export AZURE_HOST=
 export AZURE_ORGANIZATION=
 
 #### Bitbucket
-# https://docs.redhat.com/en/documentation/red_hat_trusted_application_pipeline/1.3/html-single/installing_red_hat_trusted_application_pipeline/index#optional_integrating_bitbucket
+# API token
 export BITBUCKET_USERNAME=
-export BITBUCKET_APP_PASSWORD=
+export BITBUCKET_TOKEN=
 export BITBUCKET_HOST="bitbucket.org"
 
 #### TPA

--- a/integration-tests/scripts/install.sh
+++ b/integration-tests/scripts/install.sh
@@ -244,9 +244,9 @@ bitbucket_integration() {
     echo "[INFO] Configure Bitbucket integration into TSSC"
 
     BITBUCKET_USERNAME="${BITBUCKET_USERNAME:-$(cat /usr/local/rhtap-cli-install/bitbucket-username)}"
-    BITBUCKET_APP_PASSWORD="${BITBUCKET_APP_PASSWORD:-$(cat /usr/local/rhtap-cli-install/bitbucket-app-password)}"
+    BITBUCKET_TOKEN="${BITBUCKET_TOKEN:-$(cat /usr/local/rhtap-cli-install/bitbucket-token)}"
 
-    "${TSSC_BINARY}" integration --kube-config "$KUBECONFIG" bitbucket --host="${BITBUCKET_HOST}" --username="${BITBUCKET_USERNAME}" --app-password="${BITBUCKET_APP_PASSWORD}" --force
+    "${TSSC_BINARY}" integration --kube-config "$KUBECONFIG" bitbucket --host="${BITBUCKET_HOST}" --username="${BITBUCKET_USERNAME}" --token="${BITBUCKET_TOKEN}" --force
   fi
 }
 

--- a/vendor/github.com/redhat-appstudio/helmet/internal/integration/bitbucket.go
+++ b/vendor/github.com/redhat-appstudio/helmet/internal/integration/bitbucket.go
@@ -13,9 +13,9 @@ import (
 
 // BitBucket represents the BitBucket integration coordinates.
 type BitBucket struct {
-	appPassword string // password
-	host        string // endpoint
-	username    string // username
+	token    string // API token (recommended over app password)
+	host     string // endpoint
+	username string // username (use email for Bitbucket Cloud)
 }
 
 var _ Interface = &BitBucket{}
@@ -27,11 +27,11 @@ func (b *BitBucket) PersistentFlags(c *cobra.Command) {
 	p.StringVar(&b.host, "host", b.host,
 		"BitBucket API endpoint")
 	p.StringVar(&b.username, "username", b.username,
-		"BitBucket username")
-	p.StringVar(&b.appPassword, "app-password", b.appPassword,
-		"BitBucket application password")
+		"BitBucket username (use email for Bitbucket Cloud)")
+	p.StringVar(&b.token, "token", b.token,
+		"BitBucket API token")
 
-	for _, f := range []string{"host", "username", "app-password"} {
+	for _, f := range []string{"host", "username", "token"} {
 		if err := c.MarkPersistentFlagRequired(f); err != nil {
 			panic(err)
 		}
@@ -47,7 +47,7 @@ func (b *BitBucket) SetArgument(_, _ string) error {
 func (b *BitBucket) LoggerWith(logger *slog.Logger) *slog.Logger {
 	return logger.With(
 		"username", b.username,
-		"app-password-len", len(b.appPassword),
+		"token-len", len(b.token),
 		"host", b.host,
 	)
 }
@@ -69,9 +69,9 @@ func (b *BitBucket) Data(
 	_ *config.Config,
 ) (map[string][]byte, error) {
 	return map[string][]byte{
-		"host":        []byte(b.host),
-		"username":    []byte(b.username),
-		"appPassword": []byte(b.appPassword),
+		"host":     []byte(b.host),
+		"username": []byte(b.username),
+		"token":    []byte(b.token),
 	}, nil
 }
 


### PR DESCRIPTION
Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Bitbucket integration authentication mechanism has been updated to use API tokens instead of app passwords. Users configuring Bitbucket integrations will need to provide an API token instead of an app password in their deployment and environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->