### PR TITLE
fix: pass COMMIT_ID and VERSION_ID build args to container image build

### DIFF
--- a/.tekton/tssc-cli-pull-request.yaml
+++ b/.tekton/tssc-cli-pull-request.yaml
@@ -187,7 +187,7 @@ spec:
       runAfter:
       - clone-repository
       taskSpec:
-        description: Extract version from git repository by cloning it
+        description: Extract version from git tags (matches Makefile logic)
         params:
         - name: url
           description: Git repository URL
@@ -199,35 +199,47 @@ spec:
         - name: version
           description: Git version/tag
         steps:
-        - name: clone-and-get-version
+        - name: resolve-version
           image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
           env:
           - name: GIT_URL
             value: $(params.url)
           - name: GIT_REVISION
             value: $(params.revision)
+          - name: UPSTREAM_URL
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['pipelinesascode.tekton.dev/repo-url']
+          - name: TARGET_BRANCH
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['build.appstudio.redhat.com/target_branch']
           script: |
             #!/usr/bin/env bash
             set -eo pipefail
 
-            # Create temporary directory
             WORKDIR=$(mktemp -d)
             cd "$WORKDIR"
 
-            # Clone repository with tags
-            echo "Cloning repository..."
-            # Use unshallow clone to get full history and tags for git describe
-            git clone --no-single-branch "$GIT_URL" .
+            # Clone upstream first — it has the release tags needed for git describe
+            echo "Cloning upstream repository..."
+            git clone --no-single-branch "$UPSTREAM_URL" .
+
+            # For fork PRs, fetch the PR commit from the fork
+            if [ "$GIT_URL" != "$UPSTREAM_URL" ]; then
+              echo "Fetching PR revision from fork..."
+              git remote add fork "$GIT_URL"
+              git fetch fork
+            fi
 
             # Checkout the specific revision
-            git checkout "$GIT_REVISION"  
+            git checkout "$GIT_REVISION"
 
-            # Fetch all tags explicitly
-            git fetch origin --tags 
-
-            # Get version using git describe (same logic as Makefile)
-            # Try to get the closest tag, or use commit SHA as fallback
-            VERSION=$(git describe --tags --always 2>/dev/null || echo "v0.0.0-SNAPSHOT")
+            if [ "$TARGET_BRANCH" = "main" ]; then
+              VERSION="main-$(git describe --always)"
+            else
+              VERSION=$(git describe --tags --always)
+            fi
 
             printf "%s" "$VERSION" > $(results.version.path)
             echo "Version: $VERSION"
@@ -281,6 +293,8 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS
         value:
+        - COMMIT_ID=$(tasks.clone-repository.results.commit)
+        - VERSION_ID=$(tasks.get-version.results.version)
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
@@ -306,6 +320,7 @@ spec:
         value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
+      - get-version
       taskRef:
         params:
         - name: name
@@ -516,6 +531,8 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS
         value:
+        - COMMIT_ID=$(tasks.clone-repository.results.commit)
+        - VERSION_ID=$(tasks.get-version.results.version)
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
@@ -525,6 +542,7 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
       - coverity-availability-check
+      - get-version
       taskRef:
         params:
         - name: name

--- a/.tekton/tssc-cli-push.yaml
+++ b/.tekton/tssc-cli-push.yaml
@@ -182,7 +182,7 @@ spec:
       runAfter:
       - clone-repository
       taskSpec:
-        description: Extract version from git repository by cloning it
+        description: Extract version from git tags (matches Makefile logic)
         params:
         - name: url
           description: Git repository URL
@@ -194,35 +194,47 @@ spec:
         - name: version
           description: Git version/tag
         steps:
-        - name: clone-and-get-version
+        - name: resolve-version
           image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
           env:
           - name: GIT_URL
             value: $(params.url)
           - name: GIT_REVISION
             value: $(params.revision)
+          - name: UPSTREAM_URL
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['pipelinesascode.tekton.dev/repo-url']
+          - name: TARGET_BRANCH
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['build.appstudio.redhat.com/target_branch']
           script: |
             #!/usr/bin/env bash
             set -eo pipefail
 
-            # Create temporary directory
             WORKDIR=$(mktemp -d)
             cd "$WORKDIR"
 
-            # Clone repository with tags
-            echo "Cloning repository..."
-            # Use unshallow clone to get full history and tags for git describe
-            git clone --no-single-branch "$GIT_URL" .
+            # Clone upstream first — it has the release tags needed for git describe
+            echo "Cloning upstream repository..."
+            git clone --no-single-branch "$UPSTREAM_URL" .
+
+            # For fork PRs, fetch the PR commit from the fork
+            if [ "$GIT_URL" != "$UPSTREAM_URL" ]; then
+              echo "Fetching PR revision from fork..."
+              git remote add fork "$GIT_URL"
+              git fetch fork
+            fi
 
             # Checkout the specific revision
-            git checkout "$GIT_REVISION"  
+            git checkout "$GIT_REVISION"
 
-            # Fetch all tags explicitly
-            git fetch origin --tags 
-
-            # Get version using git describe (same logic as Makefile)
-            # Try to get the closest tag, or use commit SHA as fallback
-            VERSION=$(git describe --tags --always 2>/dev/null || echo "v0.0.0-SNAPSHOT")
+            if [ "$TARGET_BRANCH" = "main" ]; then
+              VERSION="main-$(git describe --always)"
+            else
+              VERSION=$(git describe --tags --always)
+            fi
 
             printf "%s" "$VERSION" > $(results.version.path)
             echo "Version: $VERSION"
@@ -276,6 +288,8 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS
         value:
+        - COMMIT_ID=$(tasks.clone-repository.results.commit)
+        - VERSION_ID=$(tasks.get-version.results.version)
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
@@ -301,6 +315,7 @@ spec:
         value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
+      - get-version
       taskRef:
         params:
         - name: name
@@ -511,6 +526,8 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS
         value:
+        - COMMIT_ID=$(tasks.clone-repository.results.commit)
+        - VERSION_ID=$(tasks.get-version.results.version)
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
@@ -520,6 +537,7 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       runAfter:
       - coverity-availability-check
+      - get-version
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version resolution now derives from upstream git tags (matching Makefile behavior) and correctly handles upstream vs. fork PR scenarios so tags are available reliably.
  * VERSION_ID and COMMIT_ID are propagated earlier and to more pipeline stages, ensuring consistent artifact metadata and traceability.
  * Task ordering adjusted so version information is resolved before dependent build, matrix, and analysis steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->