### PR TITLE
fix: pass COMMIT_ID and VERSION_ID build args to container image build

### DIFF
--- a/.tekton/tssc-cli-pull-request.yaml
+++ b/.tekton/tssc-cli-pull-request.yaml
@@ -187,7 +187,7 @@ spec:
       runAfter:
       - clone-repository
       taskSpec:
-        description: Extract version from git repository by cloning it
+        description: Extract version from git tags (matches Makefile logic)
         params:
         - name: url
           description: Git repository URL
@@ -199,34 +199,39 @@ spec:
         - name: version
           description: Git version/tag
         steps:
-        - name: clone-and-get-version
+        - name: resolve-version
           image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
           env:
           - name: GIT_URL
             value: $(params.url)
           - name: GIT_REVISION
             value: $(params.revision)
+          - name: UPSTREAM_URL
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['pipelinesascode.tekton.dev/repo-url']
           script: |
             #!/usr/bin/env bash
             set -eo pipefail
 
-            # Create temporary directory
             WORKDIR=$(mktemp -d)
             cd "$WORKDIR"
 
-            # Clone repository with tags
-            echo "Cloning repository..."
-            # Use unshallow clone to get full history and tags for git describe
-            git clone --no-single-branch "$GIT_URL" .
+            # Clone upstream first — it has the release tags needed for git describe
+            echo "Cloning upstream repository..."
+            git clone --no-single-branch "$UPSTREAM_URL" .
+
+            # For fork PRs, fetch the PR commit from the fork
+            if [ "$GIT_URL" != "$UPSTREAM_URL" ]; then
+              echo "Fetching PR revision from fork..."
+              git remote add fork "$GIT_URL"
+              git fetch fork
+            fi
 
             # Checkout the specific revision
-            git checkout "$GIT_REVISION"  
+            git checkout "$GIT_REVISION"
 
-            # Fetch all tags explicitly
-            git fetch origin --tags 
-
-            # Get version using git describe (same logic as Makefile)
-            # Try to get the closest tag, or use commit SHA as fallback
+            # Match Makefile logic: git describe --tags --always || v0.0.0-SNAPSHOT
             VERSION=$(git describe --tags --always 2>/dev/null || echo "v0.0.0-SNAPSHOT")
 
             printf "%s" "$VERSION" > $(results.version.path)
@@ -281,6 +286,8 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS
         value:
+        - COMMIT_ID=$(tasks.clone-repository.results.commit)
+        - VERSION_ID=$(tasks.get-version.results.version)
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
@@ -306,6 +313,7 @@ spec:
         value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
+      - get-version
       taskRef:
         params:
         - name: name
@@ -516,6 +524,8 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS
         value:
+        - COMMIT_ID=$(tasks.clone-repository.results.commit)
+        - VERSION_ID=$(tasks.get-version.results.version)
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
@@ -525,6 +535,7 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
       - coverity-availability-check
+      - get-version
       taskRef:
         params:
         - name: name

--- a/.tekton/tssc-cli-push.yaml
+++ b/.tekton/tssc-cli-push.yaml
@@ -182,7 +182,7 @@ spec:
         runAfter:
           - clone-repository
         taskSpec:
-          description: Extract version from git repository by cloning it
+          description: Extract version from git tags (matches Makefile logic)
           params:
             - name: url
               description: Git repository URL
@@ -194,14 +194,18 @@ spec:
             - name: version
               description: Git version/tag
           steps:
-            - name: clone-and-get-version
+            - name: resolve-version
               image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
               env:
                 - name: GIT_URL
                   value: $(params.url)
                 - name: GIT_REVISION
                   value: $(params.revision)
-              script: "#!/usr/bin/env bash\nset -eo pipefail\n\n# Create temporary directory\nWORKDIR=$(mktemp -d)\ncd \"$WORKDIR\"\n\n# Clone repository with tags\necho \"Cloning repository...\"\n# Use unshallow clone to get full history and tags for git describe\ngit clone --no-single-branch \"$GIT_URL\" .\n\n# Checkout the specific revision\ngit checkout \"$GIT_REVISION\"  \n\n# Fetch all tags explicitly\ngit fetch origin --tags \n\n# Get version using git describe (same logic as Makefile)\n# Try to get the closest tag, or use commit SHA as fallback\nVERSION=$(git describe --tags --always 2>/dev/null || echo \"v0.0.0-SNAPSHOT\")\n\nprintf \"%s\" \"$VERSION\" > $(results.version.path)\necho \"Version: $VERSION\"\necho \"Commit ID: $GIT_REVISION\"\n"
+                - name: UPSTREAM_URL
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['pipelinesascode.tekton.dev/repo-url']
+              script: "#!/usr/bin/env bash\nset -eo pipefail\n\nWORKDIR=$(mktemp -d)\ncd \"$WORKDIR\"\n\n# Clone upstream first — it has the release tags needed for git describe\necho \"Cloning upstream repository...\"\ngit clone --no-single-branch \"$UPSTREAM_URL\" .\n\n# For fork PRs, fetch the PR commit from the fork\nif [ \"$GIT_URL\" != \"$UPSTREAM_URL\" ]; then\n  echo \"Fetching PR revision from fork...\"\n  git remote add fork \"$GIT_URL\"\n  git fetch fork\nfi\n\n# Checkout the specific revision\ngit checkout \"$GIT_REVISION\"\n\n# Match Makefile logic: git describe --tags --always || v0.0.0-SNAPSHOT\nVERSION=$(git describe --tags --always 2>/dev/null || echo \"v0.0.0-SNAPSHOT\")\n\nprintf \"%s\" \"$VERSION\" > $(results.version.path)\necho \"Version: $VERSION\"\necho \"Commit ID: $GIT_REVISION\"\n"
       - name: prefetch-dependencies
         params:
           - name: input
@@ -251,6 +255,8 @@ spec:
             value: $(tasks.clone-repository.results.commit)
           - name: BUILD_ARGS
             value:
+              - COMMIT_ID=$(tasks.clone-repository.results.commit)
+              - VERSION_ID=$(tasks.get-version.results.version)
               - $(params.build-args[*])
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
@@ -276,6 +282,7 @@ spec:
             value: $(tasks.init.results.no-proxy)
         runAfter:
           - prefetch-dependencies
+          - get-version
         taskRef:
           params:
             - name: name
@@ -486,6 +493,8 @@ spec:
             value: $(tasks.clone-repository.results.commit)
           - name: BUILD_ARGS
             value:
+              - COMMIT_ID=$(tasks.clone-repository.results.commit)
+              - VERSION_ID=$(tasks.get-version.results.version)
               - $(params.build-args[*])
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
@@ -495,6 +504,7 @@ spec:
             value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
         runAfter:
           - coverity-availability-check
+          - get-version
         taskRef:
           params:
             - name: name


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED