### PR TITLE
Fix: keycloak route

### DIFF
--- a/installer/values.yaml.tpl
+++ b/installer/values.yaml.tpl
@@ -108,7 +108,7 @@ infrastructure:
 #
 
 {{- $keycloakRouteTLSSecretName := "keycloak-tls" }}
-{{- $keycloakRouteHost := printf "sso.%s" $ingressDomain }}
+{{- $keycloakRouteHost := printf "tssc-sso.%s" $ingressDomain }}
 {{- $realmsName := "tssc-iam" }}
 {{- $tpaTestingUsersEnabled := false }}
 {{- $protocol := "https" -}}


### PR DESCRIPTION
New clusters offered by the Red Hat Catalog now have a default route that is conflicting with tssc.  Adding a prefix to fix the collision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated Keycloak SSO endpoint hostname from `sso` to `tssc-sso` subdomain. Dependent authentication URLs and issuer configurations reflect this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->