### PR TITLE
chore(plugins): Add new MSSV backend plugin

### DIFF
--- a/installer/charts/tssc-dh/templates/plugins-content.yaml
+++ b/installer/charts/tssc-dh/templates/plugins-content.yaml
@@ -112,7 +112,7 @@ plugins:
     package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-jenkins-backend:bs_1.45.3__0.22.0
 {{- end }}
   - disabled: false
-    package: oci://quay.io/redhat-tssc/backstage-plugins:1.9.0!tssc-plugins-backstage-community-plugin-multi-source-security-viewer-dynamic
+    package: oci://quay.io/redhat-tssc/backstage-plugins:1.9.0!tssc-plugins-backstage-community-plugin-multi-source-security-viewer
     pluginConfig:
       dynamicPlugins:
         frontend:
@@ -131,6 +131,8 @@ plugins:
               - path: /ci
                 title: CI
                 mountPoint: entity.page.ci
+  - disabled: false
+    package: quay.io/redhat-tssc/backstage-plugins:1.9.0!tssc-plugins-backstage-community-plugin-multi-source-security-viewer-backend
   #
   # Git
   #

--- a/installer/charts/tssc-dh/templates/plugins-content.yaml
+++ b/installer/charts/tssc-dh/templates/plugins-content.yaml
@@ -132,7 +132,7 @@ plugins:
                 title: CI
                 mountPoint: entity.page.ci
   - disabled: false
-    package: quay.io/redhat-tssc/backstage-plugins:1.9.0!tssc-plugins-backstage-community-plugin-multi-source-security-viewer-backend
+    package: oci://quay.io/redhat-tssc/backstage-plugins:1.9.0!tssc-plugins-backstage-community-plugin-multi-source-security-viewer-backend
   #
   # Git
   #


### PR DESCRIPTION
The new MSSV backend plugin allows the multi-source-security-viewer to have RBAC permissions set in the RBAC UI, instead of having to use a csv file.

Also remove `-dynamic` suffix for the MSSV plugin. No longer needed.

Demo of the MSSV backend allowing permissions for the MSSV plugin to be set in the RBAC UI:

https://github.com/user-attachments/assets/38a52bdb-0105-4011-bac9-591beb658b5d

JIRA: [RHTAPUI-133](https://issues.redhat.com/browse/RHTAPUI-133)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switched the multi-source security viewer frontend from a dynamic variant to a stable variant.

* **New Features**
  * Added backend support for the multi-source security viewer with new enabled backend entries to provide separate backend-style integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->