### PR TITLE
fix: allow a deployment without Pipelines

### DIFF
--- a/installer/charts/tssc-app-namespaces/templates/serviceaccounts/patch-serviceaccounts.yaml
+++ b/installer/charts/tssc-app-namespaces/templates/serviceaccounts/patch-serviceaccounts.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.appNamespaces.pipelines.enabled }}
 {{- $name := .Release.Name }}
 {{- $context := . }}
 {{- range .Values.appNamespaces.namespace_prefixes }}
@@ -47,4 +48,5 @@ spec:
     - name: scripts
       emptyDir: {}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/installer/charts/tssc-app-namespaces/values.yaml
+++ b/installer/charts/tssc-app-namespaces/values.yaml
@@ -3,3 +3,5 @@ appNamespaces:
   argoCD:
     name: __OVERWRITE_ME__
   namespace_prefixes: __OVERWRITE_ME__
+  pipelines:
+    enabled: __OVERWRITE_ME__

--- a/installer/charts/tssc-dh/templates/extra-env.yaml
+++ b/installer/charts/tssc-dh/templates/extra-env.yaml
@@ -71,11 +71,11 @@ data:
     GITHUB__APP__CLIENT__SECRET: {{ $ghSecretData.clientSecret }}
     GITHUB__APP__PRIVATE_KEY: {{ $ghSecretData.pem }}
     GITHUB__APP__WEBHOOK__SECRET: {{ $ghSecretData.webhookSecret }}
+    GITHUB__HOST: {{ $ghSecretData.host }}
     GITHUB__URL: {{ print "https://" ($ghSecretData.host | b64dec) | b64enc }}
     {{- $pacRoute := (lookup "route.openshift.io/v1" "Route" "openshift-pipelines" "pipelines-as-code-controller") }}
     {{- if $pacRoute }}
     GITHUB__APP__WEBHOOK__URL: {{ print "https://" $pacRoute.spec.host | b64enc }}
-    GITHUB__HOST: {{ $ghSecretData.host }}
     {{- end }}
     {{- if .Values.developerHub.RBAC.enabled }}
     GITHUB__ORG: {{ $ghSecretData.ownerLogin }}

--- a/installer/values.yaml.tpl
+++ b/installer/values.yaml.tpl
@@ -207,6 +207,8 @@ appNamespaces:
   {{- range ($rhdh.Properties.namespacePrefixes | default (tuple (printf "%s-app" .Installer.Namespace))) }}
     - {{ . }}
   {{- end }}
+  pipelines:
+    enabled: {{ $pipelines.Enabled}}
 
 #
 # tssc-gitops


### PR DESCRIPTION
cf [RHTAP-6460](https://redhat.atlassian.net/browse/RHTAP-6460)

Since another CI system may be used, Pipelines is optional.

- Modified values.yaml.tpl and values.yaml to enable pipelines configurations.
- Updated patch-serviceaccounts.yaml run based on the new configuration.
- Modified extra-env.yaml to always include GITHUB__HOST.

[RHTAP-6460]: https://redhat.atlassian.net/browse/RHTAP-6460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a new configuration setting for pipelines that can be toggled on or off during deployment, giving operators greater control over feature availability
  * Improved GitHub integration by streamlining host configuration settings to ensure they are consistently applied throughout the application setup process
  * Enhanced template-based deployment configurations to provide more flexible control over optional features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->