### PR TITLE
Upgrade rhbk-operator to stable-v26.4

### DIFF
--- a/installer/charts/tssc-subscriptions/values.yaml
+++ b/installer/charts/tssc-subscriptions/values.yaml
@@ -17,7 +17,7 @@ subscriptions:
     apiResource: keycloaks.k8s.keycloak.org
     namespace: rhbk-operator
     name: rhbk-operator
-    channel: stable-v24
+    channel: stable-v26.4
     source: redhat-operators
     sourceNamespace: openshift-marketplace
     operatorGroup:


### PR DESCRIPTION
Fix deploy error in `Red Hat OpenShift Container Platform Cluster (Multi-Cloud) ` cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Keycloak operator subscription channel in the installation configuration from stable-v24 to stable-v26.4, so installations will reference the newer operator channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->