### PR TITLE
Fix TPA login via keycloak

### DIFF
--- a/installer/charts/tssc-iam/templates/realm.yaml
+++ b/installer/charts/tssc-iam/templates/realm.yaml
@@ -1419,6 +1419,20 @@ spec:
           - offline_access
           - microprofile-jwt
         protocol: openid-connect
+        protocolMappers:
+          - name: "subject-mapper"
+            protocol: "openid-connect"
+            protocolMapper: "oidc-usermodel-property-mapper"
+            consentRequired: false
+            config:
+              user.attribute: "id"
+              claim.name: "sub"
+              jsonType.label: "String"
+              id.token.claim: "true"
+              access.token.claim: "true"
+              userinfo.token.claim: "true"
+              introspection.token.claim: "true"
+              lightweight.claim: "false"
         publicClient: true
         redirectUris: {{
           required ".frontendRedirectUris is required"


### PR DESCRIPTION
Keycloak 26 introduces more requirements of client protocol mappers. This fixes the frontend client being used by TAP

If more client need this we might need to move this protocol mapper to the profile scope [protocol mapper](https://github.com/redhat-appstudio/tssc-cli/blob/main/installer/charts/tssc-iam/templates/realm.yaml#L662)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed identity claim handling in the authentication system by explicitly configuring how user identity attributes map to standard identity claims. The mapping is now properly emitted across all token types including ID tokens, access tokens, userinfo responses, and token introspection operations, ensuring consistent identity information handling throughout authentication and authorization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->