### PR TITLE
refactor: remove namespace prefix customization from config and scripts

### DIFF
--- a/installer/config.yaml
+++ b/installer/config.yaml
@@ -66,8 +66,6 @@ tssc:
       properties:
         catalogURL: https://github.com/redhat-appstudio/tssc-dev-multi-ci/blob/release-v1.9.x/samples/all.yaml
         manageSubscription: true
-        # namespacePrefixes:
-        #   - tssc-app
         authProvider: oidc
         # Possible values: github, gitlab, oidc
         # RBAC:

--- a/installer/values.yaml.tpl
+++ b/installer/values.yaml.tpl
@@ -204,9 +204,7 @@ appNamespaces:
   argoCD:
     name: {{ $argoCDName }}
   namespace_prefixes:
-  {{- range ($rhdh.Properties.namespacePrefixes | default (tuple (printf "%s-app" .Installer.Namespace))) }}
-    - {{ . }}
-  {{- end }}
+    - {{ printf "%s-app" .Installer.Namespace }}
   pipelines:
     enabled: {{ $pipelines.Enabled}}
 

--- a/integration-tests/scripts/.ci-env
+++ b/integration-tests/scripts/.ci-env
@@ -2,11 +2,6 @@
 # For testing your changes, replace with your fork and branch of tssc-dev-multi-ci
 export DEVELOPER_HUB_CATALOG_URL=
 
-#### Customize App Deployment Namespaces
-# For setting different tssc app deployment namespaces
-# For example "argo-app,deploy-app"
-export TSSC_APP_DEPLOYMENT_NAMESPACES=""
-
 #### Github
 # https://docs.redhat.com/en/documentation/red_hat_trusted_application_pipeline/1.2/html-single/installing_red_hat_trusted_application_pipeline/index#creating_a_github_personal_access_token
 export GITHUB_APP_ID=

--- a/integration-tests/scripts/.env.template
+++ b/integration-tests/scripts/.env.template
@@ -8,11 +8,6 @@ export pipeline_config="tekton,jenkins,actions,gitlabci" # tekton, jenkins, acti
 # For testing your changes, replace with your fork and branch of tssc-dev-multi-ci
 export DEVELOPER_HUB_CATALOG_URL=
 
-#### Customize App Deployment Namespaces
-# For setting different tssc app deployment namespaces
-# For example "argo-app,deploy-app"
-export TSSC_APP_DEPLOYMENT_NAMESPACES=""
-
 #### Github
 # https://docs.redhat.com/en/documentation/red_hat_trusted_application_pipeline/1.2/html-single/installing_red_hat_trusted_application_pipeline/index#creating_a_github_personal_access_token
 export GITHUB_APP_ID=

--- a/integration-tests/scripts/install.sh
+++ b/integration-tests/scripts/install.sh
@@ -104,32 +104,6 @@ update_dh_auth_config() {
   fi
 }
 
-update_dh_namespace_prefixes() {
-  # Update Developer Hub namespace prefixes from TSSC_APP_DEPLOYMENT_NAMESPACES
-  if [[ -n "${TSSC_APP_DEPLOYMENT_NAMESPACES:-}" ]]; then
-    echo "[INFO] Update Developer Hub namespace prefixes with: $TSSC_APP_DEPLOYMENT_NAMESPACES"
-
-    # Convert comma-separated values to space-separated, then read into array
-    IFS=',' read -ra namespace_prefixes <<< "${TSSC_APP_DEPLOYMENT_NAMESPACES}"
-
-    # Clear existing namespacePrefixes array first
-    yq -i '.tssc.products[] |= select(.name == "Developer Hub").properties.namespacePrefixes = []' "${config_file}"
-
-    # Add each namespace prefix to the array
-    for namespace in "${namespace_prefixes[@]}"; do
-      namespace=$(echo "$namespace" | xargs)
-      # Skip empty strings
-      if [[ -z "$namespace" ]]; then
-        continue
-      fi
-      echo "[INFO] Adding namespace prefix: $namespace"
-      yq -i '.tssc.products[] |= select(.name == "Developer Hub").properties.namespacePrefixes += ["'"$namespace"'"]' "${config_file}"
-    done
-  else
-    echo "[INFO] TSSC_APP_DEPLOYMENT_NAMESPACES not set, keeping default namespace prefixes"
-  fi
-}
-
 # Workaround: This function has to be called before tssc import "installer/config.yaml" into cluster.
 # Currently, the `tssc integration github` subcommand lacks the ability to create a secret for an existing application.
 github_integration() {
@@ -412,7 +386,6 @@ create_cluster_config() {
   echo "[INFO] Creating the installer's cluster configuration"
   update_dh_catalog_url
   update_dh_auth_config
-  update_dh_namespace_prefixes
   disable_acs
   disable_tpa
   disable_tas


### PR DESCRIPTION
- Removed the TSSC_APP_DEPLOYMENT_NAMESPACES environment variable and related logic from install scripts and configuration files.
- Updated config.yaml and values.yaml.tpl to simplify namespace handling by using a default format.
- Cleaned up integration test scripts to reflect these changes.

Assisted-by: composer-2-fast

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified namespace prefix configuration by removing customization options. Namespace prefixes now follow a single fixed pattern based on the installer namespace, eliminating the need for manual configuration steps during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->