### PR TITLE
Upgrade GitOps 1.20

### DIFF
--- a/installer/charts/tssc-gitops/Chart.yaml
+++ b/installer/charts/tssc-gitops/Chart.yaml
@@ -4,7 +4,7 @@ name: tssc-gitops
 description: TSSC OpenShift GitOps
 type: application
 version: "1.9.0"
-appVersion: "1.19"
+appVersion: "1.20"
 annotations:
   helmet.redhat-appstudio.github.com/product-name: OpenShift GitOps
   helmet.redhat-appstudio.github.com/depends-on: tssc-openshift, tssc-subscriptions

--- a/installer/charts/tssc-gitops/templates/job-post-deploy.yaml
+++ b/installer/charts/tssc-gitops/templates/job-post-deploy.yaml
@@ -36,7 +36,7 @@ spec:
         # file which is later stored as a Kubernetes secret.
         #
         - name: argocd-generate-token
-          image: registry.redhat.io/openshift-gitops-1/argocd-rhel8:{{ .Chart.AppVersion }}
+          image: registry.redhat.io/openshift-gitops-1/argocd-rhel9:{{ .Chart.AppVersion }}
           env:
             - name: ARGOCD_HOSTNAME
               value: {{ include "argoCD.serverHostname" . }}

--- a/installer/charts/tssc-gitops/templates/tests/test.yaml
+++ b/installer/charts/tssc-gitops/templates/tests/test.yaml
@@ -26,7 +26,7 @@
     # Tests the ArgoCD instance login.
     #
     - name: {{ printf "argocd-login-%s" $argoCD.name }}
-      image: registry.redhat.io/openshift-gitops-1/argocd-rhel8:{{ .Chart.AppVersion }}
+      image: registry.redhat.io/openshift-gitops-1/argocd-rhel9:{{ .Chart.AppVersion }}
       env:
         - name: ARGOCD_HOSTNAME
           value: {{ include "argoCD.serverHostname" . }}

--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -6,7 +6,7 @@ subscriptions:
     apiResource: gitopsservices.pipelines.openshift.io
     namespace: openshift-operators
     name: openshift-gitops-operator
-    channel: gitops-1.19
+    channel: gitops-1.20
     source: redhat-operators
     sourceNamespace: openshift-marketplace
     config:


### PR DESCRIPTION
Jira: [RHTAP-6477](https://redhat.atlassian.net/browse/RHTAP-6477)

[RHTAP-6477]: https://redhat.atlassian.net/browse/RHTAP-6477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 1.20.
  * Migrated container images from RHEL8 to RHEL9.
  * Updated OpenShift GitOps subscription channel to version 1.20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->